### PR TITLE
Fix entry gen version and bump version codes

### DIFF
--- a/harness/tests/build.gradle.kts
+++ b/harness/tests/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
     kotlin("jvm") version "1.4.10"
-    id("com.utopia-rise.godot-kotlin-jvm") version "0.1.0-3.2.3"
+    id("com.utopia-rise.godot-kotlin-jvm") version "0.1.1-3.2.3"
 }
 
 repositories {

--- a/harness/tests/settings.gradle.kts
+++ b/harness/tests/settings.gradle.kts
@@ -30,7 +30,7 @@ pluginManagement {
     }
     resolutionStrategy.eachPlugin {
         if (requested.id.id == "com.utopia-rise.godot-kotlin-jvm") {
-            useModule("com.utopia-rise:godot-gradle-plugin:0.1.0-3.2.3")
+            useModule("com.utopia-rise:godot-gradle-plugin:0.1.1-3.2.3")
         }
         if (requested.id.id == "com.utopia-rise.api-generator") {
             useModule("com.utopia-rise:api-generator:0.0.1")

--- a/kt/buildSrc/src/main/kotlin/DependenciesVersions.kt
+++ b/kt/buildSrc/src/main/kotlin/DependenciesVersions.kt
@@ -5,5 +5,5 @@ object DependenciesVersions {
 
     // Remember to upgrade this version when releasing a new entry generator version and want to use
     // it.
-    const val entryGeneratorVersion = "0.1.0-3.2.3-SNAPSHOT"
+    const val entryGeneratorVersion = "0.1.1-3.2.3"
 }

--- a/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
+++ b/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
@@ -1,2 +1,2 @@
-const val godotKotlinJvmVersion = "0.1.0"
-const val godotKotlinIntellijPluginVersion = "0.1.0"
+const val godotKotlinJvmVersion = "0.1.1"
+const val godotKotlinIntellijPluginVersion = "0.1.1"

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/module/GodotModuleBuilder.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/module/GodotModuleBuilder.kt
@@ -132,7 +132,7 @@ class GodotModuleBuilder : ModuleBuilder(), ModuleBuilderListener {
                     .replace("KOTLIN_VERSION", wizardContext.getUserData(kotlinVersionKey) ?: "1.4.32")
                     .replace(
                         "GODOT_KOTLIN_JVM_VERSION",
-                        "0.1.0-3.2.3"
+                        "0.1.1-3.2.3"
                     )
                     .replace("ANDROID_ENABLED", wizardContext.getUserData(androidEnabledKey)?.toString() ?: "false")
                     .replace("DX_TOOL_PATH", wizardContext.getUserData(dxToolPathKey) ?: "dx")


### PR DESCRIPTION
This fixes the entry gen version which was wrong in the previous alpha release attempt.
New version will be `0.1.1-3.2.3`