### PR TITLE
feature/use scons cach in ci

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -1,6 +1,9 @@
 name: Check PR - Engine Editor Debug And Tests
 on: [pull_request]
 
+env:
+  GODOT_BASE_VERSION: 3.2.3
+
 jobs:
   build-godot-library:
     strategy:
@@ -72,11 +75,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
-          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
-            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
-            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
-            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -66,6 +66,17 @@ jobs:
         with:
           path: modules/kotlin_jvm
           submodules: recursive
+      # Upload cache on completion and check it out now
+      - name: Load .scons_cache directory
+        id: ${{ matrix.os }}-editor-debug-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_BRANCH}}
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
@@ -76,6 +87,8 @@ jobs:
           python -c "import sys; print(sys.version)"
           python -m pip install scons
       - name: Build with editor debug
+        env:
+          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }}
       - name: Upload OSX binary

--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -2,6 +2,7 @@ name: Check PR - Engine Editor Debug And Tests
 on: [pull_request]
 
 env:
+  SCONS_CACHE_MSVC_CONFIG: true
   GODOT_BASE_VERSION: 3.2.3
 
 jobs:

--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -68,10 +68,10 @@ jobs:
           submodules: recursive
       # Upload cache on completion and check it out now
       - name: Load .scons_cache directory
-        id: ${{ matrix.os }}-editor-debug-cache
+        id: editor-debug-cache
         uses: actions/cache@v2
         with:
-          path: ${{github.workspace}}/.scons_cache/
+          path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
             ${{github.job}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
@@ -88,7 +88,7 @@ jobs:
           python -m pip install scons
       - name: Build with editor debug
         env:
-          SCONS_CACHE: ${{github.workspace}}/.scons_cache/
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }}
       - name: Upload OSX binary

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -1,6 +1,9 @@
 name: Check PR - Engine Editor Release
 on: [pull_request]
 
+env:
+  GODOT_BASE_VERSION: 3.2.3
+
 jobs:
   build-editor-release:
     strategy:
@@ -33,6 +36,17 @@ jobs:
         with:
           path: modules/kotlin_jvm
           submodules: recursive
+      # Upload cache on completion and check it out now
+      - name: Load .scons_cache directory
+        id: editor-release-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
@@ -43,5 +57,7 @@ jobs:
           python -c "import sys; print(sys.version)"
           python -m pip install scons
       - name: Build with editor release
+        env:
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} target=release_debug

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -2,6 +2,7 @@ name: Check PR - Engine Editor Release
 on: [pull_request]
 
 env:
+  SCONS_CACHE_MSVC_CONFIG: true
   GODOT_BASE_VERSION: 3.2.3
 
 jobs:

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -1,6 +1,9 @@
 name: Check PR - Engine Export Template Debug
 on: [pull_request]
 
+env:
+  GODOT_BASE_VERSION: 3.2.3
+
 jobs:
   build-export-debug:
     strategy:
@@ -36,6 +39,39 @@ jobs:
         with:
           path: modules/kotlin_jvm
           submodules: recursive
+      # Upload cache on completion and check it out now
+      - name: Load .scons_cache directory
+        id: template-debug-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}
+      - name: Load .scons_cache directory for Android armv7
+        if: matrix.platform == 'android'
+        id: template-debug-cache-android-armv7
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/${{matrix.platform}}/armv7/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}
+      - name: Load .scons_cache directory for Android arm64-v8
+        if: matrix.platform == 'android'
+        id: template-debug-cache-android-arm64-v8
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/${{matrix.platform}}/arm64-v8/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
@@ -55,6 +91,8 @@ jobs:
         uses: android-actions/setup-android@v2
       - name: Build debug export template
         if: matrix.platform != 'android'
+        env:
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} tools=no target=release_debug bits=64
       - name: Build android debug binary armv7
@@ -63,6 +101,8 @@ jobs:
           scons platform=${{ matrix.platform }} target=release_debug android_arch=armv7
       - name: Build android debug binary arm64v8
         if: matrix.platform == 'android'
+        env:
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} target=release_debug android_arch=arm64v8
       - name: Build android debug export template

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -41,6 +41,7 @@ jobs:
           submodules: recursive
       # Upload cache on completion and check it out now
       - name: Load .scons_cache directory
+        if: matrix.platform != 'android'
         id: template-debug-cache
         uses: actions/cache@v2
         with:
@@ -92,7 +93,7 @@ jobs:
       - name: Build debug export template
         if: matrix.platform != 'android'
         env:
-          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/armv7/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} tools=no target=release_debug bits=64
       - name: Build android debug binary armv7
@@ -102,7 +103,7 @@ jobs:
       - name: Build android debug binary arm64v8
         if: matrix.platform == 'android'
         env:
-          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/arm64-v8/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} target=release_debug android_arch=arm64v8
       - name: Build android debug export template

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -94,11 +94,13 @@ jobs:
       - name: Build debug export template
         if: matrix.platform != 'android'
         env:
-          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/armv7/.scons_cache/
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} tools=no target=release_debug bits=64
       - name: Build android debug binary armv7
         if: matrix.platform == 'android'
+        env:
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/armv7/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} target=release_debug android_arch=armv7
       - name: Build android debug binary arm64v8

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -2,6 +2,7 @@ name: Check PR - Engine Export Template Debug
 on: [pull_request]
 
 env:
+  SCONS_CACHE_MSVC_CONFIG: true
   GODOT_BASE_VERSION: 3.2.3
 
 jobs:

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -1,6 +1,10 @@
 name: Check PR - Engine Export Template Release
 on: [pull_request]
 
+env:
+  SCONS_CACHE_MSVC_CONFIG: true
+  GODOT_BASE_VERSION: 3.2.3
+
 jobs:
   build-export-release:
     strategy:

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -99,12 +99,14 @@ jobs:
           scons platform=${{ matrix.platform }} tools=no target=release bits=64
       - name: Build android release binary armv7
         if: matrix.platform == 'android'
+        env:
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/armv7/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} target=release android_arch=armv7
       - name: Build android release binary arm64v8
         if: matrix.platform == 'android'
         env:
-          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/arm64-v8/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} target=release android_arch=arm64v8
       - name: Build android release export template

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -36,6 +36,40 @@ jobs:
         with:
           path: modules/kotlin_jvm
           submodules: recursive
+      # Upload cache on completion and check it out now
+      - name: Load .scons_cache directory
+        if: matrix.platform != 'android'
+        id: template-release-cache
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}
+      - name: Load .scons_cache directory for Android armv7
+        if: matrix.platform == 'android'
+        id: template-release-cache-android-armv7
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/${{matrix.platform}}/armv7/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}
+      - name: Load .scons_cache directory for Android arm64-v8
+        if: matrix.platform == 'android'
+        id: template-release-cache-android-arm64-v8
+        uses: actions/cache@v2
+        with:
+          path: ${{github.workspace}}/${{matrix.platform}}/arm64-v8/.scons_cache/
+          key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+          restore-keys: |
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}
+            ${{github.job}}-${{env.GODOT_BASE_VERSION}}
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
@@ -55,6 +89,8 @@ jobs:
         uses: android-actions/setup-android@v2
       - name: Build release export template
         if: matrix.platform != 'android'
+        env:
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} tools=no target=release bits=64
       - name: Build android release binary armv7
@@ -63,6 +99,8 @@ jobs:
           scons platform=${{ matrix.platform }} target=release android_arch=armv7
       - name: Build android release binary arm64v8
         if: matrix.platform == 'android'
+        env:
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} target=release android_arch=arm64v8
       - name: Build android release export template


### PR DESCRIPTION
This enables scons cache to fasten CI builds. Unfortunately this does not seems to fasten on windows build, maybe someone will have an idea.