### PR TITLE
Fix default values of user script types

### DIFF
--- a/kt/godot-runtime/src/main/kotlin/godot/core/Properties.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/Properties.kt
@@ -21,11 +21,11 @@ open class KtProperty<T : KtObject, P: Any?>(
     val ktPropertyInfo: KtPropertyInfo,
     protected val kProperty: KMutableProperty1<T, P>,
     protected val variantType: VariantType,
-    internal val _defaultValue: P?,
+    internal val _defaultValue: () -> P?,
     val isRef: Boolean
 ) {
     open fun getDefaultValue() {
-        TransferContext.writeReturnValue(_defaultValue, variantType)
+        TransferContext.writeReturnValue(_defaultValue(), variantType)
     }
 
     open fun callGet(instance: T) {
@@ -50,7 +50,7 @@ open class KtProperty<T : KtObject, P: Any?>(
 class KtEnumProperty<T : KtObject, P : Any>(
     ktPropertyInfo: KtPropertyInfo,
     kProperty: KMutableProperty1<T, P>,
-    defaultValue: P,
+    defaultValue: () -> P,
     val getValueConverter: (P?) -> Int,
     val setValueConverter: (Int) -> P
 ) : KtProperty<T, P>(
@@ -61,7 +61,7 @@ class KtEnumProperty<T : KtObject, P : Any>(
         false
 ) {
     override fun getDefaultValue() {
-        TransferContext.writeReturnValue(getValueConverter(_defaultValue), VariantType.JVM_INT)
+        TransferContext.writeReturnValue(getValueConverter(_defaultValue()), VariantType.JVM_INT)
     }
 
     override fun callGet(instance: T) {

--- a/kt/godot-runtime/src/main/kotlin/godot/runtime/Bootstrap.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/runtime/Bootstrap.kt
@@ -112,6 +112,7 @@ class Bootstrap {
             }
             loadClasses(registry!!.classes.toTypedArray())
             registerUserTypesNames(TypeManager.userTypes.toTypedArray())
+            registerUserTypesMembers()
         } else {
             err("Unable to find Entry class, no classes will be loaded")
         }
@@ -158,4 +159,5 @@ class Bootstrap {
     )
 
     private external fun registerUserTypesNames(userTypesNames: Array<String>)
+    private external fun registerUserTypesMembers()
 }

--- a/kt/godot-runtime/src/main/kotlin/godot/runtime/Registration.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/runtime/Registration.kt
@@ -63,7 +63,7 @@ class ClassBuilderDsl<T : KtObject>(
         className: String,
         hint: PropertyHint = PropertyHint.NONE,
         hintString: String = "",
-        defaultArgument: P?,
+        defaultArgument: () -> P?,
         rpcModeId: Int = 0,
         isRef: Boolean = false
     ) {
@@ -88,9 +88,9 @@ class ClassBuilderDsl<T : KtObject>(
     }
 
     inline fun <reified P : Enum<P>> enumProperty(
-            kProperty: KMutableProperty1<T, P>,
-            defaultValue: P,
-            rpcModeId: Int = 0
+        kProperty: KMutableProperty1<T, P>,
+        noinline defaultValue: () -> P,
+        rpcModeId: Int = 0
     ) {
         val propertyName = kProperty.name.camelToSnakeCase()
         require(!properties.contains(propertyName)) {
@@ -142,13 +142,13 @@ class ClassBuilderDsl<T : KtObject>(
     @JvmName("enumFlagPropertyMutable")
     inline fun <reified P : Enum<P>> enumFlagProperty(
         kProperty: KMutableProperty1<T, MutableSet<P>>,
-        defaultValue: MutableSet<P>,
+        noinline defaultValue: () -> MutableSet<P>,
         rpcModeId: Int
     ) = enumFlagProperty(kProperty as KMutableProperty1<T, Set<P>>, defaultValue, rpcModeId)
 
     inline fun <reified P : Enum<P>> enumFlagProperty(
         kProperty: KMutableProperty1<T, Set<P>>,
-        defaultValue: Set<P>,
+        noinline defaultValue: () -> Set<P>,
         rpcModeId: Int
     ) {
         val propertyName = kProperty.name.camelToSnakeCase()
@@ -202,7 +202,7 @@ class ClassBuilderDsl<T : KtObject>(
         variantType: VariantType,
         setValueConverter: ((Any?) -> P),
         isRef: Boolean = false,
-        defaultArgument: P,
+        defaultArgument: () -> P,
         rpcModeId: Int = 0,
         pib: KtPropertyInfoBuilderDsl.() -> Unit
     ) {

--- a/src/bootstrap.cpp
+++ b/src/bootstrap.cpp
@@ -11,7 +11,7 @@ Bootstrap::Bootstrap(jni::JObject p_wrapped, jni::JObject p_class_loader) : Java
 void
 Bootstrap::register_hooks(jni::Env& p_env, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
                           RegisterManagedEngineTypesHook p_register_managed_engine_types_hook,
-                          RegisterUserTypesNamesHook p_user_types_names_hook) {
+                          RegisterUserTypesNamesHook p_user_types_names_hook, RegisterUserTypesMembersHook p_user_types_nmembers_hook) {
     jni::JNativeMethod load_class_hook_method {
             "loadClasses",
             "([Lgodot/core/KtClass;)V",
@@ -36,11 +36,18 @@ Bootstrap::register_hooks(jni::Env& p_env, LoadClassesHook p_load_classes_hook, 
             (void*) p_user_types_names_hook
     };
 
+    jni::JNativeMethod register_user_types_members {
+            "registerUserTypesMembers",
+            "()V",
+            (void*) p_user_types_nmembers_hook
+    };
+
     Vector<jni::JNativeMethod> methods;
     methods.push_back(load_class_hook_method);
     methods.push_back(unload_class_hook_method);
     methods.push_back(register_managed_engine_types_method);
     methods.push_back(register_user_types_names);
+    methods.push_back(register_user_types_members);
     j_class.register_natives(p_env, methods);
 }
 

--- a/src/bootstrap.h
+++ b/src/bootstrap.h
@@ -12,13 +12,14 @@ public:
                                                    jobjectArray singleton_names, jobjectArray method_names,
                                                    jobjectArray types_of_methods);
     typedef void (*RegisterUserTypesNamesHook)(JNIEnv* p_env, jobject p_this, jobjectArray classes_names);
+    typedef void (*RegisterUserTypesMembersHook)(JNIEnv* p_env, jobject p_this);
 
     Bootstrap(jni::JObject p_wrapped, jni::JObject p_class_loader);
     ~Bootstrap() = default;
 
     void register_hooks(jni::Env& p_env, LoadClassesHook p_load_classes_hook, UnloadClassesHook p_unload_classes_hook,
                         RegisterManagedEngineTypesHook p_register_managed_engine_types_hook,
-                        RegisterUserTypesNamesHook p_user_types_names_hook);
+                        RegisterUserTypesNamesHook p_user_types_names_hook, RegisterUserTypesMembersHook p_user_types_nmembers_hook);
     void init(jni::Env& p_env, bool p_is_editor, const String& p_project_path, const String& p_jar_file,
               const jni::JObject& p_class_loader);
     void finish(jni::Env& p_env);

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -546,7 +546,7 @@ GDKotlin::GDKotlin() :
 }
 
 void GDKotlin::register_members(jni::Env& p_env) {
-    auto map_entry = classes.front();
+    auto* map_entry{classes.front()};
     while (map_entry) {
         map_entry->get()->fetch_members();
         map_entry = map_entry->next();

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -188,6 +188,11 @@ void register_user_types_hook(JNIEnv* p_env, jobject p_this, jobjectArray p_type
     LOG_VERBOSE("Done registering user types.");
 }
 
+void register_user_types_members_hook(JNIEnv* p_env, jobject p_this) {
+    jni::Env env(p_env);
+    GDKotlin::get_instance().register_members(env);
+}
+
 void GDKotlin::init() {
     if (Main::is_project_manager()) {
 #ifdef DEBUG_ENABLED
@@ -377,7 +382,7 @@ void GDKotlin::init() {
     bootstrap = new Bootstrap(instance, class_loader);
 
     bootstrap->register_hooks(env, load_classes_hook, unload_classes_hook, register_engine_types_hook,
-                              register_user_types_hook);
+                              register_user_types_hook, register_user_types_members_hook);
     bool is_editor = Engine::get_singleton()->is_editor_hint();
 
 #ifdef TOOLS_ENABLED
@@ -538,4 +543,12 @@ GDKotlin::GDKotlin() :
         bootstrap(nullptr),
         is_gc_started(false),
         transfer_context(nullptr) {
+}
+
+void GDKotlin::register_members(jni::Env& p_env) {
+    auto map_entry = classes.front();
+    while (map_entry) {
+        map_entry->get()->fetch_members();
+        map_entry = map_entry->next();
+    }
 }

--- a/src/gd_kotlin.h
+++ b/src/gd_kotlin.h
@@ -49,6 +49,8 @@ public:
 
     void register_classes(jni::Env& p_env, jni::JObjectArray p_classes);
 
+    void register_members(jni::Env& p_env);
+
     void unregister_classes(jni::Env& p_env, jni::JObjectArray p_classes);
 
     KtClass* find_class(const StringName& p_script_path);

--- a/src/kt_class.cpp
+++ b/src/kt_class.cpp
@@ -11,10 +11,6 @@ KtClass::KtClass(jni::JObject p_wrapped, jni::JObject& p_class_loader) :
     registered_class_name = get_registered_name(env);
     super_class = get_super_class(env);
     base_godot_class = get_base_godot_class(env);
-    fetch_methods(env);
-    fetch_properties(env);
-    fetch_signals(env);
-    fetch_constructors(env);
 }
 
 KtClass::~KtClass() {
@@ -155,4 +151,12 @@ void KtClass::get_property_list(List<PropertyInfo>* p_list) {
 
 void KtClass::get_signal_list(List<MethodInfo>* p_list) {
     get_member_list(p_list, signal_infos);
+}
+
+void KtClass::fetch_members() {
+    jni::Env env { jni::Jvm::current_env() };
+    fetch_methods(env);
+    fetch_properties(env);
+    fetch_signals(env);
+    fetch_constructors(env);
 }

--- a/src/kt_class.h
+++ b/src/kt_class.h
@@ -39,6 +39,8 @@ public:
 
     void get_signal_list(List<MethodInfo>* p_list);
 
+    void fetch_members();
+
 private:
     HashMap<StringName, KtFunction*> methods;
     HashMap<StringName, KtProperty*> properties;


### PR DESCRIPTION
This fixes a bug where, when a class has properties with default values which are other user scripts, and this class is registered after the other class, the editor/game would crash at startup:
```
Godot-JVM: Registered _VisualScriptEditor engine type with index 621.
Godot-JVM: Done registering managed engine types...
ERROR: get: FATAL: Index p_index = 6 is out of bounds (size() = 0).
   At: ./core/cowdata.h:152.
handle_crash: Program crashed with signal 4
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /home/cedric/projects/04_godot/modules/kotlin_jvm/harness/tests/jre/lib/server/libjvm.so(+0xbe1f66) [0x7f96159eff66] (??:0)
[2] /home/cedric/projects/04_godot/modules/kotlin_jvm/harness/tests/jre/lib/server/libjvm.so(JVM_handle_linux_signal+0x2cb) [0x7f96159f5d1b] (??:0)
[3] /home/cedric/projects/04_godot/modules/kotlin_jvm/harness/tests/jre/lib/server/libjvm.so(+0xbda8fa) [0x7f96159e88fa] (??:0)
[4] /usr/lib/libpthread.so.0(+0x13960) [0x7f96cf76f960] (??:0)
[5] CowData<Ref<KotlinScript> >::get(int) const (/home/cedric/projects/04_godot/./core/cowdata.h:152 (discriminator 7))
[6] Vector<Ref<KotlinScript> >::operator[](int) const (/home/cedric/projects/04_godot/./core/vector.h:85)
[7] TransferContext::set_script(JNIEnv_*, _jobject*, long, int, _jobject*, _jobject*) (/home/cedric/projects/04_godot/modules/kotlin_jvm/src/transfer_context.cpp:195)
[8] [0x7f95d900f710] (??:0)
-- END OF BACKTRACE --
```

## Problem:
Example is our tests project:
In `Invocation` we have this property: `var registerObjectNullablePreInit: OtherScript? = OtherScript()` 
in the registrar there is this default value provider: `open val registerObjectNullablePreInitDefaultValue: OtherScript = OtherScript()` 
when this executes it tries to set the script in the `init` block of `KtObject` with:
```kotlin
//...
            // inheritance in Godot is faked, a script is attached to an Object allow
            // the script to see all methods of the owning Object.
            // For user types, we need to make sure to attach this script to the Object
            // rawPtr is pointing to.
            val classIndex = TypeManager.userTypeToId[this::class]
            // If user type
            if (classIndex != null) {
                println("called with $this")
                TransferContext.setScript(rawPtr, classIndex, this, this::class.java.classLoader)
            }
//...
```
Which returned `null` for  `val classIndex = TypeManager.userTypeToId[this::class]` for clean builds as `OtherScript` was registered *after* `Invocation` but on an incremental build it is registered *before* `Invocation` which leads to the problem that cpp does not yet know the class as we pass all of them at once. So kotlin knows about our classes before cpp does. Which is fine normally but not in this case.

## Solution:
To fix this, this PR registers all classes first in cpp and fetches all members *after* all classes are registered.
It also fetches the default values lazily.

Depends on: https://github.com/utopia-rise/godot-kotlin-entry-generator/pull/27