### PR TITLE
Fix: Use OS singleton instead of stdlib to get JAVA_HOME env variable

### DIFF
--- a/src/jni/jvm_loader.cpp
+++ b/src/jni/jvm_loader.cpp
@@ -1,9 +1,7 @@
 #include "jvm_loader.h"
 
-#include <core/engine.h>
 #include <core/os/os.h>
 #include <core/project_settings.h>
-#include <modules/kotlin_jvm/src/logging.h>
 
 #ifndef __ANDROID__
 
@@ -69,7 +67,7 @@ String jni::JvmLoader::get_jvm_lib_path() {
 }
 
 String jni::JvmLoader::get_path_to_locally_installed_jvm() {
-    String javaHome{getenv("JAVA_HOME")};
+    String javaHome{OS::get_singleton()->get_environment("JAVA_HOME")};
 
     if (javaHome.empty()) {
         LOG_ERROR("JAVA_HOME is not defined! Exiting...")


### PR DESCRIPTION
We were using `getenv` method from `stdlib` to get `JAVA_HOME` environment variable.  
This method is deprecated.  
To avoid problems and potential bugs on finding `JAVA_HOME`, this makes use of `OS` singleton.