### PR TITLE
Add ci step to mark latest version as stable

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,19 @@
+name: Deploy docs
+
+on:
+  push:
+    tags:
+      - '\d+.\d+.\d+-\d+.\d+.\d+'
+
+jobs:
+  publish_stable_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete current stable tag
+        run: |
+          git tag -d stable
+          git push origin --delete stable
+      - name: Make current tag stable
+        run: |
+          git tag stable
+          git push origin stable


### PR DESCRIPTION
Resolves #182.

This just marks the current non-snapshot tag as stable (i.e creating a tag named stable). The old tag will be deleted first. RTD is now configured to use the stable tag as default.