### PR TITLE
Enhancement/add edit state to instance as extension

### DIFF
--- a/docs/src/doc/user-guide/versioning.md
+++ b/docs/src/doc/user-guide/versioning.md
@@ -1,7 +1,7 @@
 The module uses semantic versioning for its own versions but adds a suffix for the supported godot version:
 
-Full version: `0.3.1-3.4.0`
+Full version: `0.3.2-3.4.0`
 
-Module Version: `0.3.1`
+Module Version: `0.3.2`
 
 Supported Godot Version: `3.4`

--- a/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
+++ b/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
@@ -1,1 +1,1 @@
-const val godotKotlinJvmVersion = "0.3.1"
+const val godotKotlinJvmVersion = "0.3.2"

--- a/kt/godot-library/src/main/kotlin/godot/extensions/PackedSceneExt.kt
+++ b/kt/godot-library/src/main/kotlin/godot/extensions/PackedSceneExt.kt
@@ -4,6 +4,6 @@ import godot.Node
 import godot.PackedScene
 
 @Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
-inline fun <T : Node> PackedScene.instanceAs(): T? {
-    return instance() as T?
+inline fun <T : Node> PackedScene.instanceAs(editState: Long = 0): T? {
+    return instance(editState) as T?
 }


### PR DESCRIPTION
This adds editState parameter to `PackedScene.instanceAs` extension.  
Default value is 0 like in api.