### PR TITLE
Fix `exec` task setup

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/createMainDexFileTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/createMainDexFileTask.kt
@@ -26,7 +26,7 @@ fun Project.createMainDexFileTask(
                 packageBootstrapDexJarTask
             )
 
-            doLast {
+            doFirst {
                 val libsDir = project.buildDir.resolve("libs")
                 val mainJar = File(libsDir, "main.jar")
                 val godotBootstrapJar = File(libsDir, "godot-bootstrap.jar")

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageBootstrapDexJarTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageBootstrapDexJarTask.kt
@@ -21,7 +21,7 @@ fun Project.packageBootstrapDexJarTask(
 
             dependsOn(checkD8ToolAccessibleTask, checkAndroidJarAccessibleTask, packageBootstrapJarTask)
 
-            doLast {
+            doFirst {
                 val libsDir = project.buildDir.resolve("libs")
                 val godotBootstrapJar = File(libsDir, "godot-bootstrap.jar")
 

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/graal/createGraalNativeImage.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/graal/createGraalNativeImage.kt
@@ -26,7 +26,7 @@ fun Project.createGraalNativeImageTask(
                 packageBootstrapJarTask
             )
 
-            doLast {
+            doFirst {
                 val libsDir = project.buildDir.resolve("libs")
                 val resourcesDir = project.buildDir.resolve("resources")
 


### PR DESCRIPTION
Fixes task setup errors for `exec` based tasks which i introduced with #263.
#270 already contains this fix, but as it could take a while to merge; here's a dedicated hotfix.