### PR TITLE
Fix package path check on windows

### DIFF
--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
@@ -28,7 +28,6 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.allConstructors
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperclassesWithoutAny
-import java.io.File
 
 private const val MAX_CONSTRUCTOR_ARGS = 5
 
@@ -221,8 +220,8 @@ class RegisterClassAnnotator : Annotator {
             containingFilePath = containingFilePath.removePrefix(srcDir)
         }
         containingFilePath =
-            containingFilePath.substringBeforeLast("/").removePrefix("/").removeSuffix(".kt") //not File.separator as the virtual file path is platform independent with "/"
-        val packagePath = ktPackageDirective.fqName.asString().replace(".", "/") //not File.separator as the virtual file path is platform independent with "/"
+            containingFilePath.substringBeforeLast("/").removePrefix("/").removeSuffix(".kt") // not File.separator as the virtual file path is platform independent with "/"
+        val packagePath = ktPackageDirective.fqName.asString().replace(".", "/") // not File.separator as the virtual file path is platform independent with "/"
 
         if (packagePath != containingFilePath) {
             holder.registerProblem(

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
@@ -221,8 +221,8 @@ class RegisterClassAnnotator : Annotator {
             containingFilePath = containingFilePath.removePrefix(srcDir)
         }
         containingFilePath =
-            containingFilePath.substringBeforeLast(File.separator).removePrefix(File.separator).removeSuffix(".kt")
-        val packagePath = ktPackageDirective.fqName.asString().replace(".", File.separator)
+            containingFilePath.substringBeforeLast("/").removePrefix("/").removeSuffix(".kt") //not File.separator as the virtual file path is platform independent with "/"
+        val packagePath = ktPackageDirective.fqName.asString().replace(".", "/") //not File.separator as the virtual file path is platform independent with "/"
 
         if (packagePath != containingFilePath) {
             holder.registerProblem(


### PR DESCRIPTION
This fixes the package path check in the IDE plugin for windows.