### PR TITLE
Generate changelog

### DIFF
--- a/.github/workflows/create-draft-release.yaml
+++ b/.github/workflows/create-draft-release.yaml
@@ -10,6 +10,20 @@ jobs:
     name: Create Github Release
     runs-on: ubuntu-latest
     steps:
+      - name: Clone Godot JVM module.
+        uses: actions/checkout@v2
+      - name: Checkout submodules
+        uses: snickerbockers/submodules-init@v4
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Generate changelog
+        uses: eskatos/gradle-command-action@v1
+        with:
+          wrapper-directory: kt/
+          build-root-directory: kt/
+          arguments: generateChangelog
       - name: Create draft release
         id: create_release
         uses: actions/create-release@v1
@@ -20,9 +34,7 @@ jobs:
           release_name: ${{ github.ref }}
           draft: true
           prerelease: false
-          body: |
-            The pre built engines are the zip files.
-            The other files are export templates needed for exporting your game. See [exporting](https://godot-kotl.in/en/latest/user-guide/exporting/) documentation on how to use them.
+          body_path: kt/build/changelog.md
 
       - name: Output release url file
         run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt

--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -28,6 +28,32 @@ subprojects {
 }
 
 tasks {
+    val generateChangelog by creating {
+        group = "godot-kotlin-jvm"
+
+        doLast {
+            val tags = grgit.tag.list().reversed()
+            val fromTag = tags.getOrNull(1)
+            val toTag = tags.getOrNull(0)
+            val changeLogPrefix = """
+                The pre built engines are the zip files.  
+                The other files are export templates needed for exporting your game. See [exporting](https://godot-kotl.in/en/latest/user-guide/exporting/) documentation on how to use them.
+                
+                **Changelog:**
+                
+            """.trimIndent()
+
+            val changelogString = grgit.log {
+                range(fromTag?.name, toTag?.name)
+            }
+                .joinToString(separator = "\n", prefix = changeLogPrefix) { commit ->
+                    val link = "https://github.com/utopia-rise/godot-kotlin-jvm/commit/${commit.id}"
+                    "- [${commit.abbreviatedId}]($link) ${commit.shortMessage}"
+                }
+
+            project.buildDir.resolve("changelog.md").writeText(changelogString)
+        }
+    }
     val buildEngineDebug by creating(Exec::class) {
         group = "godot-kotlin-jvm"
 


### PR DESCRIPTION
Resolves #152 

This generates the changelog for releases.
example for `0.1.3`:
```markdown
The pre built engines are the zip files.  
The other files are export templates needed for exporting your game. See [exporting](https://godot-kotl.in/en/latest/user-guide/exporting/) documentation on how to use them.

**Changelog:**
- [07113b1](https://github.com/utopia-rise/godot-kotlin-jvm/commit/07113b1dd0e07ef9b03061fa9d1c7d2403cea99b) Update versions for release (#150)
- [a5b88d7](https://github.com/utopia-rise/godot-kotlin-jvm/commit/a5b88d7876a338d0d1c3223590ed6f094e293c0f) Hotfix/fix from godot to kotin basis (#142)
- [ff3d16a](https://github.com/utopia-rise/godot-kotlin-jvm/commit/ff3d16ac7af4075440eec6aa37c508e304dc80cd) Fix default values of user script types (#137)
- [1724dc2](https://github.com/utopia-rise/godot-kotlin-jvm/commit/1724dc2f83c2776c47150836449999abfeaca3fd) Fix stackoverflow by making recursive calls tailrec (#143)
- [59ccc02](https://github.com/utopia-rise/godot-kotlin-jvm/commit/59ccc02c895cb77a99edbfbf14d41771503d5179) Add example class to template (#139)
- [1bd14fb](https://github.com/utopia-rise/godot-kotlin-jvm/commit/1bd14fb0a339ecabe9e50f361be613f364e4a0d3) Add release description (#144)
- [963366e](https://github.com/utopia-rise/godot-kotlin-jvm/commit/963366ec3d886dfd9ec1181736fe25d5aa9f43e9) Add documentation about where to get the pre built engine (#138)
- [2c66153](https://github.com/utopia-rise/godot-kotlin-jvm/commit/2c66153a0fdd99bfb48959ca3884cef42c603195) Fix api differences links (#131)
- [438933c](https://github.com/utopia-rise/godot-kotlin-jvm/commit/438933c256f0f8b40d178925206463aa214e6547) Fix: Use OS singleton instead of stdlib to get JAAV_HOME env variable (#141)
```

pretty:

---
The pre built engines are the zip files.  
The other files are export templates needed for exporting your game. See [exporting](https://godot-kotl.in/en/latest/user-guide/exporting/) documentation on how to use them.

**Changelog:**
- [07113b1](https://github.com/utopia-rise/godot-kotlin-jvm/commit/07113b1dd0e07ef9b03061fa9d1c7d2403cea99b) Update versions for release (#150)
- [a5b88d7](https://github.com/utopia-rise/godot-kotlin-jvm/commit/a5b88d7876a338d0d1c3223590ed6f094e293c0f) Hotfix/fix from godot to kotin basis (#142)
- [ff3d16a](https://github.com/utopia-rise/godot-kotlin-jvm/commit/ff3d16ac7af4075440eec6aa37c508e304dc80cd) Fix default values of user script types (#137)
- [1724dc2](https://github.com/utopia-rise/godot-kotlin-jvm/commit/1724dc2f83c2776c47150836449999abfeaca3fd) Fix stackoverflow by making recursive calls tailrec (#143)
- [59ccc02](https://github.com/utopia-rise/godot-kotlin-jvm/commit/59ccc02c895cb77a99edbfbf14d41771503d5179) Add example class to template (#139)
- [1bd14fb](https://github.com/utopia-rise/godot-kotlin-jvm/commit/1bd14fb0a339ecabe9e50f361be613f364e4a0d3) Add release description (#144)
- [963366e](https://github.com/utopia-rise/godot-kotlin-jvm/commit/963366ec3d886dfd9ec1181736fe25d5aa9f43e9) Add documentation about where to get the pre built engine (#138)
- [2c66153](https://github.com/utopia-rise/godot-kotlin-jvm/commit/2c66153a0fdd99bfb48959ca3884cef42c603195) Fix api differences links (#131)
- [438933c](https://github.com/utopia-rise/godot-kotlin-jvm/commit/438933c256f0f8b40d178925206463aa214e6547) Fix: Use OS singleton instead of stdlib to get JAAV_HOME env variable (#141)