### PR TITLE
Fix ksp crash on unknown annotation

### DIFF
--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/model/GodotAnnotation.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/model/GodotAnnotation.kt
@@ -1,5 +1,3 @@
 package godot.entrygenerator.model
 
-import godot.entrygenerator.model.GodotJvmSourceElement
-
 sealed interface GodotAnnotation : GodotJvmSourceElement

--- a/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/ext/ksAnnotationExt.kt
+++ b/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/ext/ksAnnotationExt.kt
@@ -215,8 +215,6 @@ fun KSAnnotation.mapToAnnotation(parentDeclaration: KSDeclaration): GodotAnnotat
                 global
             )
         }
-        else -> throw IllegalArgumentException(
-            "Unknown annotation: ${this.fqNameUnsafe}"
-        )
+        else -> null
     }
 }


### PR DESCRIPTION
This fixes a crash during compilation when an unknown annotation is encountered.
This was initially intended to catch missing/not implemented godot annotations but it also crashes on any third party annotation being processed by our symbol processor.

In the future we should also model third party annotations in our source code abstraction so they can be used in entry gen extensions. But as they are something for the distant future, we just ignore unknown annotations for now.