### PR TITLE
Include limitations of constructor block

### DIFF
--- a/docs/src/doc/api-differences.md
+++ b/docs/src/doc/api-differences.md
@@ -35,6 +35,8 @@ override fun _onInit() {
 }
 ```
 
+The same applies of course for `init {}`.
+
 ## Enums and constants
 Godot enums are mapped to Kotlin enums, the generated enum exposes a `value` property that represents the value in Godot. Constants in Godot classes that represent an enum value (such as `Node.PAUSE_MODE_INHERIT`) are not present in this module, please use the generated enum instead (`Node.PauseMode.INHERIT`).
 

--- a/docs/src/doc/api-differences.md
+++ b/docs/src/doc/api-differences.md
@@ -12,6 +12,29 @@ Godot singletons are mapped as Kotlin objects.
 Physics2DServer.areaGetTransform(area)
 ```
 
+## Instantiation limitations
+You cannot interact with the Godot Api from within your constructors!  
+This limitation is present because we need a pointer to your object which we only have once it's instanced.
+
+So this won't work and will crash:
+```kotlin
+constructor() {
+    val tree = getTree()
+    //...
+}
+```
+
+Do such things inside the `_onInit()` function:
+```kotlin
+constructor() {
+    //...
+}
+
+override fun _onInit() {
+    val tree = getTree()
+}
+```
+
 ## Enums and constants
 Godot enums are mapped to Kotlin enums, the generated enum exposes a `value` property that represents the value in Godot. Constants in Godot classes that represent an enum value (such as `Node.PAUSE_MODE_INHERIT`) are not present in this module, please use the generated enum instead (`Node.PauseMode.INHERIT`).
 

--- a/docs/src/doc/user-guide/classes.md
+++ b/docs/src/doc/user-guide/classes.md
@@ -78,6 +78,9 @@ Constructors with arguments you have to call using the `load` function: `load("r
 !!! note ""
     The limitation of max 5 arguments for constructors is arbitrary. We decided to introduce this limitation to prevent performance bottlenecks for creating objects as each argument passed to a constructor needs to be unpacked in the binding. The more arguments, the more unpacking is needed so the performance cost increases.
 
+!!! warning "Note:"
+    Also note the instatiation limitations described in [Instantiation limitations](../api-differences.md#instantiation-limitations)
+
 ## Registration Configuration
 You can customize to some extent how your class should be registered in Godot:
 
@@ -86,7 +89,7 @@ The `@RegisterClass` annotation can take two arguments:
 - **className**: If set, the class will be registered with the name you provide
 - **isTool**: If set to true, this class is treated as a tool class. Similar to the `tool` of GDScript. **Default:** false
 
-!!! note ""
+!!! warning "Unique class names"
     If you specify the `className` in the annotation, you have to make sure that this name is unique!  
     We implemented compilation checks to make sure the compilation fails if more than two classes are registered with the same name, but we cannot check class names from other scripting languages like GDScript or C#!  
     It is also recommended installing our intellij plugin as it shows duplicated registered class names in the editor as an error. See the section [IDE](../getting-started/ide.md) for more information about the plugin.

--- a/docs/src/doc/user-guide/classes.md
+++ b/docs/src/doc/user-guide/classes.md
@@ -79,7 +79,7 @@ Constructors with arguments you have to call using the `load` function: `load("r
     The limitation of max 5 arguments for constructors is arbitrary. We decided to introduce this limitation to prevent performance bottlenecks for creating objects as each argument passed to a constructor needs to be unpacked in the binding. The more arguments, the more unpacking is needed so the performance cost increases.
 
 !!! warning "Note:"
-    Also note the instatiation limitations described in [Instantiation limitations](../api-differences.md#instantiation-limitations)
+    Also note the instantiation limitations described in [Instantiation limitations](../api-differences.md#instantiation-limitations)
 
 ## Registration Configuration
 You can customize to some extent how your class should be registered in Godot:


### PR DESCRIPTION
During discussions on discord regarding #99 we noticed that the documentation does not yet cover the limitations about the usage of the Godot Api from within constructor blocks.
This fixes it.