### PR TITLE
bugfix: explode vararg array in call extensions

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/FuncRefTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/FuncRefTest.kt
@@ -19,22 +19,61 @@ class FuncRefTest : Node() {
     @RegisterProperty(rpcMode = MultiplayerAPI.RPCMode.REMOTE)
     var blubb: Boolean = false
 
+    @RegisterProperty
+    var callFlag = false
+
+    @RegisterProperty
+    var callWithParamFlag = false
+
+    @RegisterProperty
+    var signalCallFlag = false
+
     @RegisterFunction
     override fun _ready() {
-        signalTest.connect(this, ::testFuncRef)
-        rpc(::testFuncRef)
-        rset(::blubb, false)
-        call(::callTest)
-        callDeferred(::callTest)
+        signalTest.connect(this, ::testSignalCallback)
+
+//        Cannot test rpc for now as it needs two godot instances.
+//        rpc(::testFuncRef)
+//        rset(::blubb, false)
     }
 
     @RegisterFunction(MultiplayerAPI.RPCMode.REMOTE)
-    fun testFuncRef() {
-
+    fun testSignalCallback() {
+        signalCallFlag = true
     }
 
     @RegisterFunction
-    fun callTest() {
+    fun testSignalCall() {
+        signalTest.emit()
+    }
 
+    @RegisterFunction
+    fun withoutParamCallback() {
+        callFlag = true
+    }
+
+    @RegisterFunction
+    fun testCallWithoutParam() {
+        call(this::withoutParamCallback)
+    }
+
+    @RegisterFunction
+    fun testCallDeferredWithoutParam() {
+        callDeferred(this::withoutParamCallback)
+    }
+
+    @RegisterFunction
+    fun withParamCallback(flag: Boolean) {
+        callWithParamFlag = flag
+    }
+
+    @RegisterFunction
+    fun testCallWithParam() {
+        call(this::withParamCallback, true)
+    }
+
+    @RegisterFunction
+    fun testCallDeferredWithParam() {
+        callDeferred(this::withParamCallback, true)
     }
 }

--- a/harness/tests/test/unit/test_funcref.gd
+++ b/harness/tests/test/unit/test_funcref.gd
@@ -1,0 +1,37 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_call_without_param():
+	var func_ref_test_script = godot_tests_FuncRefTest.new()
+	func_ref_test_script.test_call_without_param()
+	assert_true(func_ref_test_script.call_flag)
+	func_ref_test_script.free()
+
+func test_call_deferred_without_param():
+	var func_ref_test_script = godot_tests_FuncRefTest.new()
+	func_ref_test_script.test_call_deferred_without_param()
+	yield(get_tree().create_timer(1), "timeout")
+	assert_true(func_ref_test_script.call_flag)
+	func_ref_test_script.free()
+
+func test_call_with_param():
+	var func_ref_test_script = godot_tests_FuncRefTest.new()
+	func_ref_test_script.test_call_with_param()
+	assert_true(func_ref_test_script.call_with_param_flag)
+	func_ref_test_script.free()
+
+func test_call_deferred_with_param():
+	var func_ref_test_script = godot_tests_FuncRefTest.new()
+	func_ref_test_script.test_call_deferred_with_param()
+	yield(get_tree().create_timer(3), "timeout")
+	assert_true(func_ref_test_script.call_with_param_flag)
+	func_ref_test_script.free()
+
+func test_signal_call():
+	var func_ref_test_script = godot_tests_FuncRefTest.new()
+	get_tree().root.add_child(func_ref_test_script)
+	func_ref_test_script.test_signal_call()
+	yield(get_tree().create_timer(1), "timeout")
+	assert_true(func_ref_test_script.signal_call_flag)
+	get_tree().root.remove_child(func_ref_test_script)
+	func_ref_test_script.free()

--- a/kt/godot-library/src/main/kotlin/godot/extensions/ObjectExt.kt
+++ b/kt/godot-library/src/main/kotlin/godot/extensions/ObjectExt.kt
@@ -11,26 +11,26 @@ import kotlin.reflect.KFunction
  * Use [Object.callDeferred] to call functions by string or [callDeferredRawName] for an unconverted version of this function
  */
 inline fun <reified T : KFunction<*>> Object.callDeferred(function: T, vararg args: Any?) =
-    callDeferred(function.name.camelToSnakeCase(), args)
+    callDeferred(function.name.camelToSnakeCase(), *args)
 
 /**
  * Same as [callDeferred] but the function name is not converted to snake_case
  */
 inline fun <reified T : KFunction<*>> Object.callDeferredRawName(function: T, vararg args: Any?) =
-    callDeferred(function.name, args)
+    callDeferred(function.name, *args)
 
 /**
  * **Note:** The function name is converted to snake_case
  * Use [Object.call] to call functions by string or [callRawName] for an unconverted version of this function
  */
 inline fun <reified T : KFunction<*>> Object.call(function: T, vararg args: Any?) =
-    call(function.name.camelToSnakeCase(), args)
+    call(function.name.camelToSnakeCase(), *args)
 
 /**
  * Same as [call] but the function name is not converted to snake_case
  */
 inline fun <reified T : KFunction<*>> Object.callRawName(function: T, vararg args: Any?) =
-    call(function.name, args)
+    call(function.name, *args)
 
 /**
  * **Note:** The function name is converted to snake_case


### PR DESCRIPTION
This resolves #277 