### PR TITLE
Remove root project requirement (again)

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotPlugin.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotPlugin.kt
@@ -18,7 +18,6 @@ import java.io.File
 
 class GodotPlugin : KotlinCompilerPluginSupportPlugin {
     override fun apply(target: Project) {
-        require(target.rootProject == target) { "godot-jvm plugin can only be applied on the root project!" }
         val godotExtension = target.extensions.create("godot", GodotExtension::class.java)
         val jvm = target.extensions.getByType<KotlinJvmProjectExtension>()
         target.pluginManager.apply(ShadowPlugin::class)


### PR DESCRIPTION
I guess through a rebasing error when merging the android support, the limitation of only applying our plugin to the gradle root project got reintroduced. This fixes it by removing that line again.
I could not find any other issues yet. But I'll keep an eye on that.