### PR TITLE
Bugfix/rect2 read order

### DIFF
--- a/harness/tests/project.godot
+++ b/harness/tests/project.godot
@@ -20,6 +20,11 @@ _global_script_classes=[ {
 "path": "res://scripts/ScriptInOtherSourceDir.kt"
 }, {
 "base": "Node",
+"class": "godot_tests_CoreTypesIdentityTest",
+"language": "Kotlin",
+"path": "res://src/main/kotlin/godot/tests/CoreTypesIdentityTest.kt"
+}, {
+"base": "Node",
 "class": "godot_tests_FuncRefTest",
 "language": "Kotlin",
 "path": "res://src/main/kotlin/godot/tests/FuncRefTest.kt"
@@ -52,6 +57,7 @@ _global_script_classes=[ {
 _global_script_class_icons={
 "RPCTests": "",
 "ScriptInOtherSourceDir": "",
+"godot_tests_CoreTypesIdentityTest": "",
 "godot_tests_FuncRefTest": "",
 "godot_tests_Invocation": "",
 "godot_tests_MultiArgsConstructorTest": "",

--- a/harness/tests/src/main/kotlin/godot/tests/CoreTypesIdentityTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/CoreTypesIdentityTest.kt
@@ -1,0 +1,32 @@
+package godot.tests
+
+import godot.Node
+import godot.annotation.RegisterClass
+import godot.annotation.RegisterProperty
+import godot.core.*
+
+@RegisterClass
+class CoreTypesIdentityTest : Node() {
+
+    @RegisterProperty
+    var aabb = AABB(Vector3(1, 1, 1), Vector3(2, 2, 2))
+    @RegisterProperty
+    var basis = Basis(0, 1, 2, 3, 4, 5, 6, 7, 8)
+    @RegisterProperty
+    var color = Color(0.1, 0.2, 0.3, 0.4)
+    @RegisterProperty
+    var plane = Plane(1, 2, 3, 4)
+    @RegisterProperty
+    var quat = Quat(1, 2, 3, 4)
+    @RegisterProperty
+    var rect2 = Rect2(1.0, 2.0, 3.0, 4.0)
+    @RegisterProperty
+    var transform =
+        Transform(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+    @RegisterProperty
+    var transform2D = Transform2D(0, 1, 2, 3, 4, 5)
+    @RegisterProperty
+    var vector2 = Vector2(1, 2)
+    @RegisterProperty
+    var vector3 = Vector3(1, 2, 3)
+}

--- a/harness/tests/src/main/kotlin/godot/tests/CoreTypesIdentityTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/CoreTypesIdentityTest.kt
@@ -10,23 +10,32 @@ class CoreTypesIdentityTest : Node() {
 
     @RegisterProperty
     var aabb = AABB(Vector3(1, 1, 1), Vector3(2, 2, 2))
+
     @RegisterProperty
-    var basis = Basis(0, 1, 2, 3, 4, 5, 6, 7, 8)
+    var basis = Basis(Vector3(0, 1, 2), Vector3(3, 4, 5), Vector3(6, 7, 8))
+
     @RegisterProperty
     var color = Color(0.1, 0.2, 0.3, 0.4)
+
     @RegisterProperty
     var plane = Plane(1, 2, 3, 4)
+
     @RegisterProperty
     var quat = Quat(1, 2, 3, 4)
+
     @RegisterProperty
     var rect2 = Rect2(1.0, 2.0, 3.0, 4.0)
+
     @RegisterProperty
     var transform =
-        Transform(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)
+        Transform(Vector3(0, 1, 2), Vector3(3, 4, 5), Vector3(6, 7, 8), Vector3(9, 10, 11))
+
     @RegisterProperty
     var transform2D = Transform2D(0, 1, 2, 3, 4, 5)
+
     @RegisterProperty
     var vector2 = Vector2(1, 2)
+
     @RegisterProperty
     var vector3 = Vector3(1, 2, 3)
 }

--- a/harness/tests/test/unit/test_core_types_identity.gd
+++ b/harness/tests/test/unit/test_core_types_identity.gd
@@ -1,0 +1,62 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_should_return_right_aabb():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_aabb = AABB(Vector3(1, 1, 1), Vector3(2, 2, 2))
+	assert_eq(instance.aabb, expected_aabb, "Should get same aabb")
+	instance.free()
+
+func test_should_return_right_basis():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_basis = Basis(Vector3(0, 1, 2), Vector3(3, 4, 5), Vector3(6, 7, 8))
+	assert_eq(instance.basis, expected_basis, "Should get same basis")
+	instance.free()
+
+func test_should_return_right_color():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_color = Color(0.1, 0.2, 0.3, 0.4)
+	assert_eq(instance.color, expected_color, "Should get same color")
+	instance.free()
+
+func test_should_return_right_plane():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_plane = Plane(1, 2, 3, 4)
+	assert_eq(instance.plane, expected_plane, "Should get same plane")
+	instance.free()
+
+func test_should_return_right_quat():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_quat = Quat(1, 2, 3, 4)
+	assert_eq(instance.quat, expected_quat, "Should get same quat")
+	instance.free()
+
+func test_should_return_right_rect2():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_rect2 = Rect2(1.0, 2.0, 3.0, 4.0)
+	assert_eq(instance.rect2, expected_rect2, "Should get same rect2")
+	instance.free()
+
+func test_should_return_right_transform():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_transform = Transform(Vector3(0, 1, 2), Vector3(3, 4, 5), Vector3(6, 7, 8), Vector3(9, 10, 11))
+	assert_eq(instance.transform, expected_transform, "Should get same transform")
+	instance.free()
+
+func test_should_return_right_transform2d():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_transform2d = Transform2D(Vector2(0, 1), Vector2(2, 3), Vector2(4, 5))
+	assert_eq(instance.transform2_d, expected_transform2d, "Should get same transform2d")
+	instance.free()
+
+func test_should_return_right_vector2():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_vector2 = Vector2(1, 2)
+	assert_eq(instance.vector2, expected_vector2, "Should get same vector2")
+	instance.free()
+
+func test_should_return_right_vector3():
+	var instance = godot_tests_CoreTypesIdentityTest.new()
+	var expected_vector3 = Vector3(1, 2, 3)
+	assert_eq(instance.vector3, expected_vector3, "Should get same vector3")
+	instance.free()

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -358,9 +358,9 @@ namespace ktvariant {
     }
 
     static Variant from_kvariant_tokRect2Value(SharedBuffer* byte_buffer) {
-        return Variant(
-                Rect2(to_godot_vector2(byte_buffer), to_godot_vector2(byte_buffer))
-        );
+        const Vector2& pos{to_godot_vector2(byte_buffer)};
+        const Vector2& size{to_godot_vector2(byte_buffer)};
+        return Variant({pos, size});
     }
 
     static inline Vector3 to_godot_vector3(SharedBuffer* byte_buffer) {

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -408,17 +408,18 @@ namespace ktvariant {
     }
 
     static Variant from_kvariant_tokAabbValue(SharedBuffer* byte_buffer) {
+        const Vector3& pos{to_godot_vector3(byte_buffer)};
+        const Vector3& size{to_godot_vector3(byte_buffer)};
         return Variant(
-                AABB(to_godot_vector3(byte_buffer), to_godot_vector3(byte_buffer))
+                AABB(pos, size)
         );
     }
 
     static inline Basis to_godot_basis(SharedBuffer* byte_buffer) {
-        return {
-                to_godot_vector3(byte_buffer),
-                to_godot_vector3(byte_buffer),
-                to_godot_vector3(byte_buffer)
-        };
+        const Vector3& row0 = to_godot_vector3(byte_buffer);
+        const Vector3& row1 = to_godot_vector3(byte_buffer);
+        const Vector3& row2 = to_godot_vector3(byte_buffer);
+        return {row0, row1, row2};
     }
 
     static Variant from_kvariant_tokBasisValue(SharedBuffer* byte_buffer) {
@@ -426,8 +427,10 @@ namespace ktvariant {
     }
 
     static Variant from_kvariant_tokTransformValue(SharedBuffer* byte_buffer) {
+        const Basis& basis{to_godot_basis(byte_buffer)};
+        const Vector3& origin{to_godot_vector3(byte_buffer)};
         return Variant(
-                Transform(to_godot_basis(byte_buffer), to_godot_vector3(byte_buffer))
+                Transform(basis, origin)
         );
     }
 

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -360,7 +360,9 @@ namespace ktvariant {
     static Variant from_kvariant_tokRect2Value(SharedBuffer* byte_buffer) {
         const Vector2& pos{to_godot_vector2(byte_buffer)};
         const Vector2& size{to_godot_vector2(byte_buffer)};
-        return Variant({pos, size});
+        return Variant(
+                Rect2(pos, size)
+        );
     }
 
     static inline Vector3 to_godot_vector3(SharedBuffer* byte_buffer) {
@@ -369,6 +371,7 @@ namespace ktvariant {
         float y{decode_float(byte_buffer->get_cursor())};
         byte_buffer->increment_position(4);
         float z{decode_float(byte_buffer->get_cursor())};
+        byte_buffer->increment_position(4);
         return {x, y, z};
     }
 


### PR DESCRIPTION
This resolves #125 
Read order was wrong for Rect2. This forces read order for this case and other similars.
This needs https://github.com/utopia-rise/godot-kotlin-entry-generator/pull/24