### PR TITLE
Use `ubuntu-18.04` to build linux binaries

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -44,8 +44,9 @@ jobs:
       matrix:
         name: [ Linux, OSX, Windows ]
         include:
+          # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-18.04
             platform: x11
           - name: OSX
             os: macos-latest

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -11,8 +11,9 @@ jobs:
       matrix:
         name: [ Linux, OSX, Windows ]
         include:
+          # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-18.04
             platform: x11
           - name: OSX
             os: macos-latest

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -11,8 +11,9 @@ jobs:
       matrix:
         name: [ Linux, OSX, Windows, Android ]
         include:
+          # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-18.04
             platform: x11
           - name: OSX
             os: macos-latest

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -11,8 +11,9 @@ jobs:
       matrix:
         name: [ Linux, OSX, Windows, Android ]
         include:
+          # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
-            os: ubuntu-latest
+            os: ubuntu-18.04
             platform: x11
           - name: OSX
             os: macos-latest

--- a/.github/workflows/deploy-export-template-debug.yaml
+++ b/.github/workflows/deploy-export-template-debug.yaml
@@ -16,7 +16,8 @@ jobs:
         name: [ Linux ]
         include:
           - name: Linux
-            os: ubuntu-latest
+            # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
+            os: ubuntu-18.04
             platform: x11
             binary: godot.x11.opt.debug.64
             cat_command: cat

--- a/.github/workflows/deploy-export-template-release.yaml
+++ b/.github/workflows/deploy-export-template-release.yaml
@@ -16,7 +16,8 @@ jobs:
         name: [ Linux ]
         include:
           - name: Linux
-            os: ubuntu-latest
+            # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
+            os: ubuntu-18.04
             platform: x11
             binary: godot.x11.opt.64
             cat_command: cat

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -16,7 +16,8 @@ jobs:
         name: [ Linux ]
         include:
           - name: Linux
-            os: ubuntu-latest
+            # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
+            os: ubuntu-18.04
             platform: x11
             binary: godot.x11.opt.tools.64
             cat_command: cat


### PR DESCRIPTION
This is done because one should use the oldest distro version one wants to support, to build linux binaries. Like this we ensure the binaries are downwards compatible until the version we built the binary with.

Resolves #224 