### PR TITLE
Enhancement/set core type interface public

### DIFF
--- a/kt/godot-library/src/main/kotlin/godot/core/CoreType.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/CoreType.kt
@@ -2,7 +2,12 @@ package godot.core
 
 import godot.util.VoidPtr
 
-internal interface CoreType
+/**
+ * This interface should not be inherited within user code.
+ * Inheriting this interface should only be done in godot-library.
+ * This interface is public so that one can easily identify godot's core types.
+ */
+interface CoreType
 
 abstract class NativeCoreType: CoreType {
     internal var _handle: VoidPtr = 0


### PR DESCRIPTION
`CoreType` interface has been set `internal` since `0.3.0-3.4.0`.  
This is something that can be helpful to have public.  
As an example @CedNaru and me have a project where we created some extensions that should be called only on `CoreType` inheritor.