### PR TITLE
feature: Add macos arm64 check CI

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -83,7 +83,7 @@ jobs:
         id: editor-debug-cache
         uses: actions/cache@v2
         with:
-          path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          path: ${{github.workspace}}/${{matrix.platform}}/${{matrix.arch}}/.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
             ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
@@ -103,7 +103,7 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v1
       - name: Build with editor debug
         env:
-          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/${{matrix.arch}}/.scons_cache/
         run: |
           scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} -j${{ steps.cpu-cores.outputs.count }}
       - name: Upload OSX binary
@@ -111,7 +111,7 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: osx-editor-debug-app
-          path: bin/godot.osx.tools.64
+          path: bin/godot.osx.tools.x86_64
   test-editor-debug:
     needs: [build-editor-debug, build-godot-bootstrap]
     strategy:
@@ -155,6 +155,6 @@ jobs:
           cp godot-bootstrap/godot-bootstrap.jar osx-editor-debug-app/
           cd modules/kotlin_jvm/harness/tests/
           chmod +x run_godot_kotlin_tests.sh
-          chmod +x ../../../../osx-editor-debug-app/godot.osx.tools.64
+          chmod +x ../../../../osx-editor-debug-app/godot.osx.tools.x86_64
           jlink --add-modules java.base,java.logging --output jre
-          ./run_godot_kotlin_tests.sh ../../../../osx-editor-debug-app/godot.osx.tools.64
+          ./run_godot_kotlin_tests.sh ../../../../osx-editor-debug-app/godot.osx.tools.x86_64

--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -48,11 +48,11 @@ jobs:
           - name: Linux
             os: ubuntu-18.04
             platform: x11
-            arch: x86_64
+            arch: 64
           - name: OSX-x64
             os: macos-latest
             platform: osx
-            arch: x86_64
+            arch: 64
           - name: OSX-arm64
             os: macos-latest
             platform: osx
@@ -60,7 +60,7 @@ jobs:
           - name: Windows
             os: windows-latest
             platform: windows
-            arch: x86_64
+            arch: 64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure dependencies
@@ -107,11 +107,11 @@ jobs:
         run: |
           scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} -j${{ steps.cpu-cores.outputs.count }}
       - name: Upload OSX binary
-        if: matrix.platform == 'osx' && matrix.arch == 'x86_64'
+        if: matrix.platform == 'osx' && matrix.arch == '64'
         uses: actions/upload-artifact@v1
         with:
           name: osx-editor-debug-app
-          path: bin/godot.osx.tools.x86_64
+          path: bin/godot.osx.tools.64
   test-editor-debug:
     needs: [build-editor-debug, build-godot-bootstrap]
     strategy:
@@ -155,6 +155,6 @@ jobs:
           cp godot-bootstrap/godot-bootstrap.jar osx-editor-debug-app/
           cd modules/kotlin_jvm/harness/tests/
           chmod +x run_godot_kotlin_tests.sh
-          chmod +x ../../../../osx-editor-debug-app/godot.osx.tools.x86_64
+          chmod +x ../../../../osx-editor-debug-app/godot.osx.tools.64
           jlink --add-modules java.base,java.logging --output jre
-          ./run_godot_kotlin_tests.sh ../../../../osx-editor-debug-app/godot.osx.tools.x86_64
+          ./run_godot_kotlin_tests.sh ../../../../osx-editor-debug-app/godot.osx.tools.64

--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -107,13 +107,39 @@ jobs:
         run: |
           scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} -j${{ steps.cpu-cores.outputs.count }}
       - name: Upload OSX binary
-        if: matrix.platform == 'osx' && matrix.arch == '64'
+        if: matrix.platform == 'osx'
+        uses: actions/upload-artifact@v1
+        with:
+          name: osx-editor-debug-app-${{ matrix.arch }}
+          path: bin/godot.osx.tools.${{ matrix.arch }}
+  create-macos-universal:
+    needs: [build-editor-debug]
+    strategy:
+      matrix:
+        os: [ macos-latest ]
+        include:
+          - os: macos-latest
+            java-version: 11
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Download OSX Editor Debug App x64
+        uses: actions/download-artifact@v1
+        with:
+          name: osx-editor-debug-app-64
+      - name: Download OSX Editor Debug App arm64
+        uses: actions/download-artifact@v1
+        with:
+          name: osx-editor-debug-app-arm64
+      - name: Create OSX universal binary
+        run: |
+          lipo -create osx-editor-debug-app-64/godot.osx.tools.64 osx-editor-debug-app-arm64/godot.osx.tools.arm64 -output godot.osx.tools.universal
+      - name: Upload OSX universal binary
         uses: actions/upload-artifact@v1
         with:
           name: osx-editor-debug-app
-          path: bin/godot.osx.tools.64
+          path: godot.osx.tools.universal
   test-editor-debug:
-    needs: [build-editor-debug, build-godot-bootstrap]
+    needs: [create-macos-universal, build-godot-bootstrap]
     strategy:
       matrix:
         os: [macos-latest]
@@ -155,6 +181,6 @@ jobs:
           cp godot-bootstrap/godot-bootstrap.jar osx-editor-debug-app/
           cd modules/kotlin_jvm/harness/tests/
           chmod +x run_godot_kotlin_tests.sh
-          chmod +x ../../../../osx-editor-debug-app/godot.osx.tools.64
+          chmod +x ../../../../osx-editor-debug-app/godot.osx.tools.universal
           jlink --add-modules java.base,java.logging --output jre
-          ./run_godot_kotlin_tests.sh ../../../../osx-editor-debug-app/godot.osx.tools.64
+          ./run_godot_kotlin_tests.sh ../../../../osx-editor-debug-app/godot.osx.tools.universal

--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -42,18 +42,25 @@ jobs:
   build-editor-debug:
     strategy:
       matrix:
-        name: [ Linux, OSX, Windows ]
+        name: [ Linux, OSX-x64, OSX-arm64, Windows ]
         include:
           # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
             os: ubuntu-18.04
             platform: x11
-          - name: OSX
+            arch: x86_64
+          - name: OSX-x64
             os: macos-latest
             platform: osx
+            arch: x86_64
+          - name: OSX-arm64
+            os: macos-latest
+            platform: osx
+            arch: arm64
           - name: Windows
             os: windows-latest
             platform: windows
+            arch: x86_64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure dependencies
@@ -98,9 +105,9 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
         run: |
-          scons platform=${{ matrix.platform }} -j${{ steps.cpu-cores.outputs.count }}
+          scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} -j${{ steps.cpu-cores.outputs.count }}
       - name: Upload OSX binary
-        if: matrix.platform == 'osx'
+        if: matrix.platform == 'osx' && matrix.arch == 'x86_64'
         uses: actions/upload-artifact@v1
         with:
           name: osx-editor-debug-app

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -15,11 +15,11 @@ jobs:
           - name: Linux
             os: ubuntu-18.04
             platform: x11
-            arch: x86_64
+            arch: 64
           - name: OSX-x64
             os: macos-latest
             platform: osx
-            arch: x86_64
+            arch: 64
           - name: OSX-arm64
             os: macos-latest
             platform: osx
@@ -27,7 +27,7 @@ jobs:
           - name: Windows
             os: windows-latest
             platform: windows
-            arch: x86_64
+            arch: 64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure dependencies

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -9,18 +9,25 @@ jobs:
   build-editor-release:
     strategy:
       matrix:
-        name: [ Linux, OSX, Windows ]
+        name: [ Linux, OSX-x64, OSX-arm64, Windows ]
         include:
           # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
             os: ubuntu-18.04
             platform: x11
-          - name: OSX
+            arch: x86_64
+          - name: OSX-x64
             os: macos-latest
             platform: osx
+            arch: x86_64
+          - name: OSX-arm64
+            os: macos-latest
+            platform: osx
+            arch: arm64
           - name: Windows
             os: windows-latest
             platform: windows
+            arch: x86_64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure dependencies
@@ -43,7 +50,7 @@ jobs:
         id: editor-release-cache
         uses: actions/cache@v2
         with:
-          path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          path: ${{github.workspace}}/${{matrix.platform}}/${{matrix.arch}}/.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
             ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
@@ -63,6 +70,6 @@ jobs:
         uses: SimenB/github-actions-cpu-cores@v1
       - name: Build with editor release
         env:
-          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/${{matrix.arch}}/.scons_cache/
         run: |
-          scons platform=${{ matrix.platform }} target=release_debug -j${{ steps.cpu-cores.outputs.count }}
+          scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} target=release_debug -j${{ steps.cpu-cores.outputs.count }}

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -9,21 +9,29 @@ jobs:
   build-export-debug:
     strategy:
       matrix:
-        name: [ Linux, OSX, Windows, Android ]
+        name: [ Linux, OSX-x64, OSX-arm64, Windows, Android ]
         include:
           # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
             os: ubuntu-18.04
             platform: x11
-          - name: OSX
+            arch: x86_64
+          - name: OSX-x64
             os: macos-latest
             platform: osx
+            arch: x86_64
+          - name: OSX-arm64
+            os: macos-latest
+            platform: osx
+            arch: arm64
           - name: Windows
             os: windows-latest
             platform: windows
+            arch: x86_64
           - name: Android
             os: ubuntu-latest
             platform: android
+            arch: arm-all
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure dependencies
@@ -47,7 +55,7 @@ jobs:
         id: template-debug-cache
         uses: actions/cache@v2
         with:
-          path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          path: ${{github.workspace}}/${{matrix.platform}}/${{matrix.arch}}/.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
             ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
@@ -98,9 +106,9 @@ jobs:
       - name: Build debug export template
         if: matrix.platform != 'android'
         env:
-          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/${{matrix.arch}}/.scons_cache/
         run: |
-          scons platform=${{ matrix.platform }} tools=no target=release_debug bits=64 -j${{ steps.cpu-cores.outputs.count }}
+          scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} tools=no target=release_debug bits=64 -j${{ steps.cpu-cores.outputs.count }}
       - name: Build android debug binary armv7
         if: matrix.platform == 'android'
         env:

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -15,11 +15,11 @@ jobs:
           - name: Linux
             os: ubuntu-18.04
             platform: x11
-            arch: x86_64
+            arch: 64
           - name: OSX-x64
             os: macos-latest
             platform: osx
-            arch: x86_64
+            arch: 64
           - name: OSX-arm64
             os: macos-latest
             platform: osx
@@ -27,7 +27,7 @@ jobs:
           - name: Windows
             os: windows-latest
             platform: windows
-            arch: x86_64
+            arch: 64
           - name: Android
             os: ubuntu-latest
             platform: android

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -9,21 +9,29 @@ jobs:
   build-export-release:
     strategy:
       matrix:
-        name: [ Linux, OSX, Windows, Android ]
+        name: [ Linux, OSX-x64, OSX-arm64, Windows, Android ]
         include:
           # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
             os: ubuntu-18.04
             platform: x11
-          - name: OSX
+            arch: x86_64
+          - name: OSX-x64
             os: macos-latest
             platform: osx
+            arch: x86_64
+          - name: OSX-arm64
+            os: macos-latest
+            platform: osx
+            arch: arm64
           - name: Windows
             os: windows-latest
             platform: windows
+            arch: x86_64
           - name: Android
             os: ubuntu-latest
             platform: android
+            arch: arm-all
     runs-on: ${{ matrix.os }}
     steps:
       - name: Configure dependencies
@@ -47,7 +55,7 @@ jobs:
         id: template-release-cache
         uses: actions/cache@v2
         with:
-          path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          path: ${{github.workspace}}/${{matrix.platform}}/${{matrix.arch}}/.scons_cache/
           key: ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
           restore-keys: |
             ${{github.job}}-${{env.GODOT_BASE_VERSION}}-${{github.ref}}-${{github.sha}}
@@ -98,9 +106,9 @@ jobs:
       - name: Build release export template
         if: matrix.platform != 'android'
         env:
-          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
+          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/${{matrix.arch}}/.scons_cache/
         run: |
-          scons platform=${{ matrix.platform }} tools=no target=release bits=64 -j${{ steps.cpu-cores.outputs.count }}
+          scons platform=${{ matrix.platform }} arch=${{ matrix.arch }} tools=no target=release bits=64 -j${{ steps.cpu-cores.outputs.count }}
       - name: Build android release binary armv7
         if: matrix.platform == 'android'
         env:

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -15,11 +15,11 @@ jobs:
           - name: Linux
             os: ubuntu-18.04
             platform: x11
-            arch: x86_64
+            arch: 64
           - name: OSX-x64
             os: macos-latest
             platform: osx
-            arch: x86_64
+            arch: 64
           - name: OSX-arm64
             os: macos-latest
             platform: osx
@@ -27,7 +27,7 @@ jobs:
           - name: Windows
             os: windows-latest
             platform: windows
-            arch: x86_64
+            arch: 64
           - name: Android
             os: ubuntu-latest
             platform: android


### PR DESCRIPTION
For now this only contains addition of macos arm64 for check CI.  
I'll do the deploy workflow on another PR as I need a fork to test it.