### PR TITLE
Fix jvm type registration

### DIFF
--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
@@ -10,10 +10,10 @@ fun Type?.toKtVariantType(): ClassName = when {
     this == null || fqName == "kotlin.Unit" -> ClassName("godot.core.VariantType", "NIL")
     fqName == "kotlin.Int" -> ClassName("godot.core.VariantType", "JVM_INT")
     fqName == "godot.util.NaturalT" ||
-    fqName == "kotlin.Long" -> ClassName("godot.core.VariantType", "LONG")
+        fqName == "kotlin.Long" -> ClassName("godot.core.VariantType", "LONG")
     fqName == "kotlin.Float" -> ClassName("godot.core.VariantType", "JVM_FLOAT")
     fqName == "godot.util.RealT" ||
-    fqName == "kotlin.Double" -> ClassName("godot.core.VariantType", "DOUBLE")
+        fqName == "kotlin.Double" -> ClassName("godot.core.VariantType", "DOUBLE")
     fqName == "kotlin.String" -> ClassName("godot.core.VariantType", "STRING")
     fqName == "kotlin.Boolean" -> ClassName("godot.core.VariantType", "BOOL")
     fqName == "kotlin.Byte" -> ClassName("godot.core.VariantType", "JVM_BYTE")
@@ -29,6 +29,19 @@ fun Type?.toKtVariantType(): ClassName = when {
     fqName == "kotlin.Any" -> ClassName("godot.core.VariantType", "ANY")
     else -> ClassName("godot.core.VariantType", "OBJECT")
 }
+
+/**
+ * Same as [toKtVariantType] but resolves JVM_* types to actual godot types.
+ *
+ * Calls [toKtVariantType] under the hood for all other types
+ */
+fun Type?.toGodotVariantType(): ClassName = this?.let {
+    when (it.fqName) {
+        "kotlin.Byte", "kotlin.Int" -> ClassName("godot.core.VariantType", "LONG")
+        "kotlin.Float" -> ClassName("godot.core.VariantType", "DOUBLE")
+        else -> toKtVariantType()
+    }
+} ?: toKtVariantType()
 
 fun Type.isCoreType(): Boolean {
     return coreTypes.contains(fqName)

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/PropertyRegistrationGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/PropertyRegistrationGenerator.kt
@@ -12,6 +12,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import godot.entrygenerator.ext.getAnnotationUnsafe
 import godot.entrygenerator.ext.hasAnnotation
+import godot.entrygenerator.ext.toGodotVariantType
 import godot.entrygenerator.ext.toKtVariantType
 import godot.entrygenerator.generator.hintstring.PropertyHintStringGeneratorProvider
 import godot.entrygenerator.generator.typehint.PropertyTypeHintProvider
@@ -78,7 +79,7 @@ object PropertyRegistrationGenerator {
                 "property(%L,·%T,·%T,·%S,·%T,·%S,·$defaultValueProviderVariableName,·%L,·%T.id.toInt())",
                 getPropertyReference(registeredProperty, className),
                 registeredProperty.type.toKtVariantType(),
-                registeredProperty.type.toKtVariantType(),
+                registeredProperty.type.toGodotVariantType(),
                 typeFqNameWithNullability,
                 PropertyTypeHintProvider.provide(registeredProperty),
                 PropertyHintStringGeneratorProvider


### PR DESCRIPTION
Fixes #243.
When implementing the entry generator with ksp i forgot to register the JVM_* types as their actual godot type rather than their KtVariant type. This lead to the inspector not showing properties with the types `Int`, `Float` and `Byte`.
This PR fixes this.