### PR TITLE
Update dependencies and fix compiler warnings

### DIFF
--- a/harness/benchmarks/gradle/wrapper/gradle-wrapper.properties
+++ b/harness/benchmarks/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/harness/bunnymark/gradle/wrapper/gradle-wrapper.properties
+++ b/harness/bunnymark/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kt/buildSrc/build.gradle.kts
+++ b/kt/buildSrc/build.gradle.kts
@@ -26,6 +26,4 @@ gradlePlugin {
 
 dependencies {
     implementation(kotlin("gradle-plugin", version = "1.4.32"))
-    implementation("com.squareup:kotlinpoet:1.5.0")
-    implementation("com.fasterxml.jackson.core:jackson-databind:2.11.0")
 }

--- a/kt/buildSrc/src/main/kotlin/DependenciesVersions.kt
+++ b/kt/buildSrc/src/main/kotlin/DependenciesVersions.kt
@@ -1,10 +1,6 @@
 object DependenciesVersions {
     const val godotVersion: String = "3.2.3"
-    const val shadowJarPluginVersion: String = "5.0.0"
-    const val mpaptVersion: String = "0.8.5"
-    const val kotlinPoetVersion: String = "1.5.0"
-
-    // Remember to upgrade this version when releasing a new entry generator version and want to use
-    // it.
-    const val entryGeneratorVersion = "0.1.2-3.2.3"
+    const val shadowJarPluginVersion: String = "6.1.0"
+    const val mpaptVersion: String = "0.8.7"
+    const val kotlinPoetVersion: String = "1.8.0"
 }

--- a/kt/entry-generation/godot-annotation-processor/build.gradle.kts
+++ b/kt/entry-generation/godot-annotation-processor/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.utopia-rise:godot-kotlin-entry-generator:${DependenciesVersions.entryGeneratorVersion}")
+    implementation("com.utopia-rise:godot-kotlin-entry-generator:${project.version}")
     implementation(project(":godot-library"))
     compileOnly(kotlin("compiler-embeddable"))
     implementation("de.jensklingenberg:mpapt-runtime:${DependenciesVersions.mpaptVersion}")

--- a/kt/entry-generation/godot-kotlin-entry-generator/build.gradle.kts
+++ b/kt/entry-generation/godot-kotlin-entry-generator/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:${kotlin.coreLibrariesVersion}")
     implementation("com.squareup:kotlinpoet:${DependenciesVersions.kotlinPoetVersion}")
 }

--- a/kt/entry-generation/godot-kotlin-entry-generator/build.gradle.kts
+++ b/kt/entry-generation/godot-kotlin-entry-generator/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:1.4.10")
+    implementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:${kotlin.coreLibrariesVersion}")
     implementation("com.squareup:kotlinpoet:${DependenciesVersions.kotlinPoetVersion}")
 }
 

--- a/kt/entry-generation/godot-kotlin-entry-generator/src/main/kotlin/godot/entrygenerator/EntryGenerator.kt
+++ b/kt/entry-generation/godot-kotlin-entry-generator/src/main/kotlin/godot/entrygenerator/EntryGenerator.kt
@@ -1,6 +1,11 @@
 package godot.entrygenerator
 
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.TypeSpec
 import godot.entrygenerator.compiler.CompilerEnvironmentProvider
 import godot.entrygenerator.exceptions.ClassNameRegistrationException
 import godot.entrygenerator.exceptions.MultipleClassesPerFileRegistrationException
@@ -182,14 +187,14 @@ object EntryGenerator {
 
         if (duplicatedClasses.isNotEmpty()) {
             val exceptionMessage = buildString {
-                appendln("There are classes registered with the same name. Check your customName argument for the annotation @RegisterClass:")
+                appendLine("There are classes registered with the same name. Check your customName argument for the annotation @RegisterClass:")
                 duplicatedClasses
                     .forEachIndexed { index, duplications ->
                         if (index != 0) {
-                            appendln("---")
+                            appendLine("---")
                         }
                         duplications.forEach { (classFqName, registeredName) ->
-                            appendln("RegisteredName: $registeredName, ActualClass: $classFqName")
+                            appendLine("RegisteredName: $registeredName, ActualClass: $classFqName")
                         }
                     }
             }

--- a/kt/entry-generation/godot-kotlin-entry-generator/src/main/kotlin/godot/entrygenerator/generator/function/FunctionRegistrationGenerator.kt
+++ b/kt/entry-generation/godot-kotlin-entry-generator/src/main/kotlin/godot/entrygenerator/generator/function/FunctionRegistrationGenerator.kt
@@ -1,6 +1,8 @@
 package godot.entrygenerator.generator.function
 
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.MemberName.Companion.member
 import godot.entrygenerator.extension.getAnnotationValue
 import godot.entrygenerator.extension.toParameterKtVariantType
@@ -88,7 +90,7 @@ object FunctionRegistrationGenerator {
             append("function(%L,·%T") //functionReference, returnTypeConverterReference
 
             if (functionDescriptor.valueParameters.isNotEmpty()) {
-                functionDescriptor.valueParameters.forEach { param ->
+                functionDescriptor.valueParameters.forEach { _ ->
                     append(",·%T·to·%L") //Variant type
                 }
                 functionDescriptor.valueParameters.forEach { _ ->

--- a/kt/godot-bootstrap/build.gradle.kts
+++ b/kt/godot-bootstrap/build.gradle.kts
@@ -2,7 +2,7 @@ import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
 plugins {
     kotlin("jvm")
-    id("com.github.johnrengelman.shadow") version "6.1.0"
+    id("com.github.johnrengelman.shadow") version DependenciesVersions.shadowJarPluginVersion
 }
 
 dependencies {

--- a/kt/godot-library/src/main/kotlin/godot/extensions.kt
+++ b/kt/godot-library/src/main/kotlin/godot/extensions.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KFunction
 @Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
 inline fun <T : Node?> Node.getNode(path: String) = getNode(NodePath(path)) as T
 
-@Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
+@Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST", "EXTENSION_SHADOWED_BY_MEMBER")
 inline fun <T : Node?> Node.getNode(nodePath: NodePath) = getNode(nodePath) as T
 
 /**

--- a/kt/godot-library/src/main/kotlin/godot/signals/SignalProvider.kt
+++ b/kt/godot-library/src/main/kotlin/godot/signals/SignalProvider.kt
@@ -1,12 +1,12 @@
 package godot.signals
 
 import godot.Object
-import godot.util.camelToSnakeCase
 import kotlin.reflect.KProperty
 
 class SignalDelegate<T : Signal>(val factory: () -> T) {
     @PublishedApi
     internal var signal: T? = null
+    @Suppress("NOTHING_TO_INLINE")
     inline operator fun getValue(thisRef: Object, property: KProperty<*>): T {
         if (signal == null) {
             signal = factory()

--- a/kt/godot-runtime/src/main/kotlin/godot/core/Dictionary.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/Dictionary.kt
@@ -164,6 +164,7 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V>{
     fun duplicate(deep: Boolean): Dictionary<K, V> {
         TransferContext.writeArguments(VariantType.BOOL to deep)
         Bridge.engine_call_duplicate(_handle)
+        @Suppress("UNCHECKED_CAST")
         return (TransferContext.readReturnValue(VariantType.DICTIONARY) as Dictionary<K, V>).also {
             it.keyVariantType = keyVariantType
             it.valueVariantType = valueVariantType
@@ -193,6 +194,7 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V>{
     fun get(key: K, default: V?): V? {
         TransferContext.writeArguments(keyVariantType to key, valueVariantType to default)
         Bridge.engine_call_get(_handle)
+        @Suppress("UNCHECKED_CAST")
         return TransferContext.readReturnValue(valueVariantType, true) as V
     }
 
@@ -232,6 +234,7 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V>{
      */
     fun keys(): VariantArray<K> {
         Bridge.engine_call_keys(_handle)
+        @Suppress("UNCHECKED_CAST")
         return (TransferContext.readReturnValue(VariantType.ARRAY) as VariantArray<K>).also {
             it.variantType = keyVariantType
         }
@@ -260,6 +263,7 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V>{
      */
     fun values(): VariantArray<V> {
         Bridge.engine_call_values(_handle)
+        @Suppress("UNCHECKED_CAST")
         return (TransferContext.readReturnValue(VariantType.ARRAY) as VariantArray<V>).also {
             it.variantType = valueVariantType
         }
@@ -270,6 +274,7 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V>{
     override operator fun get(key: K): V {
         TransferContext.writeArguments(keyVariantType to key)
         Bridge.engine_call_operator_get(_handle)
+        @Suppress("UNCHECKED_CAST")
         return TransferContext.readReturnValue(valueVariantType, true) as V
     }
 

--- a/kt/godot-runtime/src/main/kotlin/godot/core/GarbageCollector.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/GarbageCollector.kt
@@ -305,6 +305,7 @@ object GarbageCollector {
     private fun forceJvmGc() {
         var any: Any? = Any()
         val wkRef = WeakReference(any)
+        @Suppress("UNUSED_VALUE")
         any = null
         while (wkRef.get() != null) {
             System.gc()

--- a/kt/godot-runtime/src/main/kotlin/godot/core/Properties.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/Properties.kt
@@ -43,6 +43,7 @@ open class KtProperty<T : KtObject, P: Any?>(
         //TODO: manage nullable argument of enum setter (only for objects)
         val arg = TransferContext.readSingleArgument(variantType)
         TransferContext.buffer.rewind()
+        @Suppress("UNCHECKED_CAST")
         return arg as P
     }
 }

--- a/kt/godot-runtime/src/main/kotlin/godot/core/Variant.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/Variant.kt
@@ -173,7 +173,7 @@ enum class VariantType(
             }
     ),
     TRANSFORM2D(
-            { buffer: ByteBuffer, expectedType: Int ->
+            { buffer: ByteBuffer, _: Int ->
                 val x = buffer.vector2
                 val y = buffer.vector2
                 val origin = buffer.vector2
@@ -386,7 +386,7 @@ enum class VariantType(
             }
     ), // 25
     POOL_COLOR_ARRAY(
-            { buffer: ByteBuffer, expectedType: Int ->
+            { buffer: ByteBuffer, _: Int ->
                 val ptr = buffer.long
                 PoolColorArray(ptr)
             },

--- a/kt/godot-runtime/src/main/kotlin/godot/core/VariantArray.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/core/VariantArray.kt
@@ -4,7 +4,7 @@ import godot.util.IndexedIterator
 import godot.util.VoidPtr
 
 
-@Suppress("unused")
+@Suppress("unused", "UNCHECKED_CAST")
 class VariantArray<T> : NativeCoreType, MutableCollection<T> {
 
     internal var variantType: VariantType = VariantType.NIL

--- a/kt/godot-runtime/src/main/kotlin/godot/runtime/Registration.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/runtime/Registration.kt
@@ -1,9 +1,36 @@
 package godot.runtime
 
-import godot.core.*
+import godot.core.CONSTRUCTOR_MAX_ARGS
+import godot.core.KtClass
+import godot.core.KtConstructor
+import godot.core.KtEnumProperty
+import godot.core.KtFunction
+import godot.core.KtFunction0
+import godot.core.KtFunction1
+import godot.core.KtFunction2
+import godot.core.KtFunction3
+import godot.core.KtFunction4
+import godot.core.KtFunction5
+import godot.core.KtFunctionInfo
+import godot.core.KtObject
+import godot.core.KtProperty
+import godot.core.KtPropertyInfo
+import godot.core.KtSignalInfo
+import godot.core.PropertyHint
+import godot.core.TypeManager
+import godot.core.VariantType
 import godot.util.camelToSnakeCase
-import kotlin.reflect.*
+import kotlin.reflect.KClass
+import kotlin.reflect.KFunction1
+import kotlin.reflect.KFunction2
+import kotlin.reflect.KFunction3
+import kotlin.reflect.KFunction4
+import kotlin.reflect.KFunction5
+import kotlin.reflect.KFunction6
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.KProperty
 
+@Suppress("UNCHECKED_CAST")
 class KtPropertyInfoBuilderDsl {
     var type: VariantType? = null
     var name: String = ""
@@ -140,6 +167,7 @@ class ClassBuilderDsl<T : KtObject>(
 //    }
 
     @JvmName("enumFlagPropertyMutable")
+    @Suppress("UNCHECKED_CAST")
     inline fun <reified P : Enum<P>> enumFlagProperty(
         kProperty: KMutableProperty1<T, MutableSet<P>>,
         noinline defaultValue: () -> MutableSet<P>,
@@ -200,7 +228,6 @@ class ClassBuilderDsl<T : KtObject>(
     fun <P: Any?> property(
         kProperty: KMutableProperty1<T, P>,
         variantType: VariantType,
-        setValueConverter: ((Any?) -> P),
         isRef: Boolean = false,
         defaultArgument: () -> P,
         rpcModeId: Int = 0,

--- a/kt/godot-runtime/src/main/kotlin/godot/util/IndexedIterator.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/util/IndexedIterator.kt
@@ -1,5 +1,6 @@
 package godot.util
 
+@Suppress("UNCHECKED_CAST")
 internal class IndexedIterator<T>(
         private var size: () -> Int,
         private val getter: (Int) -> T,
@@ -40,6 +41,7 @@ internal class Entry<K, V>(
     }
 }
 
+@Suppress("UNCHECKED_CAST")
 internal class MapIterator<K, V>(
         private val keyIterator: MutableIterator<K>,
         private val getter: (K) -> V,

--- a/kt/godot-runtime/src/main/kotlin/godot/util/Utils.kt
+++ b/kt/godot-runtime/src/main/kotlin/godot/util/Utils.kt
@@ -17,15 +17,20 @@ fun String.camelToSnakeCase(): String {
     }.toLowerCase()
 }
 
+@Suppress("NOTHING_TO_INLINE")
 inline fun Number.toRealT(): RealT = this.toDouble()
 
+@Suppress("NOTHING_TO_INLINE")
 inline fun Double.toRealT(): RealT = this
 
+@Suppress("NOTHING_TO_INLINE")
 inline fun Float.toRealT(): RealT = this.toDouble()
 
+@Suppress("NOTHING_TO_INLINE")
 @PublishedApi
 internal inline fun Number.toGodotReal(): Float = this.toFloat()
 
+@Suppress("NOTHING_TO_INLINE")
 @PublishedApi
 internal inline fun Float.toGodotReal(): Float = this
 

--- a/kt/plugins/godot-gradle-plugin/build.gradle.kts
+++ b/kt/plugins/godot-gradle-plugin/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("com.github.jengelman.gradle.plugins:shadow:${DependenciesVersions.shadowJarPluginVersion}")
 
     implementation(project(":godot-build-props"))
-    implementation("com.utopia-rise:godot-kotlin-entry-generator:${DependenciesVersions.entryGeneratorVersion}")
+    implementation("com.utopia-rise:godot-kotlin-entry-generator:${project.version}")
     compileOnly(project(":godot-kotlin-compiler-plugin-common"))
 }
 

--- a/kt/plugins/godot-gradle-plugin/build.gradle.kts
+++ b/kt/plugins/godot-gradle-plugin/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("com.github.jengelman.gradle.plugins:shadow:${DependenciesVersions.shadowJarPluginVersion}")
 
     implementation(project(":godot-build-props"))
-    implementation("com.utopia-rise:godot-kotlin-entry-generator:${project.version}")
+    implementation(project(":godot-kotlin-entry-generator"))
     compileOnly(project(":godot-kotlin-compiler-plugin-common"))
 }
 

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/setupConfigurationsAndCompilations.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/setupConfigurationsAndCompilations.kt
@@ -203,6 +203,7 @@ fun Project.setupConfigurationsAndCompilations(godotExtension: GodotExtension, j
             }
         }
 
+        @Suppress("UNUSED_VARIABLE")
         val build by getting {
             dependsOn(cleanupEntryFiles, bootstrapJar, shadowJar)
             finalizedBy(deleteBuildLock)
@@ -211,6 +212,7 @@ fun Project.setupConfigurationsAndCompilations(godotExtension: GodotExtension, j
             }
         }
 
+        @Suppress("UNUSED_VARIABLE")
         val clean by getting {
             dependsOn(createBuildLock)
             finalizedBy(deleteBuildLock)


### PR DESCRIPTION
This updates all our dependencies to the latest versions (except api gen as it's still an external project).
This also resolves or supresses all compiler warnings except those fixed in different PR's (for example enumLists in #165) or features which are not yet implemented (for example tool mode).

Gradle could not yet be updated to 7.0 because of https://youtrack.jetbrains.com/issue/KT-46165