### PR TITLE
Fix generation of service file

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/setupConfigurationsAndCompilations.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/setupConfigurationsAndCompilations.kt
@@ -134,9 +134,18 @@ fun Project.setupConfigurationsAndCompilations(godotExtension: GodotExtension, j
             }
         }
 
+        val generateServiceFile = with(create("generateServiceFile")) {
+            group = "godot-kotlin-jvm"
+            description = "Converts the main.jar to an android compatible version. Needed for android builds only"
+
+            doLast {
+                generateServiceFile()
+            }
+        }
+
         @Suppress("UNUSED_VARIABLE")
         val build = with(getByName("build")) {
-            dependsOn(bootstrapJar, shadowJar)
+            dependsOn(bootstrapJar, shadowJar, generateServiceFile)
             finalizedBy(deleteBuildLock)
             if(godotExtension.isAndroidExportEnabled.get()) {
                 finalizedBy(createGodotBootstrapDexJar, createMainDexJar)
@@ -163,4 +172,10 @@ private fun getBuildLockDir(projectDir: File): File {
         lockDir.mkdirs()
         lockDir
     }
+}
+
+private fun Project.generateServiceFile() {
+    val metaInfServicesDir = projectDir.resolve("src/main/resources/META-INF/services")
+    metaInfServicesDir.mkdirs()
+    File(metaInfServicesDir, "godot.runtime.Entry").writeText("godot.Entry")
 }


### PR DESCRIPTION
With #244 I forgot to also generate the service file again. Previously we've done that in the entry gen. But the way this was done lead to #232.
The service file is now generated from within the gradle plugin rather than the entry gen as this makes more sense IMO as the gradle plugin is the one with the project information.
With this PR we generate the service file again and also resolve #232.