### PR TITLE
Gradle tasks to download an run the pre-compiled binaries

### DIFF
--- a/kt/api-generator/build.gradle.kts
+++ b/kt/api-generator/build.gradle.kts
@@ -5,12 +5,15 @@ plugins {
 
 buildscript {
     repositories {
-        jcenter()
+        //jcenter()
+        mavenCentral()
         gradlePluginPortal()
+        google()
     }
 }
 repositories {
-    jcenter()
+    //jcenter()
+    mavenCentral()
     gradlePluginPortal()
 }
 

--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -24,6 +24,7 @@ subprojects {
     repositories {
         mavenCentral()
         gradlePluginPortal()
+        google()
     }
 }
 

--- a/kt/plugins/godot-gradle-plugin/build.gradle.kts
+++ b/kt/plugins/godot-gradle-plugin/build.gradle.kts
@@ -59,7 +59,6 @@ dependencies {
     implementation(project(":godot-build-props"))
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
     implementation("org.apache.commons:commons-lang3:3.12.0")
-    implementation("org.apache.httpcomponents.client5:httpclient5:5.1.2")
     implementation("com.konghq:unirest-java:3.13.6")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.8.2")

--- a/kt/plugins/godot-gradle-plugin/src/functionalTest/kotlin/godotruntime/GodotDownloadTaskConfigTest.kt
+++ b/kt/plugins/godot-gradle-plugin/src/functionalTest/kotlin/godotruntime/GodotDownloadTaskConfigTest.kt
@@ -1,0 +1,159 @@
+package godotruntime
+
+import godot.gradle.tasks.godotruntime.OS
+import org.gradle.testkit.runner.GradleRunner
+import org.jetbrains.kotlin.ir.backend.js.ic.newFile
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.io.File
+import java.nio.file.Path
+import java.util.*
+import kotlin.io.path.absolutePathString
+
+
+class GodotDownloadTaskConfigTest {
+
+    @TempDir
+    var testProjectDir: Path? = null
+
+    private lateinit var gradleRunner: GradleRunner
+    private lateinit var buildFile: File
+
+    @BeforeEach
+    fun setup() {
+        val root = File(testProjectDir!!.absolutePathString())
+        println(root.absolutePath)
+        //set up test folders
+        val testFile = newFile(root, "test")
+        testFile.mkdirs()
+
+        buildFile = newFile(testFile, "build.gradle.kts")
+        buildFile.createNewFile()
+
+
+        val testKitFile = newFile(root, "testkit")
+        testKitFile.mkdirs()
+
+        gradleRunner = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testFile)
+            .withTestKitDir(testKitFile)
+    }
+
+    @ParameterizedTest
+    @EnumSource(OS::class)
+    fun `Godot download task can be configured to target any supported operating systems`(os: OS) {
+        buildFile.writeText(
+            """
+            import godot.gradle.tasks.godotruntime.GodotBinaryDownloadTask
+            import godot.gradle.tasks.godotruntime.OS
+            
+            plugins {
+                // For build.gradle.kts (Kotlin DSL)
+                kotlin("jvm") version "1.6.0"
+                id("com.utopia-rise.godot-kotlin-jvm")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            godot {
+                isAndroidExportEnabled.set(false)
+                d8ToolPath.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/build-tools/31.0.0/d8"))
+                androidCompileSdkDir.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/platforms/android-30"))
+                godotKotlinJVMVersion.set("0.3.1-3.4.0")
+                val targetOS = OS.${os.name}
+                os.set(targetOS)
+                print(targetOS)        
+            }
+           
+        """.trimIndent()
+        )
+
+        val result = gradleRunner.withArguments("tasks").build()
+
+        //check that the base download task exists in the output.
+        //we will always register it so it shows up as an option.
+        assertTrue(result.output.contains("downloadGodotBinaries"))
+        println(result.output)
+    }
+
+    @ParameterizedTest
+    //we check every OS, no matter which platform we're on.
+    //include 3 versions for redundancy
+    @CsvSource(
+        "LINUX, 0.3.1-3.4.0",
+        "WINDOWS, 0.3.1-3.4.0",
+        "MAC, 0.3.1-3.4.0",
+
+        "LINUX, 0.2.0-3.3.0",
+        "WINDOWS, 0.2.0-3.3.0",
+        "MAC, 0.2.0-3.3.0",
+
+        "LINUX, 0.1.2-3.2.3",
+        "WINDOWS, 0.1.2-3.2.3",
+        "MAC, 0.1.2-3.2.3",
+    )
+    fun `Godot download task downloads the expected binaries for any supported operating systems`(
+        os: String,
+        version: String
+    ) {
+
+        buildFile.writeText(
+            """
+            import godot.gradle.tasks.godotruntime.GodotBinaryDownloadTask
+            import godot.gradle.tasks.godotruntime.OS
+            
+            plugins {
+                // For build.gradle.kts (Kotlin DSL)
+                kotlin("jvm") version "1.6.0"
+                id("com.utopia-rise.godot-kotlin-jvm")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            godot {
+                isAndroidExportEnabled.set(false)
+                d8ToolPath.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/build-tools/31.0.0/d8"))
+                androidCompileSdkDir.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/platforms/android-30"))
+                godotKotlinJVMVersion.set("$version")
+                val targetOS = OS.${os}
+                print(targetOS)
+                os.set(targetOS)
+            }
+        """.trimIndent()
+        )
+
+        val result = gradleRunner.withArguments("godotBinarySetup").build()
+
+        println(result.output)
+
+        val path = testProjectDir!!.absolutePathString() + "/test/build/godot/tmp/godot_editor_${
+            os.lowercase(
+                Locale.getDefault()
+            )
+        }.zip"
+        assertTrue(
+            File(
+                path
+            ).exists(), "editor zip file not downloaded to $path"
+        )
+        val osEnum = OS.valueOf(os)
+        val extractedFolderPath =
+            testProjectDir!!.absolutePathString() + "/test/build/godot/${os.lowercase()}/godot_editor/${osEnum.editorBinaryName}"
+
+        assertTrue(
+            File(
+                extractedFolderPath
+            ).exists(), "editor contents not extracted to $extractedFolderPath"
+        )
+    }
+}

--- a/kt/plugins/godot-gradle-plugin/src/functionalTest/kotlin/godotruntime/GodotPluginTest.kt
+++ b/kt/plugins/godot-gradle-plugin/src/functionalTest/kotlin/godotruntime/GodotPluginTest.kt
@@ -1,0 +1,83 @@
+package godotruntime
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.jetbrains.kotlin.ir.backend.js.ic.newFile
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+
+/**
+ * This seems to be redundant together with `godotruntime.GodotDownloadTaskConfigTest`, but this test checks the tasks without any configuration.
+ * Using the config DSL can produce different crashes that would not be there without it, and vice versa.
+ * */
+class GodotPluginTest {
+
+    @TempDir
+    var testProjectDir: Path? = null
+    private lateinit var gradleRunner: GradleRunner
+    private lateinit var buildFile:File
+    @BeforeEach
+    fun setup() {
+        val root = File(testProjectDir!!.absolutePathString())
+
+        //set up test folders
+        val testFile = newFile(root,"test")
+        testFile.mkdirs()
+
+        buildFile = newFile(testFile, "build.gradle.kts")
+        buildFile.createNewFile()
+
+        buildFile.writeText("""
+            plugins {
+                id("com.utopia-rise.godot-kotlin-jvm")
+                // For build.gradle.kts (Kotlin DSL)
+                kotlin("jvm") version "1.6.0"
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            godot {
+                isAndroidExportEnabled.set(false)
+                d8ToolPath.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/build-tools/31.0.0/d8"))
+                androidCompileSdkDir.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/platforms/android-30"))       
+            }
+            
+        """.trimIndent())
+
+        val testKitFile = newFile(root,"testkit")
+        testKitFile.mkdirs()
+
+        gradleRunner = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testFile)
+            .withTestKitDir(testKitFile)
+    }
+
+    @Test
+    //TODO put every registered task into this test.
+    fun `Registered tasks shows up in the task list`(){
+        val result = gradleRunner.withArguments("tasks","--stacktrace").build()
+        assertAll(
+            {taskExists("downloadGodotBinaries",result)},
+            {taskExists("extractGodotBinaries",result)},
+            {taskExists("godotBinarySetup",result)},
+            {taskExists("executeGodotEditor",result)},
+            {taskExists("runEditor",result)}
+        )
+
+        println(result.output)
+    }
+
+    fun taskExists(task:String,result: BuildResult){
+        assertTrue(result.output.contains("task"),"task with name '$task' not found")
+    }
+
+}

--- a/kt/plugins/godot-gradle-plugin/src/functionalTest/kotlin/godotruntime/GodotRuntimeTaskConfigTest.kt
+++ b/kt/plugins/godot-gradle-plugin/src/functionalTest/kotlin/godotruntime/GodotRuntimeTaskConfigTest.kt
@@ -1,0 +1,106 @@
+package godotruntime
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.jetbrains.kotlin.ir.backend.js.ic.newFile
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+
+
+class GodotRuntimeTaskConfigTest {
+
+    @TempDir
+    var testProjectDir: Path? = null
+
+    private lateinit var gradleRunner: GradleRunner
+    private lateinit var buildFile: File
+
+    @BeforeEach
+    fun setup() {
+        val root = File(testProjectDir!!.absolutePathString())
+        println(root.absolutePath)
+        //set up test folders
+        val testFile = newFile(root, "test")
+        testFile.mkdirs()
+
+        buildFile = newFile(testFile, "build.gradle.kts")
+        buildFile.createNewFile()
+
+
+        val testKitFile = newFile(root, "testkit")
+        testKitFile.mkdirs()
+
+        buildFile.writeText(
+            """
+            import godot.gradle.tasks.godotruntime.GodotBinaryDownloadTask
+            import godot.gradle.tasks.godotruntime.PathManager
+            import godot.gradle.tasks.godotruntime.OS
+            
+            plugins {
+                // For build.gradle.kts (Kotlin DSL)
+                kotlin("jvm") version "1.6.0"
+                id("com.utopia-rise.godot-kotlin-jvm")
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            godot {
+                isAndroidExportEnabled.set(false)
+                d8ToolPath.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/build-tools/31.0.0/d8"))
+                androidCompileSdkDir.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/platforms/android-30"))
+                godotKotlinJVMVersion.set("0.3.1-3.4.0")
+            }
+            
+            //if this is successful, the binary can run normally.
+            tasks{
+                named<Exec>("executeGodotEditor"){
+                    //we need to reconfigure this to have arguments.
+                    val editorPath = PathManager.getEditorExecutablePath(project = project)
+                    //we set to the "--quit" and "--no-window" flags so it starts with no window, and will close on it's own.
+                    commandLine(editorPath,"--quit","--no-window")
+                }
+            }
+            
+        """.trimIndent()
+        )
+
+        gradleRunner = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testFile)
+            .withTestKitDir(testKitFile)
+    }
+
+    @Test
+    fun `The editor binary can be executed on a fresh project`() {
+
+        val result = gradleRunner.withArguments("runEditor","--stacktrace").build()
+        println(result.output)
+        assertAll(
+            //this task contains the download tasks as well, we want these to be executed as well.
+            { taskWasSuccessful(result, "downloadGodotBinaries") },
+            { taskWasSuccessful(result, "extractGodotBinaries") },
+            { taskWasSuccessful(result, "godotBinarySetup") },
+            //running itself is 2 tasks, if the `executeGodotEditor` task is successful, then the `runEditor` task should be as well.
+            { taskWasSuccessful(result, "executeGodotEditor") },
+            { taskWasSuccessful(result, "runEditor") }
+        )
+
+    }
+
+    fun taskWasSuccessful(result: BuildResult, task: String) {
+        Assertions.assertEquals(
+            TaskOutcome.SUCCESS,
+            result.task(":$task")!!.outcome,
+            "task '$task' was not successful!"
+        )
+    }
+}

--- a/kt/plugins/godot-gradle-plugin/src/functionalTest/kotlin/godotruntime/TestEnvironment.kt
+++ b/kt/plugins/godot-gradle-plugin/src/functionalTest/kotlin/godotruntime/TestEnvironment.kt
@@ -1,0 +1,68 @@
+package godotruntime
+
+import org.gradle.testkit.runner.GradleRunner
+import org.jetbrains.kotlin.ir.backend.js.ic.newFile
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
+
+class TestEnvironment {
+    @TempDir
+    var testProjectDir: Path? = null
+    private lateinit var gradleRunner: GradleRunner
+    private lateinit var buildFile: File
+
+    @BeforeEach
+    fun setup() {
+        val root = File(testProjectDir!!.absolutePathString())
+
+        //set up test folders
+        val testFile = newFile(root,"test")
+        testFile.mkdirs()
+
+        buildFile = newFile(testFile, "build.gradle.kts")
+        buildFile.createNewFile()
+
+        val testKitFile = newFile(root,"testkit")
+        testKitFile.mkdirs()
+
+        buildFile.writeText("""
+            plugins {
+                id("com.utopia-rise.godot-kotlin-jvm")
+                // For build.gradle.kts (Kotlin DSL)
+                kotlin("jvm") version "1.6.0"
+            }
+
+            repositories {
+                mavenCentral()
+            }
+            
+            godot {
+                isAndroidExportEnabled.set(false)
+                d8ToolPath.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/build-tools/31.0.0/d8"))
+                androidCompileSdkDir.set(File("${'$'}{System.getenv("ANDROID_SDK_ROOT")}/platforms/android-30"))
+                godotKotlinJVMVersion.set("0.3.1-3.4.0")
+            }
+
+        """.trimIndent())
+
+        gradleRunner = GradleRunner.create()
+            .withPluginClasspath()
+            .withProjectDir(testFile)
+            .withTestKitDir(testKitFile)
+    }
+
+    /**
+     * Could be removed, but verifies that the test environment is functional.
+     * */
+    @Test
+    fun `Check the test setup, also printing additional information about the test environment`(){
+        print(gradleRunner.pluginClasspath)
+        val result = gradleRunner.withArguments("tasks","--stacktrace","--debug").build()
+        println(result.output)
+    }
+
+}

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
@@ -1,5 +1,7 @@
 package godot.gradle
 
+import godot.gradle.tasks.godotruntime.OS
+import org.apache.commons.lang3.SystemUtils
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import java.io.File
@@ -69,6 +71,28 @@ open class GodotExtension(objects: ObjectFactory) {
      */
     val isGraalVmNativeImageGenerationVerbose = objects.property(Boolean::class.java)
 
+    /**
+     * Properties to download a prebuilt Godot binary that contains the kotlin/JVM module.
+     *
+     *
+     * the version of the module we want to download. If unset, no download will happen.
+     * example: 0.3.3-3.4.2
+     * */
+    val godotKotlinJVMVersion = objects.property(String::class.java)
+
+    /**
+     * The base url to the "repository" where the binaries are stored.
+     * It will be resolved as <godotKotlinJVMDownloadBaseURL>/<godotKotlinJVMVersion>/<platform specific download, eg: godotKotlinJVMDownloadBaseURL>
+     * The default points to the releases section of the official github repository.
+     * example for the full resolved url: https://github.com/utopia-rise/godot-kotlin-jvm/releases/download/0.3.3-3.4.2/godot-kotlin-jvm_editor_x11_.zip
+     * */
+    val godotKotlinJVMDownloadBaseURL = objects.property(String::class.java)
+    /**
+     * The target OS for godot.
+     * */
+    val os= objects.property(OS::class.java)
+
+
     internal fun configureExtensionDefaults() {
         val buildToolsDir = System.getenv("ANDROID_SDK_ROOT")?.let { androidSdkRoot ->
             File("$androidSdkRoot/build-tools/")
@@ -102,5 +126,16 @@ open class GodotExtension(objects: ObjectFactory) {
         additionalGraalJniConfigurationFiles.set(arrayOf())
         isGraalVmNativeImageGenerationVerbose.set(false)
         windowsDeveloperVCVarsPath.set("\"%VC_VARS_PATH%\"")
+
+        godotKotlinJVMVersion.set("")
+        godotKotlinJVMDownloadBaseURL.set("https://github.com/utopia-rise/godot-kotlin-jvm/releases/download/")
+        when {
+            SystemUtils.IS_OS_WINDOWS -> os.set(OS.WINDOWS)
+            SystemUtils.IS_OS_MAC -> os.set(OS.MAC)
+            //linux is treated as the default fallback.
+            else -> {
+                os.set(OS.LINUX)
+            }
+        }
     }
 }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotPlugin.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotPlugin.kt
@@ -15,7 +15,6 @@ class GodotPlugin : Plugin<Project> {
         target.extensions.create("godot", GodotExtension::class.java).also {
             it.configureExtensionDefaults()
         }
-
         target.configureThirdPartyPlugins()
         target.setupConfigurationsAndCompilations()
         target.setupTasks()

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/GodotBinaryDownloadTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/GodotBinaryDownloadTask.kt
@@ -1,0 +1,53 @@
+package godot.gradle.tasks.godotruntime
+
+import godot.gradle.GodotExtension
+import kong.unirest.Unirest
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+
+/**
+ * This task comes with its own class, because we want to be able to make multiple versions, depending on which OS version we want to try out.
+ * This is useful for linux and mac, where we can try the application against Wine, as a quick test.
+ * */
+abstract class GodotBinaryDownloadTask : DefaultTask() {
+    init {
+        group = "godot-kotlin-jvm-internal"
+        description = "Downloads godot binaries to be used by the run tasks"
+    }
+
+    @TaskAction
+    fun downloadBinaries() {
+
+        val godotExtension = project.extensions.getByName("godot") as GodotExtension
+        //create a version url, that we can use as a base for the individual binaries
+        val os = godotExtension.os
+        val editorURL = PathManager.getEditorURL(godotExtension)
+        val editorFilePath = PathManager.getEditorFilePath(project, os.get())
+        val tempFile = PathManager.getDownloadPathForOS(os.get(), project)
+
+        File(tempFile).parentFile.mkdirs()
+
+        logger.info(
+            "downloading" +
+                " godot editor from $editorURL into $editorFilePath"
+        )
+        //we only download if the file is missing
+        if (!File(tempFile).exists()) {
+            Unirest.get(editorURL)
+                .downloadMonitor { b, fileName, bytesWritten, totalBytes -> logger.info("Downloading file, ${totalBytes - bytesWritten} bytes left") }
+                .asFile(tempFile)
+                .ifSuccess {
+                    logger.info("Editor downloaded!")
+                }
+                .ifFailure {
+                    logger.error("Failed to download godot editor! Status: ${it.statusText}")
+                    it.parsingError.ifPresent { e ->
+                        logger.error("Parsing Exception: ", e)
+                        logger.error("Original body: " + e.originalBody)
+                    }
+                }
+        }
+    }
+}

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/PathManager.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/PathManager.kt
@@ -1,0 +1,44 @@
+package godot.gradle.tasks.godotruntime
+
+import godot.gradle.GodotExtension
+import org.gradle.api.Project
+import java.util.*
+
+/**
+ * Singleton to make it easy to calculate the different paths used by the runtime.Could be a collection of functions, but being an object wraps these up nicely.
+ * The tasks use different paths for each platform to make it possible to download binaries from other platforms.
+ * No file paths or urls should be created anywhere else, to remain consistent!
+ * */
+object PathManager {
+
+    fun getDownloadPathForOS(os: OS, project:Project): String {
+        return project.buildDir.absolutePath+"/godot/tmp/godot_editor_${os.name.lowercase(Locale.getDefault())}.zip"
+    }
+
+    fun getTargetOS(project: Project): OS {
+        val godotExtension = project.extensions.getByName("godot") as GodotExtension
+        return godotExtension.os.get()
+    }
+
+    fun getEditorFilePath(project:Project): String {
+        return getEditorFilePath(project, getTargetOS(project))
+    }
+
+    fun getEditorFilePath(project:Project,os: OS): String {
+        return project.buildDir.absolutePath+"/godot/${os.name.lowercase()}/godot_editor/"
+    }
+
+    fun getEditorExecutablePath(project:Project): String {
+        val os = getTargetOS(project)
+        return getEditorFilePath(project, getTargetOS(project))+os.editorBinaryName
+    }
+
+    fun getVersionUrl(godotExtension:GodotExtension): String {
+        return godotExtension.godotKotlinJVMDownloadBaseURL.get() + "/" + godotExtension.godotKotlinJVMVersion.get() + "/"
+    }
+
+    fun getEditorURL(godotExtension:GodotExtension): String {
+        val os = godotExtension.os
+        return getVersionUrl(godotExtension)+"/"+os.get().editorDownloadName
+    }
+}

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/createGodotBinaryDownloadTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/createGodotBinaryDownloadTask.kt
@@ -1,0 +1,43 @@
+package godot.gradle.tasks.godotruntime
+
+import godot.gradle.GodotExtension
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.TaskProvider
+
+
+/**
+ * Downloads Godot binaries from the specified URL
+ * */
+fun Project.createGodotBinaryDownloadTask(): TaskProvider<GodotBinaryDownloadTask> {
+
+    return tasks.register("downloadGodotBinaries", GodotBinaryDownloadTask::class.java) {}
+}
+
+fun Project.createGodotBinaryExtractTask():TaskProvider<Copy>{
+
+    return tasks.register("extractGodotBinaries",Copy::class.java){
+        val godotExtension = project.extensions.getByName("godot") as GodotExtension
+        val os = godotExtension.os
+        val output = PathManager.getDownloadPathForOS(os.get(),project)
+        it.apply {
+            from(zipTree(output))
+            into(PathManager.getEditorFilePath(project,os.get()))
+
+            group = "godot-kotlin-jvm-internal"
+            description = "Extracts downloaded godot binaries"
+        }
+    }
+}
+
+fun Project.createGodotBinarySetupTask(downloadTask: GodotBinaryDownloadTask):TaskProvider<Task>{
+    return tasks.register("godotBinarySetup") {
+        with(it) {
+            group = "godot-kotlin-jvm"
+            description = "Sets up godot binaries for us to run the editor and our games from"
+
+            dependsOn(downloadTask)
+        }
+    }
+}

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/createGodotRuntimeTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/createGodotRuntimeTask.kt
@@ -1,0 +1,50 @@
+package godot.gradle.tasks.godotruntime
+
+
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskProvider
+
+
+fun Project.createGodotEditorBinaryExecTask(): TaskProvider<Exec> {
+
+    return tasks.register("executeGodotEditor", Exec::class.java) {
+        it.apply {
+            group = "godot-kotlin-jvm-internal"
+            description = "Runs the downloaded Godot Editor"
+            val editorPath = PathManager.getEditorExecutablePath(project = project)
+            workingDir = projectDir
+            commandLine(editorPath,"./project.godot")
+        }
+    }
+}
+
+fun Project.createGodotEditorBinaryRunTask(execTask: Task, downloadTask: Task): TaskProvider<Task> {
+
+    return tasks.register("runEditor") {
+        with(it) {
+            group = "godot-kotlin-jvm"
+            description = "Sets up the required binaries, then runs the editor"
+
+            dependsOn(downloadTask)
+            finalizedBy(execTask)
+        }
+    }
+}
+
+/**
+ * Creates a task that sets the executable permission for the binary, so we can run it.
+ * */
+fun Project.createGodotEditorPermissionTasks(execTask: Task, downloadTask: Task,extractTask:Task){
+    val targetOS = PathManager.getTargetOS(project)
+    var chmodTask:TaskProvider<Exec>? = null
+    if(targetOS == OS.LINUX){
+        val editorPath = PathManager.getEditorExecutablePath(project = project)
+        chmodTask= tasks.register("chmodEditorExecutable",Exec::class.java){
+            it.commandLine("chmod","+x",editorPath)
+            it.dependsOn(downloadTask,extractTask)
+        }
+        execTask.dependsOn(chmodTask)
+    }
+}

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/enums.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/godotruntime/enums.kt
@@ -1,0 +1,11 @@
+package godot.gradle.tasks.godotruntime
+
+/**
+ * Contains data for each supported operation systems.
+ * ONLY operating systems that we are going to develop from!
+ * */
+enum class OS(val editorDownloadName: String, val editorBinaryName:String) {
+    LINUX("godot-kotlin-jvm_editor_x11_.zip","godot.x11.opt.tools.64"),
+    MAC("godot-kotlin-jvm_editor_osx_.zip","godot.osx.opt.tools.64"),
+    WINDOWS("godot-kotlin-jvm_editor_windows_.zip","godot.windows.opt.tools.64.exe")
+}

--- a/kt/settings.gradle.kts
+++ b/kt/settings.gradle.kts
@@ -1,6 +1,12 @@
 include("godot-library")
 
 pluginManagement {
+    repositories {
+        // jcenter()
+        mavenCentral() // use this instead
+        google()
+        gradlePluginPortal()
+    }
     resolutionStrategy.eachPlugin {
         if (requested.id.id == "com.utopia-rise.api-generator") {
             useModule("com.utopia-rise:api-generator:0.0.1")


### PR DESCRIPTION
Added a set of tasks that can download and runs the pre-compiled godot binaries.
The default configuration url to download them is the official GitHub, but can be overridden manually.
The tasks can download based on your current os, and you can also set the one you want manually. (eg: you want to run the windows version through wine)
Includes a set of functional tests for the new tasks, using junit5 and the gradle test kit.

I saw that jcenter is going to go down in february, and it was already throwing me a lot of 502 exceptions so I also had to remove those. I see that it remains read only, but I'd still keep it out of the system.
https://blog.gradle.org/jcenter-shutdown