### PR TITLE
Fix api differences links

### DIFF
--- a/docs/src/doc/alpha.md
+++ b/docs/src/doc/alpha.md
@@ -1,7 +1,7 @@
 **Please note:** This is a Alpha. It is by no means production ready.
 
 # What's not working:
-The items in this list are explicitly mentioned here as these will be implemented in future versions. Also consider the [Api differences](api-differences.md) section for general differences and limitations which will not be or cannot be adressed in the near forseable future or ever.
+The items in this list are explicitly mentioned here as these will be implemented in future versions. Also consider the [Api differences](user-guide/api-differences.md) section for general differences and limitations which will not be or cannot be adressed in the near forseable future or ever.
 
 - Each registered constructor must have a unique number of arguments. Constructor overloading is not yet supported
 - No tool mode (you can set it already in the `@RegisterClass` annotation but it has no effect yet)

--- a/docs/src/doc/index.md
+++ b/docs/src/doc/index.md
@@ -5,7 +5,7 @@ Godot Kotlin/JVM is a Godot module which allows you to write your game or applic
 An embedded JRE will be shipped with your application to ensure it runs on systems that don't have java installed.
 
 If you are new to this language module, it is recommended to read through the [Versioning](versioning.md) and the [Project setup](getting-started/project-setup.md) sections first.
-Please also note the [API differences](api-differences.md) section which covers some important difference to the scripting and workflow compared to GDScript.
+Please also note the [API differences](user-guide/api-differences.md) section which covers some important difference to the scripting and workflow compared to GDScript.
 
 If you are looking for the documentation for Godot Kotlin/Native; you can find it [here](https://godot-kotlin.readthedocs.io/en/latest/).
 

--- a/docs/src/doc/user-guide/signals.md
+++ b/docs/src/doc/user-guide/signals.md
@@ -1,5 +1,5 @@
 Use the delegate `signal` to create a signal and annotate it with `@RegisterSignal`. Note that the name of
-the signal must start with a prefix `signal` (see [API differences](../api-differences.md) section for an explanation).
+the signal must start with a prefix `signal` (see [API differences](api-differences.md) section for an explanation).
 This module only supports signals with at most 10 parameters at the moment.
 
 ```kotlin


### PR DESCRIPTION
This fixes wrong links to the api differences page. Noticed by user `cris-null` on discord: https://discord.com/channels/675058327088136212/675367449184698378/832421575013171220