### PR TITLE
Hotfix/fix from godot to kotin basis

### DIFF
--- a/harness/tests/build.gradle.kts
+++ b/harness/tests/build.gradle.kts
@@ -1,7 +1,7 @@
 
 plugins {
     kotlin("jvm") version "1.4.10"
-    id("com.utopia-rise.godot-kotlin-jvm") version "0.1.2-3.2.3"
+    id("com.utopia-rise.godot-kotlin-jvm") version "0.1.3-3.2.3-SNAPSHOT"
 }
 
 repositories {

--- a/harness/tests/project.godot
+++ b/harness/tests/project.godot
@@ -40,6 +40,16 @@ _global_script_classes=[ {
 "path": "res://src/main/kotlin/godot/tests/MultiArgsConstructorTest.kt"
 }, {
 "base": "Node",
+"class": "godot_tests_coretypes_BasisTest",
+"language": "Kotlin",
+"path": "res://src/main/kotlin/godot/tests/coretypes/BasisTest.kt"
+}, {
+"base": "Node",
+"class": "godot_tests_coretypes_Vector3Test",
+"language": "Kotlin",
+"path": "res://src/main/kotlin/godot/tests/coretypes/Vector3Test.kt"
+}, {
+"base": "Node",
 "class": "godot_tests_inheritance_ClassInheritanceChild",
 "language": "Kotlin",
 "path": "res://src/main/kotlin/godot/tests/inheritance/ClassInheritanceChild.kt"
@@ -61,6 +71,8 @@ _global_script_class_icons={
 "godot_tests_FuncRefTest": "",
 "godot_tests_Invocation": "",
 "godot_tests_MultiArgsConstructorTest": "",
+"godot_tests_coretypes_BasisTest": "",
+"godot_tests_coretypes_Vector3Test": "",
 "godot_tests_inheritance_ClassInheritanceChild": "",
 "godot_tests_inheritance_ClassInheritanceParent": "",
 "godot_tests_subpackage_OtherScript": ""

--- a/harness/tests/settings.gradle.kts
+++ b/harness/tests/settings.gradle.kts
@@ -30,7 +30,7 @@ pluginManagement {
     }
     resolutionStrategy.eachPlugin {
         if (requested.id.id == "com.utopia-rise.godot-kotlin-jvm") {
-            useModule("com.utopia-rise:godot-gradle-plugin:0.1.2-3.2.3")
+            useModule("com.utopia-rise:godot-gradle-plugin:0.1.3-3.2.3-SNAPSHOT")
         }
         if (requested.id.id == "com.utopia-rise.api-generator") {
             useModule("com.utopia-rise:api-generator:0.0.1")

--- a/harness/tests/src/main/kotlin/godot/tests/CoreTypesIdentityTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/CoreTypesIdentityTest.kt
@@ -2,6 +2,7 @@ package godot.tests
 
 import godot.Node
 import godot.annotation.RegisterClass
+import godot.annotation.RegisterFunction
 import godot.annotation.RegisterProperty
 import godot.core.*
 
@@ -38,4 +39,34 @@ class CoreTypesIdentityTest : Node() {
 
     @RegisterProperty
     var vector3 = Vector3(1, 2, 3)
+
+    @RegisterFunction
+    fun aabb(aabb: AABB) = aabb
+
+    @RegisterFunction
+    fun basis(basis: Basis) = basis
+
+    @RegisterFunction
+    fun color(color: Color) = color
+
+    @RegisterFunction
+    fun plane(plane: Plane) = plane
+
+    @RegisterFunction
+    fun quat(quat: Quat) = quat
+
+    @RegisterFunction
+    fun rect2(rect2: Rect2) = rect2
+
+    @RegisterFunction
+    fun transform(transform: Transform) = transform
+
+    @RegisterFunction
+    fun transform2D(transform2D: Transform2D) = transform2D
+
+    @RegisterFunction
+    fun vector2(vector2: Vector2) = vector2
+
+    @RegisterFunction
+    fun vector3(vector3: Vector3) = vector3
 }

--- a/harness/tests/src/main/kotlin/godot/tests/FuncRefTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/FuncRefTest.kt
@@ -11,7 +11,7 @@ import godot.callDeferred
 import godot.signals.signal
 
 @RegisterClass
-class FuncRefTest: Node() {
+class FuncRefTest : Node() {
 
     @RegisterSignal
     val signalTest by signal()

--- a/harness/tests/src/main/kotlin/godot/tests/coretypes/BasisTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/coretypes/BasisTest.kt
@@ -1,0 +1,20 @@
+package godot.tests.coretypes
+
+import godot.Node
+import godot.annotation.RegisterClass
+import godot.annotation.RegisterFunction
+import godot.core.Basis
+import godot.core.Vector3
+
+@RegisterClass
+class BasisTest : Node() {
+
+    @RegisterFunction
+    fun get(basis: Basis, index: Int) = basis[index]
+
+    @RegisterFunction
+    fun set(basis: Basis, index: Int, vector3: Vector3): Basis {
+        basis[index] = vector3
+        return basis
+    }
+}

--- a/harness/tests/src/main/kotlin/godot/tests/coretypes/Vector3Test.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/coretypes/Vector3Test.kt
@@ -1,0 +1,20 @@
+package godot.tests.coretypes
+
+import godot.Node
+import godot.annotation.RegisterClass
+import godot.annotation.RegisterFunction
+import godot.core.Vector3
+import godot.util.RealT
+
+@RegisterClass
+class Vector3Test : Node() {
+
+    @RegisterFunction
+    fun get(vector3: Vector3, index: Int) = vector3[index]
+
+    @RegisterFunction
+    fun set(vector3: Vector3, index: Int, realT: RealT): Vector3 {
+        vector3[index] = realT
+        return vector3
+    }
+}

--- a/harness/tests/src/main/kotlin/godot/tests/rpctests/RpcTests.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/rpctests/RpcTests.kt
@@ -7,7 +7,7 @@ import godot.annotation.RegisterFunction
 import godot.annotation.RegisterProperty
 
 @RegisterClass("RPCTests")
-class RpcTests: Node() {
+class RpcTests : Node() {
 
     @RegisterProperty
     var remoteSyncCalled: Boolean = false

--- a/harness/tests/test/unit/test_core_types_identity.gd
+++ b/harness/tests/test/unit/test_core_types_identity.gd
@@ -5,58 +5,68 @@ func test_should_return_right_aabb():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_aabb = AABB(Vector3(1, 1, 1), Vector3(2, 2, 2))
 	assert_eq(instance.aabb, expected_aabb, "Should get same aabb")
+	assert_eq(instance.aabb(expected_aabb), expected_aabb, "Buffer should not change Aabb")
 	instance.free()
 
 func test_should_return_right_basis():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_basis = Basis(Vector3(0, 1, 2), Vector3(3, 4, 5), Vector3(6, 7, 8))
 	assert_eq(instance.basis, expected_basis, "Should get same basis")
+	assert_eq(instance.basis(expected_basis), expected_basis, "Buffer should not change Basis")
 	instance.free()
 
 func test_should_return_right_color():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_color = Color(0.1, 0.2, 0.3, 0.4)
 	assert_eq(instance.color, expected_color, "Should get same color")
+	assert_eq(instance.color(expected_color), expected_color, "Buffer should not change Color")
 	instance.free()
 
 func test_should_return_right_plane():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_plane = Plane(1, 2, 3, 4)
 	assert_eq(instance.plane, expected_plane, "Should get same plane")
+	assert_eq(instance.plane(expected_plane), expected_plane, "Buffer should not change Plane")
 	instance.free()
 
 func test_should_return_right_quat():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_quat = Quat(1, 2, 3, 4)
 	assert_eq(instance.quat, expected_quat, "Should get same quat")
+	assert_eq(instance.quat(expected_quat), expected_quat, "Buffer should not change Quat")
 	instance.free()
 
 func test_should_return_right_rect2():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_rect2 = Rect2(1.0, 2.0, 3.0, 4.0)
 	assert_eq(instance.rect2, expected_rect2, "Should get same rect2")
+	assert_eq(instance.rect2(expected_rect2), expected_rect2, "Buffer should not change Rect2")
 	instance.free()
 
 func test_should_return_right_transform():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_transform = Transform(Vector3(0, 1, 2), Vector3(3, 4, 5), Vector3(6, 7, 8), Vector3(9, 10, 11))
 	assert_eq(instance.transform, expected_transform, "Should get same transform")
+	assert_eq(instance.transform(expected_transform), expected_transform, "Buffer should not change Transform")
 	instance.free()
 
 func test_should_return_right_transform2d():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_transform2d = Transform2D(Vector2(0, 1), Vector2(2, 3), Vector2(4, 5))
 	assert_eq(instance.transform2_d, expected_transform2d, "Should get same transform2d")
+	assert_eq(instance.transform2_d(expected_transform2d), expected_transform2d, "Buffer should not change Transform2D")
 	instance.free()
 
 func test_should_return_right_vector2():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_vector2 = Vector2(1, 2)
 	assert_eq(instance.vector2, expected_vector2, "Should get same vector2")
+	assert_eq(instance.vector2(expected_vector2), expected_vector2, "Buffer should not change Vector2")
 	instance.free()
 
 func test_should_return_right_vector3():
 	var instance = godot_tests_CoreTypesIdentityTest.new()
 	var expected_vector3 = Vector3(1, 2, 3)
 	assert_eq(instance.vector3, expected_vector3, "Should get same vector3")
+	assert_eq(instance.vector3(expected_vector3), expected_vector3, "Buffer should not change Vector3")
 	instance.free()

--- a/harness/tests/test/unit/test_coretypes_basis.gd
+++ b/harness/tests/test/unit/test_coretypes_basis.gd
@@ -1,0 +1,24 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_should_get_right_vector3_using_operator_get():
+	var basis_test = godot_tests_coretypes_BasisTest.new()
+	var engine_basis = Basis(Vector3(1, 2, 3), Vector3(6, 8, 10), Vector3(5, 9, 7))
+	var jvm_basis = Basis(Vector3(1, 2, 3), Vector3(6, 8, 10), Vector3(5, 9, 7))
+	assert_eq(engine_basis[0], basis_test.get(jvm_basis, 0), "Basis get operator on JVM side should be same as gdscript one.")
+	assert_eq(engine_basis[1], basis_test.get(jvm_basis, 1), "Basis get operator on JVM side should be same as gdscript one.")
+	assert_eq(engine_basis[2], basis_test.get(jvm_basis, 2), "Basis get operator on JVM side should be same as gdscript one.")
+	basis_test.free()
+
+func test_should_set_right_vector3_using_operator_set():
+	var basis_test = godot_tests_coretypes_BasisTest.new()
+	var engine_basis = Basis(Vector3(1, 2, 3), Vector3(6, 8, 10), Vector3(5, 9, 7))
+	var jvm_basis = Basis(Vector3(1, 2, 3), Vector3(6, 8, 10), Vector3(5, 9, 7))
+	engine_basis[0] = Vector3(10, 20, 30)
+	engine_basis[1] = Vector3(60, 80, 100)
+	engine_basis[2] = Vector3(50, 90, 70)
+	jvm_basis = basis_test.set(jvm_basis, 0, Vector3(10, 20, 30))
+	jvm_basis = basis_test.set(jvm_basis, 1, Vector3(60, 80, 100))
+	jvm_basis = basis_test.set(jvm_basis, 2, Vector3(50, 90, 70))
+	assert_eq(engine_basis, jvm_basis, "Basis set operator on JVM side should be same as gdscript one.")
+	basis_test.free()

--- a/harness/tests/test/unit/test_coretypes_vector3.gd
+++ b/harness/tests/test/unit/test_coretypes_vector3.gd
@@ -1,0 +1,24 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_operator_get_on_jvm_side_should_return_right_axis():
+	var vector3_test = godot_tests_coretypes_Vector3Test.new()
+	var engine_vector = Vector3(1, 2, 3)
+	var jvm_vector = Vector3(1, 2, 3)
+	assert_eq(engine_vector[0], vector3_test.get(jvm_vector, 0), "Vector3 operator get on jvm side should act the same as gdscript one.")
+	assert_eq(engine_vector[1], vector3_test.get(jvm_vector, 1), "Vector3 operator get on jvm side should act the same as gdscript one.")
+	assert_eq(engine_vector[2], vector3_test.get(jvm_vector, 2), "Vector3 operator get on jvm side should act the same as gdscript one.")
+	vector3_test.free()
+
+func test_operator_set_on_jvm_side_should_set_right_axis():
+	var vector3_test = godot_tests_coretypes_Vector3Test.new()
+	var engine_vector = Vector3(1, 2, 3)
+	var jvm_vector = Vector3(1, 2, 3)
+	engine_vector[0] = 10
+	engine_vector[1] = 20
+	engine_vector[2] = 30
+	jvm_vector = vector3_test.set(jvm_vector, 0, 10.0)
+	jvm_vector = vector3_test.set(jvm_vector, 1, 20.0)
+	jvm_vector = vector3_test.set(jvm_vector, 2, 30.0)
+	assert_eq(engine_vector, jvm_vector, "Vector3 operator set on jvm side should act the same as gdscript one.")
+	vector3_test.free()

--- a/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
+++ b/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
@@ -1,2 +1,2 @@
-const val godotKotlinJvmVersion = "0.1.2"
+const val godotKotlinJvmVersion = "0.1.3"
 const val godotKotlinIntellijPluginVersion = "0.1.2"

--- a/kt/godot-runtime/src/main/kotlin/godot/core/Basis.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/Basis.kt
@@ -812,7 +812,7 @@ class Basis() : CoreType {
     }
 
     operator fun set(index: Int, value: Vector3) {
-        return setAxis(index, value)
+        setAxis(index, value)
     }
 }
 

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -113,9 +113,9 @@ namespace ktvariant {
     }
 
     static inline void append_basis(SharedBuffer* des, const Basis& data) {
-        append_vector3(des, data.get_axis(0));
-        append_vector3(des, data.get_axis(1));
-        append_vector3(des, data.get_axis(2));
+        append_vector3(des, data.elements[0]);
+        append_vector3(des, data.elements[1]);
+        append_vector3(des, data.elements[2]);
     }
 
     static void to_kvariant_fromBASIS(SharedBuffer* des, const Variant& src) {

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -99,6 +99,7 @@ namespace ktvariant {
 
     static void to_kvariant_fromQUAT(SharedBuffer* des, const Variant& src) {
         Quat src_quat{src.operator Quat()};
+        set_variant_type(des, Variant::Type::QUAT);
         des->increment_position(encode_float(src_quat.x, des->get_cursor()));
         des->increment_position(encode_float(src_quat.y, des->get_cursor()));
         des->increment_position(encode_float(src_quat.z, des->get_cursor()));


### PR DESCRIPTION
There several bugs in cpp to kotlin sending:
- Basis data were not set correctly (confusion between axis and elements)
- Variant type for plane was not sent through buffer, which does not respect protocol.

This adds core types identity tests for cpp to kotlin.

This resolves #132 