### PR TITLE
Rename node helpers

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/FuncRefTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/FuncRefTest.kt
@@ -6,8 +6,8 @@ import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 import godot.annotation.RegisterProperty
 import godot.annotation.RegisterSignal
-import godot.call
-import godot.callDeferred
+import godot.extensions.call
+import godot.extensions.callDeferred
 import godot.signals.signal
 
 @RegisterClass

--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -40,7 +40,7 @@ import godot.core.Vector2
 import godot.core.Vector3
 import godot.core.dictionaryOf
 import godot.core.variantArrayOf
-import godot.extensions.node
+import godot.extensions.getNodeAs
 import godot.signals.signal
 import godot.tests.subpackage.OtherScript
 import godot.util.RealT
@@ -365,10 +365,10 @@ class Invocation : Spatial() {
 		name = formerName
 		val test = DateTime.now() //external dependency to test dependency inclusion in dummyCompilation
 
-        val getNode: Button? = node("CanvasLayer/Button")
+        val getNode = getNodeAs<Button>("CanvasLayer/Button")
 
         val path = NodePath("CanvasLayer/Button")
-        val getNode2: Button? = node(path)
+        val getNode2 = getNodeAs<Button>(path)
 
 		signalNoParam.connect(invocation, invocation::hookNoParam)
 		signalOneParam.connect(invocation, invocation::hookOneParam)

--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -40,6 +40,7 @@ import godot.core.Vector2
 import godot.core.Vector3
 import godot.core.dictionaryOf
 import godot.core.variantArrayOf
+import godot.extensions.node
 import godot.signals.signal
 import godot.tests.subpackage.OtherScript
 import godot.util.RealT
@@ -364,10 +365,16 @@ class Invocation : Spatial() {
 		name = formerName
 		val test = DateTime.now() //external dependency to test dependency inclusion in dummyCompilation
 
+        val getNode: Button? = node("CanvasLayer/Button")
+
+        val path = NodePath("CanvasLayer/Button")
+        val getNode2: Button? = node(path)
+
 		signalNoParam.connect(invocation, invocation::hookNoParam)
 		signalOneParam.connect(invocation, invocation::hookOneParam)
 		signalTwoParam.connect(invocation, invocation::hookTwoParam)
-		(getNodeOrNull(NodePath("CanvasLayer/Button")) as Button?)?.signalPressed?.connect(
+
+		(getNodeOrNull(path) as Button?)?.signalPressed?.connect(
 			invocation,
 			invocation::hookNoParam
 		)

--- a/kt/godot-library/src/main/kotlin/godot/extensions/NodeExt.kt
+++ b/kt/godot-library/src/main/kotlin/godot/extensions/NodeExt.kt
@@ -1,0 +1,10 @@
+package godot.extensions
+
+import godot.Node
+import godot.core.NodePath
+
+@Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
+inline fun <T : Node> Node.node(path: String) = getNode(NodePath(path)) as T?
+
+@Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
+inline fun <T : Node> Node.node(nodePath: NodePath) = getNode(nodePath) as T?

--- a/kt/godot-library/src/main/kotlin/godot/extensions/NodeExt.kt
+++ b/kt/godot-library/src/main/kotlin/godot/extensions/NodeExt.kt
@@ -4,7 +4,7 @@ import godot.Node
 import godot.core.NodePath
 
 @Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
-inline fun <T : Node> Node.node(path: String) = getNode(NodePath(path)) as T?
+inline fun <T : Node> Node.getNodeAs(path: String) = getNode(NodePath(path)) as T?
 
 @Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
-inline fun <T : Node> Node.node(nodePath: NodePath) = getNode(nodePath) as T?
+inline fun <T : Node> Node.getNodeAs(nodePath: NodePath) = getNode(nodePath) as T?

--- a/kt/godot-library/src/main/kotlin/godot/extensions/ObjectExt.kt
+++ b/kt/godot-library/src/main/kotlin/godot/extensions/ObjectExt.kt
@@ -1,16 +1,10 @@
-package godot
+package godot.extensions
 
-import godot.core.NodePath
+import godot.Object
 import godot.core.VariantArray
 import godot.signals.Signal
 import godot.util.camelToSnakeCase
 import kotlin.reflect.KFunction
-
-@Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
-inline fun <T : Node?> Node.getNode(path: String) = getNode(NodePath(path)) as T
-
-@Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST", "EXTENSION_SHADOWED_BY_MEMBER")
-inline fun <T : Node?> Node.getNode(nodePath: NodePath) = getNode(nodePath) as T
 
 /**
  * **Note:** The function name is converted to snake_case


### PR DESCRIPTION
Extensions are now in their own package and I split them into 2 files, one for Object, one for Node.

Also because of a conflict with the "getNode" name, the helpers have been rename simple "node".

related issue : #183 