### PR TITLE
Scripts created from Godot have a package set.

### DIFF
--- a/src/kotlin_language.cpp
+++ b/src/kotlin_language.cpp
@@ -147,8 +147,7 @@ void KotlinLanguage::get_string_delimiters(List<String>* p_delimiters) const {
 
 Ref<Script> KotlinLanguage::get_template(const String& p_class_name, const String& p_base_class_name) const {
     String kotlinClassTemplate {
-        "package fixme\n"
-        "\n"
+        "%PACKAGE%"
         "import " GODOT_KOTLIN_PACKAGE ".%BASE%\n"
         "import godot.annotation.RegisterClass\n"
         "import godot.annotation.RegisterFunction\n"

--- a/src/kotlin_script.cpp
+++ b/src/kotlin_script.cpp
@@ -168,7 +168,6 @@ void KotlinScript::set_path(const String& p_path, bool p_take_over) {
     String package = p_path.replace("src/main/kotlin/", "")
             .trim_prefix("res://")
             .trim_suffix(get_name() + "." + KotlinLanguage::get_instance().get_extension())
-            .trim_prefix("/")
             .trim_suffix("/")
             .replace("/", ".");
 
@@ -181,7 +180,6 @@ void KotlinScript::set_path(const String& p_path, bool p_take_over) {
 
 #ifndef TOOLS_ENABLED
     if (!kotlin_class) {
-
         kotlin_class = GDKotlin::get_instance().find_class(p_path);
     }
 #endif

--- a/src/kotlin_script.cpp
+++ b/src/kotlin_script.cpp
@@ -165,6 +165,11 @@ Variant KotlinScript::_new(const Variant** p_args, int p_argcount, Variant::Call
 void KotlinScript::set_path(const String& p_path, bool p_take_over) {
     Resource::set_path(p_path, p_take_over);
 
+#ifndef TOOLS_ENABLED
+    if (!kotlin_class) {
+        kotlin_class = GDKotlin::get_instance().find_class(p_path);
+    }
+#else
     String package = p_path.replace("src/main/kotlin/", "")
             .trim_prefix("res://")
             .trim_suffix(get_name() + "." + KotlinLanguage::get_instance().get_extension())
@@ -177,11 +182,6 @@ void KotlinScript::set_path(const String& p_path, bool p_take_over) {
 
     String source_code = get_source_code().replace("%PACKAGE%", package);
     set_source_code(source_code);
-
-#ifndef TOOLS_ENABLED
-    if (!kotlin_class) {
-        kotlin_class = GDKotlin::get_instance().find_class(p_path);
-    }
 #endif
 }
 

--- a/src/kotlin_script.cpp
+++ b/src/kotlin_script.cpp
@@ -170,11 +170,11 @@ void KotlinScript::set_path(const String& p_path, bool p_take_over) {
         kotlin_class = GDKotlin::get_instance().find_class(p_path);
     }
 #else
-    String package = p_path.replace("src/main/kotlin/", "")
-            .trim_prefix("res://")
-            .trim_suffix(get_name() + "." + KotlinLanguage::get_instance().get_extension())
-            .trim_suffix("/")
-            .replace("/", ".");
+    String package{p_path.replace("src/main/kotlin/", "")
+                           .trim_prefix("res://")
+                           .trim_suffix(get_name() + "." + KotlinLanguage::get_instance().get_extension())
+                           .trim_suffix("/")
+                           .replace("/", ".")};
 
     if (!package.empty()) {
         package = "package " + package + "\n\n";

--- a/src/kotlin_script.cpp
+++ b/src/kotlin_script.cpp
@@ -164,8 +164,26 @@ Variant KotlinScript::_new(const Variant** p_args, int p_argcount, Variant::Call
 
 void KotlinScript::set_path(const String& p_path, bool p_take_over) {
     Resource::set_path(p_path, p_take_over);
+
+    String package = p_path.replace("res://", "")
+            .replace("src/main/kotlin", "")
+            .replace("/" + get_name(), "")
+            .replace("."+ KotlinLanguage::get_instance().get_extension(), "")
+            .replace("/", ".");
+
+    if(package != get_name()){
+        package = "package " + package + "\n\n";
+    }
+    else{
+        package = "";
+    }
+
+    String source_code = get_source_code().replace("%PACKAGE%", package);
+    set_source_code(source_code);
+
 #ifndef TOOLS_ENABLED
     if (!kotlin_class) {
+
         kotlin_class = GDKotlin::get_instance().find_class(p_path);
     }
 #endif
@@ -178,7 +196,7 @@ KotlinScript::KotlinScript() : kotlin_class(nullptr) {
 PlaceHolderScriptInstance* KotlinScript::placeholder_instance_create(Object* p_this) {
 #ifdef TOOLS_ENABLED
     PlaceHolderScriptInstance* placeholder{
-        memnew(PlaceHolderScriptInstance(&KotlinLanguage::get_instance(), Ref<Script>(this), p_this))
+            memnew(PlaceHolderScriptInstance(&KotlinLanguage::get_instance(), Ref<Script>(this), p_this))
     };
     p_this->set_script_instance(placeholder);
     placeholders.insert(placeholder);
@@ -191,7 +209,7 @@ PlaceHolderScriptInstance* KotlinScript::placeholder_instance_create(Object* p_t
 
 void KotlinScript::update_exports() {
 #ifdef TOOLS_ENABLED
-    for (Set<PlaceHolderScriptInstance *>::Element *E = placeholders.front(); E; E = E->next()) {
+    for (Set<PlaceHolderScriptInstance*>::Element* E = placeholders.front(); E; E = E->next()) {
         _update_exports(E->get());
     }
 #endif

--- a/src/kotlin_script.cpp
+++ b/src/kotlin_script.cpp
@@ -165,17 +165,15 @@ Variant KotlinScript::_new(const Variant** p_args, int p_argcount, Variant::Call
 void KotlinScript::set_path(const String& p_path, bool p_take_over) {
     Resource::set_path(p_path, p_take_over);
 
-    String package = p_path.replace("res://", "")
-            .replace("src/main/kotlin", "")
-            .replace("/" + get_name(), "")
-            .replace("."+ KotlinLanguage::get_instance().get_extension(), "")
+    String package = p_path.replace("src/main/kotlin/", "")
+            .trim_prefix("res://")
+            .trim_suffix(get_name() + "." + KotlinLanguage::get_instance().get_extension())
+            .trim_prefix("/")
+            .trim_suffix("/")
             .replace("/", ".");
 
-    if(package != get_name()){
+    if (!package.empty()) {
         package = "package " + package + "\n\n";
-    }
-    else{
-        package = "";
     }
 
     String source_code = get_source_code().replace("%PACKAGE%", package);


### PR DESCRIPTION
Fix #177 

![image](https://user-images.githubusercontent.com/31470327/115978921-ffbf7100-a582-11eb-9f9c-0b0a7fcf535e.png)

The package name is inferred from the file path of the newly created script.
For now, it only works if you the main source directory.
A package name will still be written if you use a custom source dir but it won't be correct. Unless we find a way to set the path of the custom dir in the C++ code I can't fix that particular case.

If the script is at the root of the source directory no package is written at all as well, as it should be.

![image](https://user-images.githubusercontent.com/31470327/115978984-63e23500-a583-11eb-820a-01a4cbfc5ff5.png)


