### PR TITLE
bugfix/ci/change to new action zip

### DIFF
--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -110,7 +110,7 @@ jobs:
           arguments: godot-library:build
 
       - name: Zip release
-        uses: papeloto/action-zip@v1
+        uses: vimtor/action-zip@v1
         with:
           files: bin/${{ matrix.binary }} modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
           dest: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip


### PR DESCRIPTION
It seems `papeloto` changed his name, and someone clever (you can report him) decided to break the world by creating a trolling repo with former name: https://github.com/papeloto/action-zip/issues/1

This changes action to new repo.