### PR TITLE
Fix godot-library publication by only including non fat jar in actual publication

### DIFF
--- a/kt/godot-library/build.gradle.kts
+++ b/kt/godot-library/build.gradle.kts
@@ -56,7 +56,7 @@ publishing {
             }
             artifactId = "godot-library"
             description = "Contains godot api as kotlin classes and jvm cpp interaction code."
-            from(components.getByName("java"))
+            artifact(tasks.jar)
         }
     }
 }


### PR DESCRIPTION
The fat jar is only needed for the editor release and is added to it through the github workflow.
The maven publication on the other hand only needs the non fat jar version.

This was previously handled through the dedicated `godot-bootstrap` module, and the module `godot-library` did formerly not contain any `shadowJar` task hence there was not a conflict with possible jars to publish. This is fixed by now explicitly setting the non shadow task output as the publish artifact.