### PR TITLE
fix: Getter now calls method from parent even if getter starts with is

### DIFF
--- a/kt/api-generator/src/main/kotlin/godot/codegen/Property.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/Property.kt
@@ -31,7 +31,7 @@ class Property @JsonCreator constructor(
     lateinit var engineSetterIndexName: String
     lateinit var engineGetterIndexName: String
 
-    var parentMethodToCall: String? = null
+    var shouldRenameJvmProperty = false
 
     init {
         type = type.convertTypeToKotlin()
@@ -112,11 +112,21 @@ class Property @JsonCreator constructor(
                     .build()
             )
         } else {
-            if (parentMethodToCall != null) {
+            if (shouldRenameJvmProperty) {
                 propertySpecBuilder.getter(
                     FunSpec.getterBuilder()
                         .addStatement(
-                            "return super.$parentMethodToCall()"
+                            "return super.$getter()"
+                        )
+                        .addAnnotation(
+                            AnnotationSpec.builder(JvmName::class)
+                                .addMember("\"${getter}_prop\"")
+                                .build()
+                        )
+                        .addAnnotation(
+                            AnnotationSpec.builder(Suppress::class)
+                                .addMember("\"INAPPLICABLE_JVM_NAME\"")
+                                .build()
                         )
                         .build()
                 )

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/BitmapFont.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/BitmapFont.kt
@@ -29,7 +29,7 @@ import kotlin.Long
 import kotlin.NotImplementedError
 import kotlin.String
 import kotlin.Suppress
-import kotlin.UninitializedPropertyAccessException
+import kotlin.jvm.JvmName
 
 /**
  * Renders text using fonts under the [godot.BMFont](https://www.angelcode.com/products/bmfont/) format.
@@ -44,7 +44,9 @@ open class BitmapFont : Font() {
    * Ascent (number of pixels above the baseline).
    */
   open var ascent: Double
-    get() = super.getFontAscent()
+    @JvmName("getAscent_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.getAscent()
     set(value) {
       TransferContext.writeArguments(DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_BITMAPFONT_SET_ASCENT, NIL)
@@ -54,10 +56,9 @@ open class BitmapFont : Font() {
    * If `true`, distance field hint is enabled.
    */
   open var distanceField: Boolean
-    get() {
-      throw
-          UninitializedPropertyAccessException("Cannot access property distanceField: has no getter")
-    }
+    @JvmName("isDistanceFieldHint_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.isDistanceFieldHint()
     set(value) {
       TransferContext.writeArguments(BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_BITMAPFONT_SET_DISTANCE_FIELD,
@@ -82,7 +83,9 @@ open class BitmapFont : Font() {
    * Total font height (ascent plus descent) in pixels.
    */
   open var height: Double
-    get() = super.getFontHeight()
+    @JvmName("getHeight_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.getHeight()
     set(value) {
       TransferContext.writeArguments(DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_BITMAPFONT_SET_HEIGHT, NIL)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/CanvasItem.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/CanvasItem.kt
@@ -650,7 +650,7 @@ open class CanvasItem : Node() {
   /**
    * Returns the global transform matrix of this item.
    */
-  open fun getCanvasItemGlobalTransform(): Transform2D {
+  open fun getGlobalTransform(): Transform2D {
     TransferContext.writeArguments()
     TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CANVASITEM_GET_GLOBAL_TRANSFORM,
         TRANSFORM2D)
@@ -680,7 +680,7 @@ open class CanvasItem : Node() {
   /**
    * Returns the transform matrix of this item.
    */
-  open fun getCanvasItemTransform(): Transform2D {
+  open fun getTransform(): Transform2D {
     TransferContext.writeArguments()
     TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CANVASITEM_GET_TRANSFORM,
         TRANSFORM2D)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/CurveTexture.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/CurveTexture.kt
@@ -12,6 +12,7 @@ import godot.core.VariantType.NIL
 import godot.core.VariantType.OBJECT
 import kotlin.Long
 import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 /**
  * A texture that shows a curve.
@@ -38,7 +39,9 @@ open class CurveTexture : Texture() {
    * The width of the texture.
    */
   open var width: Long
-    get() = super.getTextureWidth()
+    @JvmName("getWidth_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.getWidth()
     set(value) {
       TransferContext.writeArguments(LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CURVETEXTURE_SET_WIDTH, NIL)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/ExternalTexture.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/ExternalTexture.kt
@@ -15,6 +15,7 @@ import godot.core.Vector2
 import kotlin.Long
 import kotlin.Suppress
 import kotlin.Unit
+import kotlin.jvm.JvmName
 
 /**
  * Enable OpenGL ES external texture extension.
@@ -29,7 +30,9 @@ open class ExternalTexture : Texture() {
    * External texture size.
    */
   open var size: Vector2
-    get() = super.getTextureSize()
+    @JvmName("getSize_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.getSize()
     set(value) {
       TransferContext.writeArguments(VECTOR2 to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_EXTERNALTEXTURE_SET_SIZE, NIL)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Font.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Font.kt
@@ -77,7 +77,7 @@ open class Font : Resource() {
   /**
    * Returns the font ascent (number of pixels above the baseline).
    */
-  open fun getFontAscent(): Double {
+  open fun getAscent(): Double {
     TransferContext.writeArguments()
     TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_FONT_GET_ASCENT, DOUBLE)
     return TransferContext.readReturnValue(DOUBLE, false) as Double
@@ -104,7 +104,7 @@ open class Font : Resource() {
   /**
    * Returns the total font height (ascent plus descent) in pixels.
    */
-  open fun getFontHeight(): Double {
+  open fun getHeight(): Double {
     TransferContext.writeArguments()
     TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_FONT_GET_HEIGHT, DOUBLE)
     return TransferContext.readReturnValue(DOUBLE, false) as Double

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/GradientTexture.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/GradientTexture.kt
@@ -12,6 +12,7 @@ import godot.core.VariantType.NIL
 import godot.core.VariantType.OBJECT
 import kotlin.Long
 import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 /**
  * Gradient-filled texture.
@@ -39,7 +40,9 @@ open class GradientTexture : Texture() {
    * The number of color samples that will be obtained from the [godot.Gradient].
    */
   open var width: Long
-    get() = super.getTextureWidth()
+    @JvmName("getWidth_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.getWidth()
     set(value) {
       TransferContext.writeArguments(LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_GRADIENTTEXTURE_SET_WIDTH, NIL)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventAction.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventAction.kt
@@ -15,7 +15,7 @@ import kotlin.Boolean
 import kotlin.Double
 import kotlin.String
 import kotlin.Suppress
-import kotlin.UninitializedPropertyAccessException
+import kotlin.jvm.JvmName
 
 /**
  * Input event type for actions.
@@ -46,9 +46,9 @@ open class InputEventAction : InputEvent() {
    * If `true`, the action's state is pressed. If `false`, the action's state is released.
    */
   open var pressed: Boolean
-    get() {
-      throw UninitializedPropertyAccessException("Cannot access property pressed: has no getter")
-    }
+    @JvmName("isPressed_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.isPressed()
     set(value) {
       TransferContext.writeArguments(BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_INPUTEVENTACTION_SET_PRESSED, NIL)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventJoypadButton.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventJoypadButton.kt
@@ -15,7 +15,7 @@ import kotlin.Boolean
 import kotlin.Double
 import kotlin.Long
 import kotlin.Suppress
-import kotlin.UninitializedPropertyAccessException
+import kotlin.jvm.JvmName
 
 /**
  * Input event for gamepad buttons.
@@ -47,9 +47,9 @@ open class InputEventJoypadButton : InputEvent() {
    * If `true`, the button's state is pressed. If `false`, the button's state is released.
    */
   open var pressed: Boolean
-    get() {
-      throw UninitializedPropertyAccessException("Cannot access property pressed: has no getter")
-    }
+    @JvmName("isPressed_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.isPressed()
     set(value) {
       TransferContext.writeArguments(BOOL to value)
       TransferContext.callMethod(rawPtr,

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventKey.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventKey.kt
@@ -13,7 +13,7 @@ import godot.core.VariantType.NIL
 import kotlin.Boolean
 import kotlin.Long
 import kotlin.Suppress
-import kotlin.UninitializedPropertyAccessException
+import kotlin.jvm.JvmName
 
 /**
  * Input event type for keyboard events.
@@ -29,9 +29,9 @@ open class InputEventKey : InputEventWithModifiers() {
    * If `true`, the key was already pressed before this event. It means the user is holding the key down.
    */
   open var echo: Boolean
-    get() {
-      throw UninitializedPropertyAccessException("Cannot access property echo: has no getter")
-    }
+    @JvmName("isEcho_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.isEcho()
     set(value) {
       TransferContext.writeArguments(BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_INPUTEVENTKEY_SET_ECHO, NIL)
@@ -41,9 +41,9 @@ open class InputEventKey : InputEventWithModifiers() {
    * If `true`, the key's state is pressed. If `false`, the key's state is released.
    */
   open var pressed: Boolean
-    get() {
-      throw UninitializedPropertyAccessException("Cannot access property pressed: has no getter")
-    }
+    @JvmName("isPressed_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.isPressed()
     set(value) {
       TransferContext.writeArguments(BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_INPUTEVENTKEY_SET_PRESSED, NIL)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventMouseButton.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventMouseButton.kt
@@ -15,7 +15,7 @@ import kotlin.Boolean
 import kotlin.Double
 import kotlin.Long
 import kotlin.Suppress
-import kotlin.UninitializedPropertyAccessException
+import kotlin.jvm.JvmName
 
 /**
  * Input event type for mouse button events.
@@ -79,9 +79,9 @@ open class InputEventMouseButton : InputEventMouse() {
    * If `true`, the mouse button's state is pressed. If `false`, the mouse button's state is released.
    */
   open var pressed: Boolean
-    get() {
-      throw UninitializedPropertyAccessException("Cannot access property pressed: has no getter")
-    }
+    @JvmName("isPressed_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.isPressed()
     set(value) {
       TransferContext.writeArguments(BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_INPUTEVENTMOUSEBUTTON_SET_PRESSED,

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventScreenTouch.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/InputEventScreenTouch.kt
@@ -16,8 +16,8 @@ import godot.core.Vector2
 import kotlin.Boolean
 import kotlin.Long
 import kotlin.Suppress
-import kotlin.UninitializedPropertyAccessException
 import kotlin.Unit
+import kotlin.jvm.JvmName
 
 /**
  * Input event type for screen touch events.
@@ -67,9 +67,9 @@ open class InputEventScreenTouch : InputEvent() {
    * If `true`, the touch's state is pressed. If `false`, the touch's state is released.
    */
   open var pressed: Boolean
-    get() {
-      throw UninitializedPropertyAccessException("Cannot access property pressed: has no getter")
-    }
+    @JvmName("isPressed_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.isPressed()
     set(value) {
       TransferContext.writeArguments(BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_INPUTEVENTSCREENTOUCH_SET_PRESSED,

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Node2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Node2D.kt
@@ -22,6 +22,7 @@ import kotlin.Double
 import kotlin.Long
 import kotlin.Suppress
 import kotlin.Unit
+import kotlin.jvm.JvmName
 
 /**
  * A 2D game object, inherited by all 2D-related nodes. Has a position, rotation, scale, and Z index.
@@ -97,7 +98,9 @@ open class Node2D : CanvasItem() {
    * Global [godot.core.Transform2D].
    */
   open var globalTransform: Transform2D
-    get() = super.getCanvasItemGlobalTransform()
+    @JvmName("getGlobalTransform_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.getGlobalTransform()
     set(value) {
       TransferContext.writeArguments(TRANSFORM2D to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_NODE2D_SET_GLOBAL_TRANSFORM, NIL)
@@ -164,7 +167,9 @@ open class Node2D : CanvasItem() {
    * Local [godot.core.Transform2D].
    */
   open var transform: Transform2D
-    get() = super.getCanvasItemTransform()
+    @JvmName("getTransform_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.getTransform()
     set(value) {
       TransferContext.writeArguments(TRANSFORM2D to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_NODE2D_SET_TRANSFORM, NIL)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/NoiseTexture.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/NoiseTexture.kt
@@ -17,6 +17,7 @@ import kotlin.Double
 import kotlin.Long
 import kotlin.NotImplementedError
 import kotlin.Suppress
+import kotlin.jvm.JvmName
 
 @GodotBaseType
 open class NoiseTexture : Texture() {
@@ -47,7 +48,9 @@ open class NoiseTexture : Texture() {
     }
 
   open var height: Long
-    get() = super.getTextureHeight()
+    @JvmName("getHeight_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.getHeight()
     set(value) {
       TransferContext.writeArguments(LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_NOISETEXTURE_SET_HEIGHT, NIL)
@@ -76,7 +79,9 @@ open class NoiseTexture : Texture() {
     }
 
   open var width: Long
-    get() = super.getTextureWidth()
+    @JvmName("getWidth_prop")
+    @Suppress("INAPPLICABLE_JVM_NAME")
+    get() = super.getWidth()
     set(value) {
       TransferContext.writeArguments(LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_NOISETEXTURE_SET_WIDTH, NIL)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Texture.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Texture.kt
@@ -114,7 +114,7 @@ open class Texture : Resource() {
   /**
    * Returns the texture height.
    */
-  open fun getTextureHeight(): Long {
+  open fun getHeight(): Long {
     TransferContext.writeArguments()
     TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_TEXTURE_GET_HEIGHT, LONG)
     return TransferContext.readReturnValue(LONG, false) as Long
@@ -123,7 +123,7 @@ open class Texture : Resource() {
   /**
    * Returns the texture size.
    */
-  open fun getTextureSize(): Vector2 {
+  open fun getSize(): Vector2 {
     TransferContext.writeArguments()
     TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_TEXTURE_GET_SIZE, VECTOR2)
     return TransferContext.readReturnValue(VECTOR2, false) as Vector2
@@ -132,7 +132,7 @@ open class Texture : Resource() {
   /**
    * Returns the texture width.
    */
-  open fun getTextureWidth(): Long {
+  open fun getWidth(): Long {
     TransferContext.writeArguments()
     TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_TEXTURE_GET_WIDTH, LONG)
     return TransferContext.readReturnValue(LONG, false) as Long


### PR DESCRIPTION
Generated getters were not calling parent method if method was starting with `is`.
This resolves #216 