### PR TITLE
Add support for indexed properties in api-generator

### DIFF
--- a/kt/api-generator/src/main/kotlin/godot/codegen/Property.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/Property.kt
@@ -109,13 +109,13 @@ class Property @JsonCreator constructor(
             val argumentsString = if (index == -1) {
                 "%T to value"
             } else {
-                "%T to $index, %T to value"
+                "%T to ${index}L, %T to value"
             }
 
             val argumentsTypes = if (index == -1)
                 listOf(type)
             else
-                listOf("Int", type)
+                listOf("Long", type)
 
             propertySpecBuilder.setter(
                 FunSpec.setterBuilder()
@@ -139,13 +139,13 @@ class Property @JsonCreator constructor(
             val argumentsString = if (index == -1) {
                 ""
             } else {
-                "%T to $index"
+                "%T to ${index}L"
             }
 
             val argumentsTypes = if (index == -1) {
                 listOf()
             } else {
-                listOf("Int")
+                listOf("Long")
             }
 
             propertySpecBuilder.getter(

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimatedTexture.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimatedTexture.kt
@@ -65,6656 +65,6656 @@ public open class AnimatedTexture : Texture() {
 
   public open var frame0_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_0_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_0_DELAY_SEC, NIL)
     }
 
   public open var frame0_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_0_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 0L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_0_TEXTURE, NIL)
     }
 
   public open var frame1_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_1_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_1_DELAY_SEC, NIL)
     }
 
   public open var frame1_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_1_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 1L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_1_TEXTURE, NIL)
     }
 
   public open var frame10_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_10_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 10L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_10_DELAY_SEC, NIL)
     }
 
   public open var frame10_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_10_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 10L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_10_TEXTURE, NIL)
     }
 
   public open var frame100_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 100L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_100_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 100L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_100_DELAY_SEC, NIL)
     }
 
   public open var frame100_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 100L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_100_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 100L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_100_TEXTURE, NIL)
     }
 
   public open var frame101_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 101L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_101_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 101L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_101_DELAY_SEC, NIL)
     }
 
   public open var frame101_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 101L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_101_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 101L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_101_TEXTURE, NIL)
     }
 
   public open var frame102_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 102L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_102_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 102L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_102_DELAY_SEC, NIL)
     }
 
   public open var frame102_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 102L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_102_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 102L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_102_TEXTURE, NIL)
     }
 
   public open var frame103_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 103L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_103_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 103L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_103_DELAY_SEC, NIL)
     }
 
   public open var frame103_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 103L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_103_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 103L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_103_TEXTURE, NIL)
     }
 
   public open var frame104_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 104L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_104_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 104L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_104_DELAY_SEC, NIL)
     }
 
   public open var frame104_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 104L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_104_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 104L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_104_TEXTURE, NIL)
     }
 
   public open var frame105_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 105L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_105_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 105L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_105_DELAY_SEC, NIL)
     }
 
   public open var frame105_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 105L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_105_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 105L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_105_TEXTURE, NIL)
     }
 
   public open var frame106_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 106L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_106_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 106L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_106_DELAY_SEC, NIL)
     }
 
   public open var frame106_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 106L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_106_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 106L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_106_TEXTURE, NIL)
     }
 
   public open var frame107_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 107L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_107_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 107L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_107_DELAY_SEC, NIL)
     }
 
   public open var frame107_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 107L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_107_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 107L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_107_TEXTURE, NIL)
     }
 
   public open var frame108_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 108L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_108_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 108L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_108_DELAY_SEC, NIL)
     }
 
   public open var frame108_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 108L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_108_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 108L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_108_TEXTURE, NIL)
     }
 
   public open var frame109_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 109L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_109_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 109L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_109_DELAY_SEC, NIL)
     }
 
   public open var frame109_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 109L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_109_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 109L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_109_TEXTURE, NIL)
     }
 
   public open var frame11_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_11_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 11L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_11_DELAY_SEC, NIL)
     }
 
   public open var frame11_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_11_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 11L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_11_TEXTURE, NIL)
     }
 
   public open var frame110_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 110L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_110_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 110L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_110_DELAY_SEC, NIL)
     }
 
   public open var frame110_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 110L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_110_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 110L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_110_TEXTURE, NIL)
     }
 
   public open var frame111_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 111L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_111_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 111L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_111_DELAY_SEC, NIL)
     }
 
   public open var frame111_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 111L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_111_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 111L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_111_TEXTURE, NIL)
     }
 
   public open var frame112_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 112L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_112_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 112L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_112_DELAY_SEC, NIL)
     }
 
   public open var frame112_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 112L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_112_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 112L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_112_TEXTURE, NIL)
     }
 
   public open var frame113_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 113L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_113_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 113L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_113_DELAY_SEC, NIL)
     }
 
   public open var frame113_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 113L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_113_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 113L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_113_TEXTURE, NIL)
     }
 
   public open var frame114_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 114L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_114_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 114L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_114_DELAY_SEC, NIL)
     }
 
   public open var frame114_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 114L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_114_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 114L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_114_TEXTURE, NIL)
     }
 
   public open var frame115_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 115L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_115_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 115L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_115_DELAY_SEC, NIL)
     }
 
   public open var frame115_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 115L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_115_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 115L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_115_TEXTURE, NIL)
     }
 
   public open var frame116_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 116L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_116_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 116L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_116_DELAY_SEC, NIL)
     }
 
   public open var frame116_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 116L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_116_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 116L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_116_TEXTURE, NIL)
     }
 
   public open var frame117_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 117L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_117_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 117L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_117_DELAY_SEC, NIL)
     }
 
   public open var frame117_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 117L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_117_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 117L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_117_TEXTURE, NIL)
     }
 
   public open var frame118_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 118L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_118_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 118L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_118_DELAY_SEC, NIL)
     }
 
   public open var frame118_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 118L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_118_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 118L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_118_TEXTURE, NIL)
     }
 
   public open var frame119_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 119L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_119_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 119L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_119_DELAY_SEC, NIL)
     }
 
   public open var frame119_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 119L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_119_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 119L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_119_TEXTURE, NIL)
     }
 
   public open var frame12_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_12_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 12L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_12_DELAY_SEC, NIL)
     }
 
   public open var frame12_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_12_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 12L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_12_TEXTURE, NIL)
     }
 
   public open var frame120_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 120L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_120_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 120L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_120_DELAY_SEC, NIL)
     }
 
   public open var frame120_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 120L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_120_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 120L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_120_TEXTURE, NIL)
     }
 
   public open var frame121_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 121L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_121_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 121L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_121_DELAY_SEC, NIL)
     }
 
   public open var frame121_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 121L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_121_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 121L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_121_TEXTURE, NIL)
     }
 
   public open var frame122_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 122L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_122_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 122L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_122_DELAY_SEC, NIL)
     }
 
   public open var frame122_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 122L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_122_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 122L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_122_TEXTURE, NIL)
     }
 
   public open var frame123_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 123L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_123_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 123L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_123_DELAY_SEC, NIL)
     }
 
   public open var frame123_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 123L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_123_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 123L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_123_TEXTURE, NIL)
     }
 
   public open var frame124_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 124L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_124_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 124L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_124_DELAY_SEC, NIL)
     }
 
   public open var frame124_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 124L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_124_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 124L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_124_TEXTURE, NIL)
     }
 
   public open var frame125_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 125L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_125_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 125L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_125_DELAY_SEC, NIL)
     }
 
   public open var frame125_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 125L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_125_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 125L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_125_TEXTURE, NIL)
     }
 
   public open var frame126_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 126L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_126_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 126L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_126_DELAY_SEC, NIL)
     }
 
   public open var frame126_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 126L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_126_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 126L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_126_TEXTURE, NIL)
     }
 
   public open var frame127_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 127L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_127_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 127L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_127_DELAY_SEC, NIL)
     }
 
   public open var frame127_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 127L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_127_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 127L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_127_TEXTURE, NIL)
     }
 
   public open var frame128_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 128L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_128_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 128L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_128_DELAY_SEC, NIL)
     }
 
   public open var frame128_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 128L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_128_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 128L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_128_TEXTURE, NIL)
     }
 
   public open var frame129_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 129L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_129_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 129L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_129_DELAY_SEC, NIL)
     }
 
   public open var frame129_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 129L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_129_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 129L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_129_TEXTURE, NIL)
     }
 
   public open var frame13_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_13_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 13L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_13_DELAY_SEC, NIL)
     }
 
   public open var frame13_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_13_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 13L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_13_TEXTURE, NIL)
     }
 
   public open var frame130_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 130L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_130_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 130L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_130_DELAY_SEC, NIL)
     }
 
   public open var frame130_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 130L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_130_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 130L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_130_TEXTURE, NIL)
     }
 
   public open var frame131_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 131L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_131_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 131L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_131_DELAY_SEC, NIL)
     }
 
   public open var frame131_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 131L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_131_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 131L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_131_TEXTURE, NIL)
     }
 
   public open var frame132_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 132L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_132_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 132L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_132_DELAY_SEC, NIL)
     }
 
   public open var frame132_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 132L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_132_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 132L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_132_TEXTURE, NIL)
     }
 
   public open var frame133_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 133L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_133_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 133L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_133_DELAY_SEC, NIL)
     }
 
   public open var frame133_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 133L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_133_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 133L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_133_TEXTURE, NIL)
     }
 
   public open var frame134_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 134L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_134_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 134L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_134_DELAY_SEC, NIL)
     }
 
   public open var frame134_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 134L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_134_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 134L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_134_TEXTURE, NIL)
     }
 
   public open var frame135_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 135L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_135_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 135L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_135_DELAY_SEC, NIL)
     }
 
   public open var frame135_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 135L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_135_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 135L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_135_TEXTURE, NIL)
     }
 
   public open var frame136_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 136L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_136_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 136L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_136_DELAY_SEC, NIL)
     }
 
   public open var frame136_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 136L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_136_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 136L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_136_TEXTURE, NIL)
     }
 
   public open var frame137_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 137L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_137_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 137L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_137_DELAY_SEC, NIL)
     }
 
   public open var frame137_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 137L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_137_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 137L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_137_TEXTURE, NIL)
     }
 
   public open var frame138_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 138L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_138_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 138L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_138_DELAY_SEC, NIL)
     }
 
   public open var frame138_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 138L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_138_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 138L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_138_TEXTURE, NIL)
     }
 
   public open var frame139_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 139L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_139_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 139L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_139_DELAY_SEC, NIL)
     }
 
   public open var frame139_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 139L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_139_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 139L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_139_TEXTURE, NIL)
     }
 
   public open var frame14_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_14_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 14L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_14_DELAY_SEC, NIL)
     }
 
   public open var frame14_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_14_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 14L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_14_TEXTURE, NIL)
     }
 
   public open var frame140_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 140L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_140_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 140L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_140_DELAY_SEC, NIL)
     }
 
   public open var frame140_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 140L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_140_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 140L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_140_TEXTURE, NIL)
     }
 
   public open var frame141_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 141L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_141_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 141L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_141_DELAY_SEC, NIL)
     }
 
   public open var frame141_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 141L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_141_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 141L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_141_TEXTURE, NIL)
     }
 
   public open var frame142_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 142L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_142_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 142L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_142_DELAY_SEC, NIL)
     }
 
   public open var frame142_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 142L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_142_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 142L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_142_TEXTURE, NIL)
     }
 
   public open var frame143_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 143L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_143_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 143L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_143_DELAY_SEC, NIL)
     }
 
   public open var frame143_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 143L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_143_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 143L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_143_TEXTURE, NIL)
     }
 
   public open var frame144_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 144L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_144_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 144L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_144_DELAY_SEC, NIL)
     }
 
   public open var frame144_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 144L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_144_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 144L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_144_TEXTURE, NIL)
     }
 
   public open var frame145_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 145L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_145_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 145L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_145_DELAY_SEC, NIL)
     }
 
   public open var frame145_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 145L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_145_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 145L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_145_TEXTURE, NIL)
     }
 
   public open var frame146_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 146L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_146_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 146L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_146_DELAY_SEC, NIL)
     }
 
   public open var frame146_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 146L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_146_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 146L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_146_TEXTURE, NIL)
     }
 
   public open var frame147_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 147L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_147_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 147L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_147_DELAY_SEC, NIL)
     }
 
   public open var frame147_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 147L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_147_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 147L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_147_TEXTURE, NIL)
     }
 
   public open var frame148_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 148L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_148_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 148L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_148_DELAY_SEC, NIL)
     }
 
   public open var frame148_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 148L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_148_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 148L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_148_TEXTURE, NIL)
     }
 
   public open var frame149_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 149L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_149_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 149L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_149_DELAY_SEC, NIL)
     }
 
   public open var frame149_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 149L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_149_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 149L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_149_TEXTURE, NIL)
     }
 
   public open var frame15_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_15_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 15L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_15_DELAY_SEC, NIL)
     }
 
   public open var frame15_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_15_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 15L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_15_TEXTURE, NIL)
     }
 
   public open var frame150_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 150L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_150_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 150L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_150_DELAY_SEC, NIL)
     }
 
   public open var frame150_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 150L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_150_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 150L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_150_TEXTURE, NIL)
     }
 
   public open var frame151_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 151L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_151_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 151L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_151_DELAY_SEC, NIL)
     }
 
   public open var frame151_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 151L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_151_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 151L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_151_TEXTURE, NIL)
     }
 
   public open var frame152_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 152L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_152_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 152L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_152_DELAY_SEC, NIL)
     }
 
   public open var frame152_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 152L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_152_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 152L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_152_TEXTURE, NIL)
     }
 
   public open var frame153_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 153L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_153_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 153L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_153_DELAY_SEC, NIL)
     }
 
   public open var frame153_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 153L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_153_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 153L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_153_TEXTURE, NIL)
     }
 
   public open var frame154_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 154L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_154_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 154L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_154_DELAY_SEC, NIL)
     }
 
   public open var frame154_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 154L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_154_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 154L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_154_TEXTURE, NIL)
     }
 
   public open var frame155_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 155L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_155_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 155L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_155_DELAY_SEC, NIL)
     }
 
   public open var frame155_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 155L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_155_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 155L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_155_TEXTURE, NIL)
     }
 
   public open var frame156_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 156L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_156_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 156L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_156_DELAY_SEC, NIL)
     }
 
   public open var frame156_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 156L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_156_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 156L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_156_TEXTURE, NIL)
     }
 
   public open var frame157_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 157L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_157_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 157L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_157_DELAY_SEC, NIL)
     }
 
   public open var frame157_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 157L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_157_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 157L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_157_TEXTURE, NIL)
     }
 
   public open var frame158_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 158L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_158_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 158L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_158_DELAY_SEC, NIL)
     }
 
   public open var frame158_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 158L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_158_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 158L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_158_TEXTURE, NIL)
     }
 
   public open var frame159_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 159L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_159_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 159L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_159_DELAY_SEC, NIL)
     }
 
   public open var frame159_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 159L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_159_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 159L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_159_TEXTURE, NIL)
     }
 
   public open var frame16_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_16_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 16L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_16_DELAY_SEC, NIL)
     }
 
   public open var frame16_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_16_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 16L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_16_TEXTURE, NIL)
     }
 
   public open var frame160_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 160L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_160_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 160L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_160_DELAY_SEC, NIL)
     }
 
   public open var frame160_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 160L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_160_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 160L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_160_TEXTURE, NIL)
     }
 
   public open var frame161_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 161L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_161_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 161L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_161_DELAY_SEC, NIL)
     }
 
   public open var frame161_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 161L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_161_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 161L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_161_TEXTURE, NIL)
     }
 
   public open var frame162_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 162L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_162_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 162L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_162_DELAY_SEC, NIL)
     }
 
   public open var frame162_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 162L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_162_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 162L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_162_TEXTURE, NIL)
     }
 
   public open var frame163_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 163L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_163_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 163L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_163_DELAY_SEC, NIL)
     }
 
   public open var frame163_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 163L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_163_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 163L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_163_TEXTURE, NIL)
     }
 
   public open var frame164_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 164L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_164_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 164L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_164_DELAY_SEC, NIL)
     }
 
   public open var frame164_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 164L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_164_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 164L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_164_TEXTURE, NIL)
     }
 
   public open var frame165_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 165L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_165_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 165L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_165_DELAY_SEC, NIL)
     }
 
   public open var frame165_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 165L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_165_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 165L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_165_TEXTURE, NIL)
     }
 
   public open var frame166_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 166L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_166_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 166L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_166_DELAY_SEC, NIL)
     }
 
   public open var frame166_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 166L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_166_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 166L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_166_TEXTURE, NIL)
     }
 
   public open var frame167_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 167L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_167_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 167L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_167_DELAY_SEC, NIL)
     }
 
   public open var frame167_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 167L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_167_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 167L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_167_TEXTURE, NIL)
     }
 
   public open var frame168_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 168L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_168_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 168L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_168_DELAY_SEC, NIL)
     }
 
   public open var frame168_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 168L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_168_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 168L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_168_TEXTURE, NIL)
     }
 
   public open var frame169_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 169L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_169_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 169L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_169_DELAY_SEC, NIL)
     }
 
   public open var frame169_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 169L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_169_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 169L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_169_TEXTURE, NIL)
     }
 
   public open var frame17_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_17_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 17L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_17_DELAY_SEC, NIL)
     }
 
   public open var frame17_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_17_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 17L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_17_TEXTURE, NIL)
     }
 
   public open var frame170_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 170L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_170_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 170L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_170_DELAY_SEC, NIL)
     }
 
   public open var frame170_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 170L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_170_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 170L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_170_TEXTURE, NIL)
     }
 
   public open var frame171_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 171L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_171_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 171L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_171_DELAY_SEC, NIL)
     }
 
   public open var frame171_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 171L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_171_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 171L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_171_TEXTURE, NIL)
     }
 
   public open var frame172_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 172L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_172_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 172L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_172_DELAY_SEC, NIL)
     }
 
   public open var frame172_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 172L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_172_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 172L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_172_TEXTURE, NIL)
     }
 
   public open var frame173_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 173L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_173_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 173L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_173_DELAY_SEC, NIL)
     }
 
   public open var frame173_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 173L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_173_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 173L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_173_TEXTURE, NIL)
     }
 
   public open var frame174_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 174L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_174_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 174L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_174_DELAY_SEC, NIL)
     }
 
   public open var frame174_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 174L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_174_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 174L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_174_TEXTURE, NIL)
     }
 
   public open var frame175_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 175L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_175_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 175L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_175_DELAY_SEC, NIL)
     }
 
   public open var frame175_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 175L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_175_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 175L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_175_TEXTURE, NIL)
     }
 
   public open var frame176_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 176L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_176_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 176L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_176_DELAY_SEC, NIL)
     }
 
   public open var frame176_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 176L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_176_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 176L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_176_TEXTURE, NIL)
     }
 
   public open var frame177_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 177L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_177_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 177L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_177_DELAY_SEC, NIL)
     }
 
   public open var frame177_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 177L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_177_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 177L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_177_TEXTURE, NIL)
     }
 
   public open var frame178_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 178L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_178_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 178L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_178_DELAY_SEC, NIL)
     }
 
   public open var frame178_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 178L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_178_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 178L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_178_TEXTURE, NIL)
     }
 
   public open var frame179_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 179L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_179_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 179L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_179_DELAY_SEC, NIL)
     }
 
   public open var frame179_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 179L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_179_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 179L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_179_TEXTURE, NIL)
     }
 
   public open var frame18_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_18_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 18L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_18_DELAY_SEC, NIL)
     }
 
   public open var frame18_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_18_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 18L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_18_TEXTURE, NIL)
     }
 
   public open var frame180_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 180L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_180_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 180L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_180_DELAY_SEC, NIL)
     }
 
   public open var frame180_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 180L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_180_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 180L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_180_TEXTURE, NIL)
     }
 
   public open var frame181_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 181L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_181_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 181L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_181_DELAY_SEC, NIL)
     }
 
   public open var frame181_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 181L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_181_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 181L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_181_TEXTURE, NIL)
     }
 
   public open var frame182_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 182L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_182_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 182L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_182_DELAY_SEC, NIL)
     }
 
   public open var frame182_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 182L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_182_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 182L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_182_TEXTURE, NIL)
     }
 
   public open var frame183_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 183L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_183_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 183L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_183_DELAY_SEC, NIL)
     }
 
   public open var frame183_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 183L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_183_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 183L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_183_TEXTURE, NIL)
     }
 
   public open var frame184_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 184L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_184_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 184L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_184_DELAY_SEC, NIL)
     }
 
   public open var frame184_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 184L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_184_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 184L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_184_TEXTURE, NIL)
     }
 
   public open var frame185_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 185L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_185_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 185L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_185_DELAY_SEC, NIL)
     }
 
   public open var frame185_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 185L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_185_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 185L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_185_TEXTURE, NIL)
     }
 
   public open var frame186_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 186L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_186_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 186L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_186_DELAY_SEC, NIL)
     }
 
   public open var frame186_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 186L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_186_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 186L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_186_TEXTURE, NIL)
     }
 
   public open var frame187_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 187L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_187_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 187L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_187_DELAY_SEC, NIL)
     }
 
   public open var frame187_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 187L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_187_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 187L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_187_TEXTURE, NIL)
     }
 
   public open var frame188_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 188L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_188_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 188L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_188_DELAY_SEC, NIL)
     }
 
   public open var frame188_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 188L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_188_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 188L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_188_TEXTURE, NIL)
     }
 
   public open var frame189_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 189L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_189_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 189L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_189_DELAY_SEC, NIL)
     }
 
   public open var frame189_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 189L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_189_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 189L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_189_TEXTURE, NIL)
     }
 
   public open var frame19_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_19_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 19L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_19_DELAY_SEC, NIL)
     }
 
   public open var frame19_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_19_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 19L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_19_TEXTURE, NIL)
     }
 
   public open var frame190_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 190L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_190_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 190L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_190_DELAY_SEC, NIL)
     }
 
   public open var frame190_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 190L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_190_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 190L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_190_TEXTURE, NIL)
     }
 
   public open var frame191_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 191L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_191_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 191L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_191_DELAY_SEC, NIL)
     }
 
   public open var frame191_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 191L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_191_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 191L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_191_TEXTURE, NIL)
     }
 
   public open var frame192_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 192L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_192_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 192L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_192_DELAY_SEC, NIL)
     }
 
   public open var frame192_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 192L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_192_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 192L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_192_TEXTURE, NIL)
     }
 
   public open var frame193_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 193L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_193_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 193L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_193_DELAY_SEC, NIL)
     }
 
   public open var frame193_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 193L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_193_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 193L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_193_TEXTURE, NIL)
     }
 
   public open var frame194_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 194L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_194_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 194L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_194_DELAY_SEC, NIL)
     }
 
   public open var frame194_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 194L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_194_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 194L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_194_TEXTURE, NIL)
     }
 
   public open var frame195_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 195L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_195_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 195L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_195_DELAY_SEC, NIL)
     }
 
   public open var frame195_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 195L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_195_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 195L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_195_TEXTURE, NIL)
     }
 
   public open var frame196_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 196L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_196_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 196L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_196_DELAY_SEC, NIL)
     }
 
   public open var frame196_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 196L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_196_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 196L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_196_TEXTURE, NIL)
     }
 
   public open var frame197_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 197L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_197_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 197L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_197_DELAY_SEC, NIL)
     }
 
   public open var frame197_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 197L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_197_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 197L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_197_TEXTURE, NIL)
     }
 
   public open var frame198_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 198L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_198_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 198L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_198_DELAY_SEC, NIL)
     }
 
   public open var frame198_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 198L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_198_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 198L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_198_TEXTURE, NIL)
     }
 
   public open var frame199_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 199L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_199_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 199L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_199_DELAY_SEC, NIL)
     }
 
   public open var frame199_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 199L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_199_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 199L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_199_TEXTURE, NIL)
     }
 
   public open var frame2_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_2_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_2_DELAY_SEC, NIL)
     }
 
   public open var frame2_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_2_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 2L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_2_TEXTURE, NIL)
     }
 
   public open var frame20_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_20_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 20L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_20_DELAY_SEC, NIL)
     }
 
   public open var frame20_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_20_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 20L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_20_TEXTURE, NIL)
     }
 
   public open var frame200_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 200L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_200_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 200L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_200_DELAY_SEC, NIL)
     }
 
   public open var frame200_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 200L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_200_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 200L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_200_TEXTURE, NIL)
     }
 
   public open var frame201_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 201L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_201_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 201L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_201_DELAY_SEC, NIL)
     }
 
   public open var frame201_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 201L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_201_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 201L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_201_TEXTURE, NIL)
     }
 
   public open var frame202_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 202L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_202_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 202L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_202_DELAY_SEC, NIL)
     }
 
   public open var frame202_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 202L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_202_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 202L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_202_TEXTURE, NIL)
     }
 
   public open var frame203_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 203L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_203_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 203L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_203_DELAY_SEC, NIL)
     }
 
   public open var frame203_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 203L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_203_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 203L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_203_TEXTURE, NIL)
     }
 
   public open var frame204_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 204L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_204_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 204L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_204_DELAY_SEC, NIL)
     }
 
   public open var frame204_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 204L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_204_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 204L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_204_TEXTURE, NIL)
     }
 
   public open var frame205_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 205L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_205_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 205L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_205_DELAY_SEC, NIL)
     }
 
   public open var frame205_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 205L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_205_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 205L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_205_TEXTURE, NIL)
     }
 
   public open var frame206_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 206L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_206_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 206L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_206_DELAY_SEC, NIL)
     }
 
   public open var frame206_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 206L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_206_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 206L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_206_TEXTURE, NIL)
     }
 
   public open var frame207_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 207L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_207_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 207L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_207_DELAY_SEC, NIL)
     }
 
   public open var frame207_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 207L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_207_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 207L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_207_TEXTURE, NIL)
     }
 
   public open var frame208_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 208L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_208_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 208L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_208_DELAY_SEC, NIL)
     }
 
   public open var frame208_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 208L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_208_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 208L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_208_TEXTURE, NIL)
     }
 
   public open var frame209_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 209L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_209_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 209L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_209_DELAY_SEC, NIL)
     }
 
   public open var frame209_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 209L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_209_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 209L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_209_TEXTURE, NIL)
     }
 
   public open var frame21_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_21_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 21L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_21_DELAY_SEC, NIL)
     }
 
   public open var frame21_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_21_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 21L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_21_TEXTURE, NIL)
     }
 
   public open var frame210_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 210L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_210_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 210L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_210_DELAY_SEC, NIL)
     }
 
   public open var frame210_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 210L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_210_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 210L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_210_TEXTURE, NIL)
     }
 
   public open var frame211_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 211L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_211_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 211L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_211_DELAY_SEC, NIL)
     }
 
   public open var frame211_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 211L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_211_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 211L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_211_TEXTURE, NIL)
     }
 
   public open var frame212_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 212L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_212_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 212L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_212_DELAY_SEC, NIL)
     }
 
   public open var frame212_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 212L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_212_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 212L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_212_TEXTURE, NIL)
     }
 
   public open var frame213_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 213L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_213_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 213L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_213_DELAY_SEC, NIL)
     }
 
   public open var frame213_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 213L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_213_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 213L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_213_TEXTURE, NIL)
     }
 
   public open var frame214_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 214L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_214_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 214L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_214_DELAY_SEC, NIL)
     }
 
   public open var frame214_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 214L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_214_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 214L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_214_TEXTURE, NIL)
     }
 
   public open var frame215_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 215L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_215_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 215L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_215_DELAY_SEC, NIL)
     }
 
   public open var frame215_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 215L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_215_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 215L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_215_TEXTURE, NIL)
     }
 
   public open var frame216_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 216L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_216_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 216L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_216_DELAY_SEC, NIL)
     }
 
   public open var frame216_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 216L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_216_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 216L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_216_TEXTURE, NIL)
     }
 
   public open var frame217_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 217L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_217_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 217L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_217_DELAY_SEC, NIL)
     }
 
   public open var frame217_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 217L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_217_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 217L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_217_TEXTURE, NIL)
     }
 
   public open var frame218_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 218L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_218_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 218L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_218_DELAY_SEC, NIL)
     }
 
   public open var frame218_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 218L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_218_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 218L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_218_TEXTURE, NIL)
     }
 
   public open var frame219_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 219L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_219_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 219L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_219_DELAY_SEC, NIL)
     }
 
   public open var frame219_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 219L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_219_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 219L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_219_TEXTURE, NIL)
     }
 
   public open var frame22_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 22L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_22_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 22L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_22_DELAY_SEC, NIL)
     }
 
   public open var frame22_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 22L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_22_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 22L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_22_TEXTURE, NIL)
     }
 
   public open var frame220_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 220L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_220_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 220L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_220_DELAY_SEC, NIL)
     }
 
   public open var frame220_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 220L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_220_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 220L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_220_TEXTURE, NIL)
     }
 
   public open var frame221_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 221L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_221_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 221L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_221_DELAY_SEC, NIL)
     }
 
   public open var frame221_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 221L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_221_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 221L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_221_TEXTURE, NIL)
     }
 
   public open var frame222_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 222L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_222_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 222L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_222_DELAY_SEC, NIL)
     }
 
   public open var frame222_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 222L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_222_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 222L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_222_TEXTURE, NIL)
     }
 
   public open var frame223_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 223L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_223_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 223L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_223_DELAY_SEC, NIL)
     }
 
   public open var frame223_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 223L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_223_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 223L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_223_TEXTURE, NIL)
     }
 
   public open var frame224_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 224L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_224_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 224L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_224_DELAY_SEC, NIL)
     }
 
   public open var frame224_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 224L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_224_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 224L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_224_TEXTURE, NIL)
     }
 
   public open var frame225_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 225L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_225_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 225L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_225_DELAY_SEC, NIL)
     }
 
   public open var frame225_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 225L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_225_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 225L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_225_TEXTURE, NIL)
     }
 
   public open var frame226_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 226L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_226_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 226L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_226_DELAY_SEC, NIL)
     }
 
   public open var frame226_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 226L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_226_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 226L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_226_TEXTURE, NIL)
     }
 
   public open var frame227_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 227L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_227_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 227L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_227_DELAY_SEC, NIL)
     }
 
   public open var frame227_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 227L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_227_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 227L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_227_TEXTURE, NIL)
     }
 
   public open var frame228_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 228L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_228_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 228L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_228_DELAY_SEC, NIL)
     }
 
   public open var frame228_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 228L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_228_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 228L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_228_TEXTURE, NIL)
     }
 
   public open var frame229_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 229L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_229_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 229L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_229_DELAY_SEC, NIL)
     }
 
   public open var frame229_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 229L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_229_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 229L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_229_TEXTURE, NIL)
     }
 
   public open var frame23_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 23L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_23_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 23L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_23_DELAY_SEC, NIL)
     }
 
   public open var frame23_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 23L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_23_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 23L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_23_TEXTURE, NIL)
     }
 
   public open var frame230_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 230L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_230_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 230L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_230_DELAY_SEC, NIL)
     }
 
   public open var frame230_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 230L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_230_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 230L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_230_TEXTURE, NIL)
     }
 
   public open var frame231_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 231L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_231_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 231L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_231_DELAY_SEC, NIL)
     }
 
   public open var frame231_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 231L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_231_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 231L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_231_TEXTURE, NIL)
     }
 
   public open var frame232_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 232L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_232_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 232L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_232_DELAY_SEC, NIL)
     }
 
   public open var frame232_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 232L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_232_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 232L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_232_TEXTURE, NIL)
     }
 
   public open var frame233_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 233L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_233_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 233L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_233_DELAY_SEC, NIL)
     }
 
   public open var frame233_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 233L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_233_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 233L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_233_TEXTURE, NIL)
     }
 
   public open var frame234_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 234L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_234_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 234L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_234_DELAY_SEC, NIL)
     }
 
   public open var frame234_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 234L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_234_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 234L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_234_TEXTURE, NIL)
     }
 
   public open var frame235_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 235L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_235_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 235L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_235_DELAY_SEC, NIL)
     }
 
   public open var frame235_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 235L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_235_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 235L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_235_TEXTURE, NIL)
     }
 
   public open var frame236_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 236L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_236_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 236L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_236_DELAY_SEC, NIL)
     }
 
   public open var frame236_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 236L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_236_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 236L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_236_TEXTURE, NIL)
     }
 
   public open var frame237_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 237L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_237_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 237L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_237_DELAY_SEC, NIL)
     }
 
   public open var frame237_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 237L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_237_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 237L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_237_TEXTURE, NIL)
     }
 
   public open var frame238_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 238L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_238_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 238L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_238_DELAY_SEC, NIL)
     }
 
   public open var frame238_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 238L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_238_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 238L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_238_TEXTURE, NIL)
     }
 
   public open var frame239_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 239L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_239_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 239L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_239_DELAY_SEC, NIL)
     }
 
   public open var frame239_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 239L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_239_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 239L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_239_TEXTURE, NIL)
     }
 
   public open var frame24_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 24L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_24_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 24L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_24_DELAY_SEC, NIL)
     }
 
   public open var frame24_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 24L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_24_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 24L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_24_TEXTURE, NIL)
     }
 
   public open var frame240_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 240L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_240_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 240L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_240_DELAY_SEC, NIL)
     }
 
   public open var frame240_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 240L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_240_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 240L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_240_TEXTURE, NIL)
     }
 
   public open var frame241_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 241L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_241_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 241L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_241_DELAY_SEC, NIL)
     }
 
   public open var frame241_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 241L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_241_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 241L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_241_TEXTURE, NIL)
     }
 
   public open var frame242_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 242L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_242_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 242L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_242_DELAY_SEC, NIL)
     }
 
   public open var frame242_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 242L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_242_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 242L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_242_TEXTURE, NIL)
     }
 
   public open var frame243_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 243L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_243_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 243L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_243_DELAY_SEC, NIL)
     }
 
   public open var frame243_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 243L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_243_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 243L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_243_TEXTURE, NIL)
     }
 
   public open var frame244_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 244L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_244_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 244L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_244_DELAY_SEC, NIL)
     }
 
   public open var frame244_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 244L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_244_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 244L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_244_TEXTURE, NIL)
     }
 
   public open var frame245_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 245L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_245_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 245L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_245_DELAY_SEC, NIL)
     }
 
   public open var frame245_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 245L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_245_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 245L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_245_TEXTURE, NIL)
     }
 
   public open var frame246_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 246L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_246_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 246L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_246_DELAY_SEC, NIL)
     }
 
   public open var frame246_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 246L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_246_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 246L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_246_TEXTURE, NIL)
     }
 
   public open var frame247_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 247L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_247_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 247L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_247_DELAY_SEC, NIL)
     }
 
   public open var frame247_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 247L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_247_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 247L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_247_TEXTURE, NIL)
     }
 
   public open var frame248_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 248L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_248_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 248L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_248_DELAY_SEC, NIL)
     }
 
   public open var frame248_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 248L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_248_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 248L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_248_TEXTURE, NIL)
     }
 
   public open var frame249_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 249L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_249_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 249L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_249_DELAY_SEC, NIL)
     }
 
   public open var frame249_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 249L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_249_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 249L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_249_TEXTURE, NIL)
     }
 
   public open var frame25_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 25L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_25_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 25L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_25_DELAY_SEC, NIL)
     }
 
   public open var frame25_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 25L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_25_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 25L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_25_TEXTURE, NIL)
     }
 
   public open var frame250_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 250L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_250_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 250L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_250_DELAY_SEC, NIL)
     }
 
   public open var frame250_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 250L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_250_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 250L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_250_TEXTURE, NIL)
     }
 
   public open var frame251_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 251L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_251_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 251L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_251_DELAY_SEC, NIL)
     }
 
   public open var frame251_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 251L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_251_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 251L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_251_TEXTURE, NIL)
     }
 
   public open var frame252_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 252L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_252_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 252L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_252_DELAY_SEC, NIL)
     }
 
   public open var frame252_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 252L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_252_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 252L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_252_TEXTURE, NIL)
     }
 
   public open var frame253_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 253L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_253_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 253L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_253_DELAY_SEC, NIL)
     }
 
   public open var frame253_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 253L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_253_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 253L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_253_TEXTURE, NIL)
     }
 
   public open var frame254_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 254L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_254_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 254L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_254_DELAY_SEC, NIL)
     }
 
   public open var frame254_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 254L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_254_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 254L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_254_TEXTURE, NIL)
     }
 
   public open var frame255_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 255L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_255_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 255L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_255_DELAY_SEC, NIL)
     }
 
   public open var frame255_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 255L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_255_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 255L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_255_TEXTURE, NIL)
     }
 
   public open var frame26_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 26L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_26_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 26L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_26_DELAY_SEC, NIL)
     }
 
   public open var frame26_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 26L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_26_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 26L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_26_TEXTURE, NIL)
     }
 
   public open var frame27_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 27L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_27_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 27L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_27_DELAY_SEC, NIL)
     }
 
   public open var frame27_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 27L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_27_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 27L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_27_TEXTURE, NIL)
     }
 
   public open var frame28_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 28L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_28_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 28L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_28_DELAY_SEC, NIL)
     }
 
   public open var frame28_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 28L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_28_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 28L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_28_TEXTURE, NIL)
     }
 
   public open var frame29_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 29L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_29_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 29L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_29_DELAY_SEC, NIL)
     }
 
   public open var frame29_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 29L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_29_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 29L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_29_TEXTURE, NIL)
     }
 
   public open var frame3_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_3_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_3_DELAY_SEC, NIL)
     }
 
   public open var frame3_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_3_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 3L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_3_TEXTURE, NIL)
     }
 
   public open var frame30_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 30L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_30_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 30L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_30_DELAY_SEC, NIL)
     }
 
   public open var frame30_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 30L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_30_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 30L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_30_TEXTURE, NIL)
     }
 
   public open var frame31_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 31L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_31_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 31L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_31_DELAY_SEC, NIL)
     }
 
   public open var frame31_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 31L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_31_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 31L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_31_TEXTURE, NIL)
     }
 
   public open var frame32_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 32L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_32_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 32L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_32_DELAY_SEC, NIL)
     }
 
   public open var frame32_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 32L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_32_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 32L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_32_TEXTURE, NIL)
     }
 
   public open var frame33_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 33L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_33_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 33L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_33_DELAY_SEC, NIL)
     }
 
   public open var frame33_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 33L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_33_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 33L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_33_TEXTURE, NIL)
     }
 
   public open var frame34_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 34L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_34_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 34L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_34_DELAY_SEC, NIL)
     }
 
   public open var frame34_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 34L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_34_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 34L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_34_TEXTURE, NIL)
     }
 
   public open var frame35_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 35L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_35_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 35L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_35_DELAY_SEC, NIL)
     }
 
   public open var frame35_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 35L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_35_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 35L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_35_TEXTURE, NIL)
     }
 
   public open var frame36_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 36L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_36_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 36L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_36_DELAY_SEC, NIL)
     }
 
   public open var frame36_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 36L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_36_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 36L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_36_TEXTURE, NIL)
     }
 
   public open var frame37_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 37L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_37_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 37L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_37_DELAY_SEC, NIL)
     }
 
   public open var frame37_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 37L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_37_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 37L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_37_TEXTURE, NIL)
     }
 
   public open var frame38_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 38L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_38_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 38L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_38_DELAY_SEC, NIL)
     }
 
   public open var frame38_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 38L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_38_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 38L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_38_TEXTURE, NIL)
     }
 
   public open var frame39_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 39L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_39_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 39L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_39_DELAY_SEC, NIL)
     }
 
   public open var frame39_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 39L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_39_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 39L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_39_TEXTURE, NIL)
     }
 
   public open var frame4_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_4_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_4_DELAY_SEC, NIL)
     }
 
   public open var frame4_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_4_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 4L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_4_TEXTURE, NIL)
     }
 
   public open var frame40_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 40L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_40_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 40L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_40_DELAY_SEC, NIL)
     }
 
   public open var frame40_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 40L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_40_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 40L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_40_TEXTURE, NIL)
     }
 
   public open var frame41_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 41L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_41_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 41L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_41_DELAY_SEC, NIL)
     }
 
   public open var frame41_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 41L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_41_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 41L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_41_TEXTURE, NIL)
     }
 
   public open var frame42_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 42L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_42_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 42L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_42_DELAY_SEC, NIL)
     }
 
   public open var frame42_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 42L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_42_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 42L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_42_TEXTURE, NIL)
     }
 
   public open var frame43_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 43L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_43_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 43L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_43_DELAY_SEC, NIL)
     }
 
   public open var frame43_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 43L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_43_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 43L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_43_TEXTURE, NIL)
     }
 
   public open var frame44_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 44L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_44_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 44L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_44_DELAY_SEC, NIL)
     }
 
   public open var frame44_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 44L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_44_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 44L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_44_TEXTURE, NIL)
     }
 
   public open var frame45_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 45L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_45_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 45L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_45_DELAY_SEC, NIL)
     }
 
   public open var frame45_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 45L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_45_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 45L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_45_TEXTURE, NIL)
     }
 
   public open var frame46_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 46L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_46_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 46L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_46_DELAY_SEC, NIL)
     }
 
   public open var frame46_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 46L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_46_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 46L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_46_TEXTURE, NIL)
     }
 
   public open var frame47_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 47L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_47_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 47L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_47_DELAY_SEC, NIL)
     }
 
   public open var frame47_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 47L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_47_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 47L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_47_TEXTURE, NIL)
     }
 
   public open var frame48_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 48L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_48_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 48L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_48_DELAY_SEC, NIL)
     }
 
   public open var frame48_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 48L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_48_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 48L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_48_TEXTURE, NIL)
     }
 
   public open var frame49_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 49L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_49_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 49L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_49_DELAY_SEC, NIL)
     }
 
   public open var frame49_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 49L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_49_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 49L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_49_TEXTURE, NIL)
     }
 
   public open var frame5_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_5_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_5_DELAY_SEC, NIL)
     }
 
   public open var frame5_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_5_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 5L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_5_TEXTURE, NIL)
     }
 
   public open var frame50_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 50L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_50_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 50L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_50_DELAY_SEC, NIL)
     }
 
   public open var frame50_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 50L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_50_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 50L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_50_TEXTURE, NIL)
     }
 
   public open var frame51_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 51L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_51_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 51L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_51_DELAY_SEC, NIL)
     }
 
   public open var frame51_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 51L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_51_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 51L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_51_TEXTURE, NIL)
     }
 
   public open var frame52_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 52L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_52_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 52L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_52_DELAY_SEC, NIL)
     }
 
   public open var frame52_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 52L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_52_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 52L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_52_TEXTURE, NIL)
     }
 
   public open var frame53_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 53L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_53_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 53L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_53_DELAY_SEC, NIL)
     }
 
   public open var frame53_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 53L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_53_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 53L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_53_TEXTURE, NIL)
     }
 
   public open var frame54_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 54L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_54_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 54L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_54_DELAY_SEC, NIL)
     }
 
   public open var frame54_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 54L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_54_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 54L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_54_TEXTURE, NIL)
     }
 
   public open var frame55_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 55L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_55_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 55L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_55_DELAY_SEC, NIL)
     }
 
   public open var frame55_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 55L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_55_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 55L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_55_TEXTURE, NIL)
     }
 
   public open var frame56_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 56L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_56_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 56L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_56_DELAY_SEC, NIL)
     }
 
   public open var frame56_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 56L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_56_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 56L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_56_TEXTURE, NIL)
     }
 
   public open var frame57_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 57L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_57_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 57L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_57_DELAY_SEC, NIL)
     }
 
   public open var frame57_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 57L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_57_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 57L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_57_TEXTURE, NIL)
     }
 
   public open var frame58_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 58L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_58_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 58L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_58_DELAY_SEC, NIL)
     }
 
   public open var frame58_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 58L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_58_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 58L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_58_TEXTURE, NIL)
     }
 
   public open var frame59_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 59L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_59_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 59L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_59_DELAY_SEC, NIL)
     }
 
   public open var frame59_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 59L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_59_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 59L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_59_TEXTURE, NIL)
     }
 
   public open var frame6_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_6_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_6_DELAY_SEC, NIL)
     }
 
   public open var frame6_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_6_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 6L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_6_TEXTURE, NIL)
     }
 
   public open var frame60_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 60L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_60_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 60L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_60_DELAY_SEC, NIL)
     }
 
   public open var frame60_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 60L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_60_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 60L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_60_TEXTURE, NIL)
     }
 
   public open var frame61_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 61L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_61_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 61L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_61_DELAY_SEC, NIL)
     }
 
   public open var frame61_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 61L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_61_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 61L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_61_TEXTURE, NIL)
     }
 
   public open var frame62_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 62L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_62_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 62L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_62_DELAY_SEC, NIL)
     }
 
   public open var frame62_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 62L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_62_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 62L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_62_TEXTURE, NIL)
     }
 
   public open var frame63_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 63L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_63_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 63L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_63_DELAY_SEC, NIL)
     }
 
   public open var frame63_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 63L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_63_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 63L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_63_TEXTURE, NIL)
     }
 
   public open var frame64_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 64L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_64_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 64L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_64_DELAY_SEC, NIL)
     }
 
   public open var frame64_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 64L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_64_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 64L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_64_TEXTURE, NIL)
     }
 
   public open var frame65_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 65L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_65_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 65L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_65_DELAY_SEC, NIL)
     }
 
   public open var frame65_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 65L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_65_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 65L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_65_TEXTURE, NIL)
     }
 
   public open var frame66_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 66L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_66_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 66L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_66_DELAY_SEC, NIL)
     }
 
   public open var frame66_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 66L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_66_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 66L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_66_TEXTURE, NIL)
     }
 
   public open var frame67_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 67L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_67_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 67L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_67_DELAY_SEC, NIL)
     }
 
   public open var frame67_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 67L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_67_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 67L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_67_TEXTURE, NIL)
     }
 
   public open var frame68_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 68L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_68_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 68L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_68_DELAY_SEC, NIL)
     }
 
   public open var frame68_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 68L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_68_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 68L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_68_TEXTURE, NIL)
     }
 
   public open var frame69_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 69L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_69_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 69L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_69_DELAY_SEC, NIL)
     }
 
   public open var frame69_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 69L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_69_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 69L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_69_TEXTURE, NIL)
     }
 
   public open var frame7_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_7_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_7_DELAY_SEC, NIL)
     }
 
   public open var frame7_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_7_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 7L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_7_TEXTURE, NIL)
     }
 
   public open var frame70_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 70L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_70_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 70L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_70_DELAY_SEC, NIL)
     }
 
   public open var frame70_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 70L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_70_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 70L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_70_TEXTURE, NIL)
     }
 
   public open var frame71_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 71L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_71_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 71L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_71_DELAY_SEC, NIL)
     }
 
   public open var frame71_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 71L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_71_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 71L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_71_TEXTURE, NIL)
     }
 
   public open var frame72_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 72L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_72_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 72L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_72_DELAY_SEC, NIL)
     }
 
   public open var frame72_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 72L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_72_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 72L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_72_TEXTURE, NIL)
     }
 
   public open var frame73_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 73L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_73_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 73L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_73_DELAY_SEC, NIL)
     }
 
   public open var frame73_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 73L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_73_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 73L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_73_TEXTURE, NIL)
     }
 
   public open var frame74_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 74L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_74_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 74L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_74_DELAY_SEC, NIL)
     }
 
   public open var frame74_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 74L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_74_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 74L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_74_TEXTURE, NIL)
     }
 
   public open var frame75_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 75L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_75_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 75L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_75_DELAY_SEC, NIL)
     }
 
   public open var frame75_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 75L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_75_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 75L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_75_TEXTURE, NIL)
     }
 
   public open var frame76_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 76L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_76_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 76L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_76_DELAY_SEC, NIL)
     }
 
   public open var frame76_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 76L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_76_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 76L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_76_TEXTURE, NIL)
     }
 
   public open var frame77_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 77L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_77_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 77L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_77_DELAY_SEC, NIL)
     }
 
   public open var frame77_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 77L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_77_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 77L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_77_TEXTURE, NIL)
     }
 
   public open var frame78_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 78L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_78_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 78L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_78_DELAY_SEC, NIL)
     }
 
   public open var frame78_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 78L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_78_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 78L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_78_TEXTURE, NIL)
     }
 
   public open var frame79_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 79L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_79_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 79L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_79_DELAY_SEC, NIL)
     }
 
   public open var frame79_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 79L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_79_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 79L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_79_TEXTURE, NIL)
     }
 
   public open var frame8_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_8_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_8_DELAY_SEC, NIL)
     }
 
   public open var frame8_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_8_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 8L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_8_TEXTURE, NIL)
     }
 
   public open var frame80_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 80L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_80_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 80L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_80_DELAY_SEC, NIL)
     }
 
   public open var frame80_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 80L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_80_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 80L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_80_TEXTURE, NIL)
     }
 
   public open var frame81_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 81L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_81_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 81L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_81_DELAY_SEC, NIL)
     }
 
   public open var frame81_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 81L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_81_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 81L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_81_TEXTURE, NIL)
     }
 
   public open var frame82_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 82L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_82_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 82L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_82_DELAY_SEC, NIL)
     }
 
   public open var frame82_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 82L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_82_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 82L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_82_TEXTURE, NIL)
     }
 
   public open var frame83_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 83L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_83_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 83L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_83_DELAY_SEC, NIL)
     }
 
   public open var frame83_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 83L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_83_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 83L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_83_TEXTURE, NIL)
     }
 
   public open var frame84_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 84L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_84_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 84L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_84_DELAY_SEC, NIL)
     }
 
   public open var frame84_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 84L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_84_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 84L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_84_TEXTURE, NIL)
     }
 
   public open var frame85_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 85L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_85_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 85L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_85_DELAY_SEC, NIL)
     }
 
   public open var frame85_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 85L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_85_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 85L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_85_TEXTURE, NIL)
     }
 
   public open var frame86_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 86L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_86_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 86L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_86_DELAY_SEC, NIL)
     }
 
   public open var frame86_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 86L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_86_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 86L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_86_TEXTURE, NIL)
     }
 
   public open var frame87_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 87L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_87_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 87L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_87_DELAY_SEC, NIL)
     }
 
   public open var frame87_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 87L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_87_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 87L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_87_TEXTURE, NIL)
     }
 
   public open var frame88_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 88L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_88_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 88L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_88_DELAY_SEC, NIL)
     }
 
   public open var frame88_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 88L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_88_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 88L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_88_TEXTURE, NIL)
     }
 
   public open var frame89_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 89L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_89_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 89L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_89_DELAY_SEC, NIL)
     }
 
   public open var frame89_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 89L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_89_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 89L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_89_TEXTURE, NIL)
     }
 
   public open var frame9_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_9_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_9_DELAY_SEC, NIL)
     }
 
   public open var frame9_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_9_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 9L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_9_TEXTURE, NIL)
     }
 
   public open var frame90_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 90L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_90_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 90L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_90_DELAY_SEC, NIL)
     }
 
   public open var frame90_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 90L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_90_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 90L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_90_TEXTURE, NIL)
     }
 
   public open var frame91_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 91L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_91_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 91L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_91_DELAY_SEC, NIL)
     }
 
   public open var frame91_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 91L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_91_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 91L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_91_TEXTURE, NIL)
     }
 
   public open var frame92_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 92L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_92_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 92L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_92_DELAY_SEC, NIL)
     }
 
   public open var frame92_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 92L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_92_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 92L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_92_TEXTURE, NIL)
     }
 
   public open var frame93_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 93L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_93_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 93L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_93_DELAY_SEC, NIL)
     }
 
   public open var frame93_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 93L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_93_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 93L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_93_TEXTURE, NIL)
     }
 
   public open var frame94_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 94L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_94_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 94L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_94_DELAY_SEC, NIL)
     }
 
   public open var frame94_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 94L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_94_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 94L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_94_TEXTURE, NIL)
     }
 
   public open var frame95_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 95L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_95_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 95L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_95_DELAY_SEC, NIL)
     }
 
   public open var frame95_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 95L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_95_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 95L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_95_TEXTURE, NIL)
     }
 
   public open var frame96_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 96L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_96_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 96L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_96_DELAY_SEC, NIL)
     }
 
   public open var frame96_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 96L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_96_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 96L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_96_TEXTURE, NIL)
     }
 
   public open var frame97_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 97L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_97_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 97L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_97_DELAY_SEC, NIL)
     }
 
   public open var frame97_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 97L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_97_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 97L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_97_TEXTURE, NIL)
     }
 
   public open var frame98_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 98L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_98_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 98L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_98_DELAY_SEC, NIL)
     }
 
   public open var frame98_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 98L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_98_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 98L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_98_TEXTURE, NIL)
     }
 
   public open var frame99_delaySec: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 99L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_99_DELAY_SEC, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 99L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_99_DELAY_SEC, NIL)
     }
 
   public open var frame99_texture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 99L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_GET_FRAME_99_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 99L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATEDTEXTURE_SET_FRAME_99_TEXTURE, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimationNodeBlendSpace1D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimationNodeBlendSpace1D.kt
@@ -36,7 +36,7 @@ import kotlin.Unit
 public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
   public open val blendPoint0_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_0_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -44,20 +44,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint0_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_0_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_0_POS, NIL)
     }
 
   public open val blendPoint1_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_1_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -65,20 +65,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint1_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_1_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_1_POS, NIL)
     }
 
   public open val blendPoint10_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_10_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -86,20 +86,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint10_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_10_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 10L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_10_POS, NIL)
     }
 
   public open val blendPoint11_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_11_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -107,20 +107,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint11_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_11_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 11L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_11_POS, NIL)
     }
 
   public open val blendPoint12_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_12_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -128,20 +128,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint12_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_12_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 12L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_12_POS, NIL)
     }
 
   public open val blendPoint13_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_13_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -149,20 +149,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint13_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_13_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 13L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_13_POS, NIL)
     }
 
   public open val blendPoint14_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_14_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -170,20 +170,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint14_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_14_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 14L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_14_POS, NIL)
     }
 
   public open val blendPoint15_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_15_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -191,20 +191,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint15_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_15_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 15L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_15_POS, NIL)
     }
 
   public open val blendPoint16_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_16_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -212,20 +212,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint16_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_16_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 16L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_16_POS, NIL)
     }
 
   public open val blendPoint17_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_17_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -233,20 +233,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint17_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_17_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 17L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_17_POS, NIL)
     }
 
   public open val blendPoint18_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_18_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -254,20 +254,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint18_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_18_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 18L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_18_POS, NIL)
     }
 
   public open val blendPoint19_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_19_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -275,20 +275,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint19_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_19_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 19L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_19_POS, NIL)
     }
 
   public open val blendPoint2_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_2_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -296,20 +296,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint2_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_2_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_2_POS, NIL)
     }
 
   public open val blendPoint20_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_20_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -317,20 +317,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint20_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_20_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 20L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_20_POS, NIL)
     }
 
   public open val blendPoint21_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_21_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -338,20 +338,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint21_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_21_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 21L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_21_POS, NIL)
     }
 
   public open val blendPoint22_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 22L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_22_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -359,20 +359,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint22_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 22L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_22_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 22L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_22_POS, NIL)
     }
 
   public open val blendPoint23_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 23L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_23_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -380,20 +380,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint23_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 23L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_23_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 23L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_23_POS, NIL)
     }
 
   public open val blendPoint24_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 24L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_24_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -401,20 +401,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint24_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 24L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_24_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 24L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_24_POS, NIL)
     }
 
   public open val blendPoint25_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 25L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_25_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -422,20 +422,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint25_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 25L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_25_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 25L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_25_POS, NIL)
     }
 
   public open val blendPoint26_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 26L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_26_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -443,20 +443,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint26_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 26L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_26_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 26L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_26_POS, NIL)
     }
 
   public open val blendPoint27_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 27L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_27_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -464,20 +464,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint27_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 27L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_27_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 27L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_27_POS, NIL)
     }
 
   public open val blendPoint28_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 28L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_28_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -485,20 +485,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint28_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 28L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_28_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 28L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_28_POS, NIL)
     }
 
   public open val blendPoint29_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 29L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_29_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -506,20 +506,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint29_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 29L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_29_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 29L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_29_POS, NIL)
     }
 
   public open val blendPoint3_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_3_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -527,20 +527,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint3_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_3_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_3_POS, NIL)
     }
 
   public open val blendPoint30_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 30L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_30_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -548,20 +548,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint30_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 30L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_30_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 30L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_30_POS, NIL)
     }
 
   public open val blendPoint31_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 31L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_31_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -569,20 +569,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint31_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 31L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_31_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 31L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_31_POS, NIL)
     }
 
   public open val blendPoint32_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 32L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_32_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -590,20 +590,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint32_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 32L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_32_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 32L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_32_POS, NIL)
     }
 
   public open val blendPoint33_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 33L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_33_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -611,20 +611,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint33_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 33L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_33_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 33L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_33_POS, NIL)
     }
 
   public open val blendPoint34_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 34L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_34_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -632,20 +632,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint34_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 34L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_34_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 34L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_34_POS, NIL)
     }
 
   public open val blendPoint35_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 35L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_35_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -653,20 +653,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint35_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 35L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_35_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 35L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_35_POS, NIL)
     }
 
   public open val blendPoint36_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 36L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_36_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -674,20 +674,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint36_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 36L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_36_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 36L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_36_POS, NIL)
     }
 
   public open val blendPoint37_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 37L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_37_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -695,20 +695,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint37_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 37L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_37_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 37L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_37_POS, NIL)
     }
 
   public open val blendPoint38_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 38L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_38_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -716,20 +716,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint38_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 38L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_38_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 38L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_38_POS, NIL)
     }
 
   public open val blendPoint39_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 39L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_39_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -737,20 +737,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint39_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 39L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_39_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 39L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_39_POS, NIL)
     }
 
   public open val blendPoint4_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_4_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -758,20 +758,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint4_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_4_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_4_POS, NIL)
     }
 
   public open val blendPoint40_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 40L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_40_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -779,20 +779,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint40_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 40L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_40_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 40L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_40_POS, NIL)
     }
 
   public open val blendPoint41_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 41L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_41_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -800,20 +800,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint41_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 41L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_41_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 41L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_41_POS, NIL)
     }
 
   public open val blendPoint42_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 42L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_42_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -821,20 +821,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint42_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 42L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_42_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 42L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_42_POS, NIL)
     }
 
   public open val blendPoint43_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 43L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_43_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -842,20 +842,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint43_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 43L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_43_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 43L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_43_POS, NIL)
     }
 
   public open val blendPoint44_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 44L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_44_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -863,20 +863,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint44_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 44L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_44_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 44L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_44_POS, NIL)
     }
 
   public open val blendPoint45_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 45L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_45_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -884,20 +884,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint45_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 45L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_45_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 45L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_45_POS, NIL)
     }
 
   public open val blendPoint46_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 46L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_46_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -905,20 +905,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint46_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 46L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_46_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 46L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_46_POS, NIL)
     }
 
   public open val blendPoint47_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 47L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_47_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -926,20 +926,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint47_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 47L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_47_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 47L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_47_POS, NIL)
     }
 
   public open val blendPoint48_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 48L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_48_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -947,20 +947,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint48_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 48L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_48_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 48L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_48_POS, NIL)
     }
 
   public open val blendPoint49_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 49L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_49_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -968,20 +968,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint49_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 49L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_49_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 49L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_49_POS, NIL)
     }
 
   public open val blendPoint5_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_5_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -989,20 +989,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint5_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_5_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_5_POS, NIL)
     }
 
   public open val blendPoint50_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 50L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_50_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1010,20 +1010,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint50_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 50L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_50_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 50L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_50_POS, NIL)
     }
 
   public open val blendPoint51_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 51L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_51_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1031,20 +1031,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint51_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 51L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_51_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 51L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_51_POS, NIL)
     }
 
   public open val blendPoint52_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 52L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_52_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1052,20 +1052,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint52_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 52L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_52_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 52L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_52_POS, NIL)
     }
 
   public open val blendPoint53_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 53L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_53_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1073,20 +1073,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint53_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 53L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_53_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 53L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_53_POS, NIL)
     }
 
   public open val blendPoint54_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 54L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_54_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1094,20 +1094,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint54_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 54L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_54_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 54L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_54_POS, NIL)
     }
 
   public open val blendPoint55_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 55L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_55_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1115,20 +1115,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint55_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 55L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_55_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 55L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_55_POS, NIL)
     }
 
   public open val blendPoint56_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 56L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_56_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1136,20 +1136,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint56_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 56L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_56_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 56L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_56_POS, NIL)
     }
 
   public open val blendPoint57_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 57L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_57_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1157,20 +1157,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint57_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 57L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_57_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 57L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_57_POS, NIL)
     }
 
   public open val blendPoint58_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 58L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_58_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1178,20 +1178,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint58_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 58L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_58_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 58L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_58_POS, NIL)
     }
 
   public open val blendPoint59_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 59L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_59_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1199,20 +1199,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint59_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 59L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_59_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 59L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_59_POS, NIL)
     }
 
   public open val blendPoint6_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_6_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1220,20 +1220,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint6_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_6_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_6_POS, NIL)
     }
 
   public open val blendPoint60_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 60L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_60_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1241,20 +1241,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint60_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 60L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_60_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 60L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_60_POS, NIL)
     }
 
   public open val blendPoint61_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 61L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_61_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1262,20 +1262,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint61_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 61L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_61_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 61L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_61_POS, NIL)
     }
 
   public open val blendPoint62_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 62L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_62_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1283,20 +1283,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint62_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 62L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_62_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 62L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_62_POS, NIL)
     }
 
   public open val blendPoint63_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 63L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_63_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1304,20 +1304,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint63_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 63L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_63_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 63L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_63_POS, NIL)
     }
 
   public open val blendPoint7_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_7_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1325,20 +1325,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint7_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_7_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_7_POS, NIL)
     }
 
   public open val blendPoint8_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_8_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1346,20 +1346,20 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint8_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_8_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_8_POS, NIL)
     }
 
   public open val blendPoint9_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_9_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1367,13 +1367,13 @@ public open class AnimationNodeBlendSpace1D : AnimationRootNode() {
 
   public open var blendPoint9_pos: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_GET_BLEND_POINT_9_POS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE1D_SET_BLEND_POINT_9_POS, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimationNodeBlendSpace2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimationNodeBlendSpace2D.kt
@@ -78,7 +78,7 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open val blendPoint0_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_0_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -86,20 +86,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint0_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_0_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 0L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_0_POS, NIL)
     }
 
   public open val blendPoint1_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_1_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -107,20 +107,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint1_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_1_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 1L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_1_POS, NIL)
     }
 
   public open val blendPoint10_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_10_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -128,20 +128,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint10_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_10_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 10L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_10_POS, NIL)
     }
 
   public open val blendPoint11_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_11_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -149,20 +149,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint11_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_11_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 11L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_11_POS, NIL)
     }
 
   public open val blendPoint12_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_12_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -170,20 +170,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint12_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_12_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 12L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_12_POS, NIL)
     }
 
   public open val blendPoint13_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_13_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -191,20 +191,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint13_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_13_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 13L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_13_POS, NIL)
     }
 
   public open val blendPoint14_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_14_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -212,20 +212,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint14_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_14_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 14L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_14_POS, NIL)
     }
 
   public open val blendPoint15_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_15_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -233,20 +233,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint15_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_15_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 15L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_15_POS, NIL)
     }
 
   public open val blendPoint16_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_16_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -254,20 +254,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint16_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_16_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 16L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_16_POS, NIL)
     }
 
   public open val blendPoint17_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_17_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -275,20 +275,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint17_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_17_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 17L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_17_POS, NIL)
     }
 
   public open val blendPoint18_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_18_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -296,20 +296,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint18_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_18_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 18L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_18_POS, NIL)
     }
 
   public open val blendPoint19_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_19_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -317,20 +317,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint19_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_19_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 19L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_19_POS, NIL)
     }
 
   public open val blendPoint2_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_2_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -338,20 +338,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint2_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_2_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 2L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_2_POS, NIL)
     }
 
   public open val blendPoint20_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_20_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -359,20 +359,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint20_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_20_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 20L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_20_POS, NIL)
     }
 
   public open val blendPoint21_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_21_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -380,20 +380,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint21_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_21_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 21L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_21_POS, NIL)
     }
 
   public open val blendPoint22_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 22L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_22_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -401,20 +401,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint22_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 22L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_22_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 22L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_22_POS, NIL)
     }
 
   public open val blendPoint23_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 23L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_23_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -422,20 +422,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint23_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 23L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_23_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 23L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_23_POS, NIL)
     }
 
   public open val blendPoint24_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 24L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_24_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -443,20 +443,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint24_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 24L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_24_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 24L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_24_POS, NIL)
     }
 
   public open val blendPoint25_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 25L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_25_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -464,20 +464,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint25_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 25L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_25_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 25L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_25_POS, NIL)
     }
 
   public open val blendPoint26_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 26L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_26_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -485,20 +485,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint26_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 26L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_26_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 26L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_26_POS, NIL)
     }
 
   public open val blendPoint27_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 27L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_27_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -506,20 +506,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint27_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 27L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_27_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 27L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_27_POS, NIL)
     }
 
   public open val blendPoint28_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 28L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_28_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -527,20 +527,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint28_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 28L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_28_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 28L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_28_POS, NIL)
     }
 
   public open val blendPoint29_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 29L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_29_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -548,20 +548,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint29_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 29L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_29_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 29L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_29_POS, NIL)
     }
 
   public open val blendPoint3_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_3_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -569,20 +569,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint3_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_3_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 3L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_3_POS, NIL)
     }
 
   public open val blendPoint30_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 30L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_30_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -590,20 +590,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint30_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 30L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_30_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 30L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_30_POS, NIL)
     }
 
   public open val blendPoint31_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 31L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_31_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -611,20 +611,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint31_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 31L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_31_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 31L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_31_POS, NIL)
     }
 
   public open val blendPoint32_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 32L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_32_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -632,20 +632,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint32_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 32L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_32_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 32L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_32_POS, NIL)
     }
 
   public open val blendPoint33_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 33L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_33_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -653,20 +653,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint33_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 33L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_33_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 33L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_33_POS, NIL)
     }
 
   public open val blendPoint34_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 34L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_34_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -674,20 +674,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint34_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 34L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_34_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 34L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_34_POS, NIL)
     }
 
   public open val blendPoint35_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 35L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_35_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -695,20 +695,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint35_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 35L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_35_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 35L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_35_POS, NIL)
     }
 
   public open val blendPoint36_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 36L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_36_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -716,20 +716,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint36_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 36L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_36_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 36L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_36_POS, NIL)
     }
 
   public open val blendPoint37_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 37L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_37_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -737,20 +737,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint37_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 37L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_37_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 37L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_37_POS, NIL)
     }
 
   public open val blendPoint38_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 38L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_38_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -758,20 +758,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint38_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 38L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_38_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 38L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_38_POS, NIL)
     }
 
   public open val blendPoint39_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 39L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_39_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -779,20 +779,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint39_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 39L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_39_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 39L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_39_POS, NIL)
     }
 
   public open val blendPoint4_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_4_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -800,20 +800,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint4_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_4_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 4L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_4_POS, NIL)
     }
 
   public open val blendPoint40_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 40L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_40_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -821,20 +821,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint40_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 40L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_40_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 40L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_40_POS, NIL)
     }
 
   public open val blendPoint41_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 41L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_41_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -842,20 +842,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint41_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 41L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_41_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 41L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_41_POS, NIL)
     }
 
   public open val blendPoint42_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 42L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_42_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -863,20 +863,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint42_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 42L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_42_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 42L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_42_POS, NIL)
     }
 
   public open val blendPoint43_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 43L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_43_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -884,20 +884,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint43_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 43L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_43_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 43L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_43_POS, NIL)
     }
 
   public open val blendPoint44_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 44L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_44_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -905,20 +905,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint44_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 44L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_44_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 44L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_44_POS, NIL)
     }
 
   public open val blendPoint45_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 45L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_45_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -926,20 +926,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint45_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 45L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_45_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 45L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_45_POS, NIL)
     }
 
   public open val blendPoint46_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 46L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_46_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -947,20 +947,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint46_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 46L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_46_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 46L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_46_POS, NIL)
     }
 
   public open val blendPoint47_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 47L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_47_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -968,20 +968,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint47_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 47L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_47_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 47L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_47_POS, NIL)
     }
 
   public open val blendPoint48_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 48L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_48_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -989,20 +989,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint48_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 48L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_48_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 48L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_48_POS, NIL)
     }
 
   public open val blendPoint49_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 49L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_49_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1010,20 +1010,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint49_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 49L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_49_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 49L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_49_POS, NIL)
     }
 
   public open val blendPoint5_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_5_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1031,20 +1031,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint5_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_5_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 5L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_5_POS, NIL)
     }
 
   public open val blendPoint50_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 50L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_50_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1052,20 +1052,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint50_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 50L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_50_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 50L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_50_POS, NIL)
     }
 
   public open val blendPoint51_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 51L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_51_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1073,20 +1073,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint51_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 51L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_51_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 51L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_51_POS, NIL)
     }
 
   public open val blendPoint52_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 52L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_52_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1094,20 +1094,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint52_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 52L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_52_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 52L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_52_POS, NIL)
     }
 
   public open val blendPoint53_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 53L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_53_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1115,20 +1115,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint53_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 53L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_53_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 53L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_53_POS, NIL)
     }
 
   public open val blendPoint54_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 54L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_54_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1136,20 +1136,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint54_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 54L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_54_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 54L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_54_POS, NIL)
     }
 
   public open val blendPoint55_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 55L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_55_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1157,20 +1157,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint55_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 55L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_55_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 55L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_55_POS, NIL)
     }
 
   public open val blendPoint56_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 56L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_56_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1178,20 +1178,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint56_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 56L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_56_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 56L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_56_POS, NIL)
     }
 
   public open val blendPoint57_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 57L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_57_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1199,20 +1199,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint57_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 57L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_57_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 57L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_57_POS, NIL)
     }
 
   public open val blendPoint58_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 58L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_58_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1220,20 +1220,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint58_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 58L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_58_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 58L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_58_POS, NIL)
     }
 
   public open val blendPoint59_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 59L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_59_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1241,20 +1241,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint59_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 59L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_59_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 59L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_59_POS, NIL)
     }
 
   public open val blendPoint6_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_6_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1262,20 +1262,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint6_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_6_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 6L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_6_POS, NIL)
     }
 
   public open val blendPoint60_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 60L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_60_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1283,20 +1283,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint60_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 60L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_60_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 60L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_60_POS, NIL)
     }
 
   public open val blendPoint61_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 61L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_61_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1304,20 +1304,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint61_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 61L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_61_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 61L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_61_POS, NIL)
     }
 
   public open val blendPoint62_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 62L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_62_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1325,20 +1325,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint62_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 62L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_62_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 62L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_62_POS, NIL)
     }
 
   public open val blendPoint63_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 63L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_63_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1346,20 +1346,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint63_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 63L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_63_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 63L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_63_POS, NIL)
     }
 
   public open val blendPoint7_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_7_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1367,20 +1367,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint7_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_7_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 7L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_7_POS, NIL)
     }
 
   public open val blendPoint8_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_8_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1388,20 +1388,20 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint8_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_8_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 8L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_8_POS, NIL)
     }
 
   public open val blendPoint9_node: AnimationRootNode?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_9_NODE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as AnimationRootNode?
@@ -1409,13 +1409,13 @@ public open class AnimationNodeBlendSpace2D : AnimationRootNode() {
 
   public open var blendPoint9_pos: Vector2
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_GET_BLEND_POINT_9_POS, VECTOR2)
       return TransferContext.readReturnValue(VECTOR2, false) as Vector2
     }
     set(`value`) {
-      TransferContext.writeArguments(VECTOR2 to value)
+      TransferContext.writeArguments(LONG to 9L, VECTOR2 to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODEBLENDSPACE2D_SET_BLEND_POINT_9_POS, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimationNodeTransition.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimationNodeTransition.kt
@@ -31,832 +31,832 @@ import kotlin.Unit
 public open class AnimationNodeTransition : AnimationNode() {
   public open var input0_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_0_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_0_AUTO_ADVANCE, NIL)
     }
 
   public open var input0_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_0_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 0L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_0_NAME, NIL)
     }
 
   public open var input1_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_1_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_1_AUTO_ADVANCE, NIL)
     }
 
   public open var input1_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_1_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 1L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_1_NAME, NIL)
     }
 
   public open var input10_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_10_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 10L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_10_AUTO_ADVANCE, NIL)
     }
 
   public open var input10_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_10_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 10L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_10_NAME, NIL)
     }
 
   public open var input11_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_11_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 11L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_11_AUTO_ADVANCE, NIL)
     }
 
   public open var input11_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_11_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 11L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_11_NAME, NIL)
     }
 
   public open var input12_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_12_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 12L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_12_AUTO_ADVANCE, NIL)
     }
 
   public open var input12_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_12_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 12L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_12_NAME, NIL)
     }
 
   public open var input13_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_13_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 13L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_13_AUTO_ADVANCE, NIL)
     }
 
   public open var input13_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_13_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 13L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_13_NAME, NIL)
     }
 
   public open var input14_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_14_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 14L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_14_AUTO_ADVANCE, NIL)
     }
 
   public open var input14_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_14_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 14L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_14_NAME, NIL)
     }
 
   public open var input15_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_15_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 15L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_15_AUTO_ADVANCE, NIL)
     }
 
   public open var input15_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_15_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 15L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_15_NAME, NIL)
     }
 
   public open var input16_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_16_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 16L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_16_AUTO_ADVANCE, NIL)
     }
 
   public open var input16_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_16_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 16L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_16_NAME, NIL)
     }
 
   public open var input17_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_17_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 17L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_17_AUTO_ADVANCE, NIL)
     }
 
   public open var input17_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_17_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 17L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_17_NAME, NIL)
     }
 
   public open var input18_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_18_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 18L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_18_AUTO_ADVANCE, NIL)
     }
 
   public open var input18_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_18_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 18L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_18_NAME, NIL)
     }
 
   public open var input19_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_19_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 19L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_19_AUTO_ADVANCE, NIL)
     }
 
   public open var input19_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_19_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 19L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_19_NAME, NIL)
     }
 
   public open var input2_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_2_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_2_AUTO_ADVANCE, NIL)
     }
 
   public open var input2_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_2_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 2L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_2_NAME, NIL)
     }
 
   public open var input20_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_20_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 20L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_20_AUTO_ADVANCE, NIL)
     }
 
   public open var input20_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_20_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 20L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_20_NAME, NIL)
     }
 
   public open var input21_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_21_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 21L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_21_AUTO_ADVANCE, NIL)
     }
 
   public open var input21_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_21_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 21L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_21_NAME, NIL)
     }
 
   public open var input22_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 22L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_22_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 22L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_22_AUTO_ADVANCE, NIL)
     }
 
   public open var input22_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 22L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_22_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 22L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_22_NAME, NIL)
     }
 
   public open var input23_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 23L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_23_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 23L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_23_AUTO_ADVANCE, NIL)
     }
 
   public open var input23_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 23L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_23_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 23L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_23_NAME, NIL)
     }
 
   public open var input24_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 24L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_24_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 24L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_24_AUTO_ADVANCE, NIL)
     }
 
   public open var input24_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 24L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_24_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 24L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_24_NAME, NIL)
     }
 
   public open var input25_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 25L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_25_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 25L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_25_AUTO_ADVANCE, NIL)
     }
 
   public open var input25_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 25L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_25_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 25L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_25_NAME, NIL)
     }
 
   public open var input26_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 26L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_26_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 26L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_26_AUTO_ADVANCE, NIL)
     }
 
   public open var input26_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 26L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_26_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 26L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_26_NAME, NIL)
     }
 
   public open var input27_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 27L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_27_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 27L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_27_AUTO_ADVANCE, NIL)
     }
 
   public open var input27_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 27L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_27_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 27L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_27_NAME, NIL)
     }
 
   public open var input28_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 28L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_28_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 28L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_28_AUTO_ADVANCE, NIL)
     }
 
   public open var input28_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 28L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_28_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 28L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_28_NAME, NIL)
     }
 
   public open var input29_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 29L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_29_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 29L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_29_AUTO_ADVANCE, NIL)
     }
 
   public open var input29_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 29L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_29_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 29L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_29_NAME, NIL)
     }
 
   public open var input3_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_3_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 3L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_3_AUTO_ADVANCE, NIL)
     }
 
   public open var input3_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_3_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 3L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_3_NAME, NIL)
     }
 
   public open var input30_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 30L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_30_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 30L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_30_AUTO_ADVANCE, NIL)
     }
 
   public open var input30_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 30L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_30_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 30L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_30_NAME, NIL)
     }
 
   public open var input31_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 31L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_31_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 31L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_31_AUTO_ADVANCE, NIL)
     }
 
   public open var input31_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 31L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_31_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 31L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_31_NAME, NIL)
     }
 
   public open var input4_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_4_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_4_AUTO_ADVANCE, NIL)
     }
 
   public open var input4_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_4_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 4L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_4_NAME, NIL)
     }
 
   public open var input5_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_5_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 5L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_5_AUTO_ADVANCE, NIL)
     }
 
   public open var input5_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_5_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 5L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_5_NAME, NIL)
     }
 
   public open var input6_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_6_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 6L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_6_AUTO_ADVANCE, NIL)
     }
 
   public open var input6_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_6_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 6L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_6_NAME, NIL)
     }
 
   public open var input7_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_7_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 7L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_7_AUTO_ADVANCE, NIL)
     }
 
   public open var input7_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_7_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 7L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_7_NAME, NIL)
     }
 
   public open var input8_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_8_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 8L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_8_AUTO_ADVANCE, NIL)
     }
 
   public open var input8_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_8_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 8L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_8_NAME, NIL)
     }
 
   public open var input9_autoAdvance: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_9_AUTO_ADVANCE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 9L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_9_AUTO_ADVANCE, NIL)
     }
 
   public open var input9_name: String
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_GET_INPUT_9_NAME, STRING)
       return TransferContext.readReturnValue(STRING, false) as String
     }
     set(`value`) {
-      TransferContext.writeArguments(STRING to value)
+      TransferContext.writeArguments(LONG to 9L, STRING to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_ANIMATIONNODETRANSITION_SET_INPUT_9_NAME, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/AudioEffectChorus.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/AudioEffectChorus.kt
@@ -38,312 +38,312 @@ public open class AudioEffectChorus : AudioEffect() {
 
   public open var voice_1_cutoffHz: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_1_CUTOFF_HZ, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_1_CUTOFF_HZ, NIL)
     }
 
   public open var voice_1_delayMs: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_1_DELAY_MS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_1_DELAY_MS, NIL)
     }
 
   public open var voice_1_depthMs: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_1_DEPTH_MS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_1_DEPTH_MS, NIL)
     }
 
   public open var voice_1_levelDb: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_1_LEVEL_DB, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_1_LEVEL_DB, NIL)
     }
 
   public open var voice_1_pan: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_1_PAN,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_1_PAN,
           NIL)
     }
 
   public open var voice_1_rateHz: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_1_RATE_HZ, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_1_RATE_HZ, NIL)
     }
 
   public open var voice_2_cutoffHz: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_2_CUTOFF_HZ, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_2_CUTOFF_HZ, NIL)
     }
 
   public open var voice_2_delayMs: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_2_DELAY_MS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_2_DELAY_MS, NIL)
     }
 
   public open var voice_2_depthMs: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_2_DEPTH_MS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_2_DEPTH_MS, NIL)
     }
 
   public open var voice_2_levelDb: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_2_LEVEL_DB, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_2_LEVEL_DB, NIL)
     }
 
   public open var voice_2_pan: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_2_PAN,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_2_PAN,
           NIL)
     }
 
   public open var voice_2_rateHz: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_2_RATE_HZ, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_2_RATE_HZ, NIL)
     }
 
   public open var voice_3_cutoffHz: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_3_CUTOFF_HZ, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_3_CUTOFF_HZ, NIL)
     }
 
   public open var voice_3_delayMs: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_3_DELAY_MS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_3_DELAY_MS, NIL)
     }
 
   public open var voice_3_depthMs: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_3_DEPTH_MS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_3_DEPTH_MS, NIL)
     }
 
   public open var voice_3_levelDb: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_3_LEVEL_DB, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_3_LEVEL_DB, NIL)
     }
 
   public open var voice_3_pan: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_3_PAN,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_3_PAN,
           NIL)
     }
 
   public open var voice_3_rateHz: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_3_RATE_HZ, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_3_RATE_HZ, NIL)
     }
 
   public open var voice_4_cutoffHz: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_4_CUTOFF_HZ, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_4_CUTOFF_HZ, NIL)
     }
 
   public open var voice_4_delayMs: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_4_DELAY_MS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_4_DELAY_MS, NIL)
     }
 
   public open var voice_4_depthMs: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_4_DEPTH_MS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_4_DEPTH_MS, NIL)
     }
 
   public open var voice_4_levelDb: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_4_LEVEL_DB, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_4_LEVEL_DB, NIL)
     }
 
   public open var voice_4_pan: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_4_PAN,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_4_PAN,
           NIL)
     }
 
   public open var voice_4_rateHz: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_GET_VOICE_4_RATE_HZ, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_AUDIOEFFECTCHORUS_SET_VOICE_4_RATE_HZ, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/CPUParticles.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/CPUParticles.kt
@@ -59,12 +59,12 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var angle: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANGLE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANGLE, NIL)
     }
 
@@ -73,13 +73,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var angleCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANGLE_CURVE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 7L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANGLE_CURVE, NIL)
     }
 
@@ -88,13 +88,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var angleRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANGLE_RANDOM,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANGLE_RANDOM,
           NIL)
     }
@@ -104,13 +104,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var angularVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANGULAR_VELOCITY,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANGULAR_VELOCITY,
           NIL)
     }
@@ -120,13 +120,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var angularVelocityCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANGULAR_VELOCITY_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 1L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANGULAR_VELOCITY_CURVE, NIL)
     }
@@ -136,13 +136,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var angularVelocityRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANGULAR_VELOCITY_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANGULAR_VELOCITY_RANDOM, NIL)
     }
@@ -152,13 +152,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var animOffset: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANIM_OFFSET,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 11L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANIM_OFFSET, NIL)
     }
 
@@ -167,13 +167,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var animOffsetCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANIM_OFFSET_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 11L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANIM_OFFSET_CURVE, NIL)
     }
@@ -183,13 +183,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var animOffsetRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANIM_OFFSET_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 11L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANIM_OFFSET_RANDOM, NIL)
     }
@@ -199,13 +199,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var animSpeed: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANIM_SPEED,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 10L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANIM_SPEED, NIL)
     }
 
@@ -214,13 +214,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var animSpeedCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANIM_SPEED_CURVE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 10L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANIM_SPEED_CURVE,
           NIL)
     }
@@ -230,13 +230,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var animSpeedRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ANIM_SPEED_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 10L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ANIM_SPEED_RANDOM, NIL)
     }
@@ -275,12 +275,12 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_DAMPING, NIL)
     }
 
@@ -289,13 +289,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var dampingCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_DAMPING_CURVE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 6L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_DAMPING_CURVE,
           NIL)
     }
@@ -305,13 +305,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var dampingRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_DAMPING_RANDOM,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_DAMPING_RANDOM,
           NIL)
     }
@@ -554,13 +554,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var flagAlignY: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_FLAG_ALIGN_Y,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_FLAG_ALIGN_Y,
           NIL)
     }
@@ -570,13 +570,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var flagDisableZ: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_FLAG_DISABLE_Z,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_FLAG_DISABLE_Z,
           NIL)
     }
@@ -586,13 +586,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var flagRotateY: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_FLAG_ROTATE_Y,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_FLAG_ROTATE_Y,
           NIL)
     }
@@ -645,13 +645,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var hueVariation: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_HUE_VARIATION,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_HUE_VARIATION,
           NIL)
     }
@@ -661,13 +661,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var hueVariationCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_HUE_VARIATION_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 9L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_HUE_VARIATION_CURVE, NIL)
     }
@@ -677,13 +677,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var hueVariationRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_HUE_VARIATION_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_HUE_VARIATION_RANDOM, NIL)
     }
@@ -693,13 +693,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var initialVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_INITIAL_VELOCITY,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_INITIAL_VELOCITY,
           NIL)
     }
@@ -709,13 +709,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var initialVelocityRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_INITIAL_VELOCITY_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_INITIAL_VELOCITY_RANDOM, NIL)
     }
@@ -755,13 +755,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var linearAccel: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_LINEAR_ACCEL,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_LINEAR_ACCEL,
           NIL)
     }
@@ -771,13 +771,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var linearAccelCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_LINEAR_ACCEL_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 3L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_LINEAR_ACCEL_CURVE, NIL)
     }
@@ -787,13 +787,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var linearAccelRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_LINEAR_ACCEL_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_LINEAR_ACCEL_RANDOM, NIL)
     }
@@ -849,13 +849,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var orbitVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ORBIT_VELOCITY,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ORBIT_VELOCITY,
           NIL)
     }
@@ -865,13 +865,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var orbitVelocityCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ORBIT_VELOCITY_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 2L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ORBIT_VELOCITY_CURVE, NIL)
     }
@@ -881,13 +881,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var orbitVelocityRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_ORBIT_VELOCITY_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_ORBIT_VELOCITY_RANDOM, NIL)
     }
@@ -912,13 +912,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var radialAccel: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_RADIAL_ACCEL,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_RADIAL_ACCEL,
           NIL)
     }
@@ -928,13 +928,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var radialAccelCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_RADIAL_ACCEL_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 4L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_RADIAL_ACCEL_CURVE, NIL)
     }
@@ -944,13 +944,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var radialAccelRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_RADIAL_ACCEL_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_RADIAL_ACCEL_RANDOM, NIL)
     }
@@ -975,13 +975,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var scaleAmount: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_SCALE_AMOUNT,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_SCALE_AMOUNT,
           NIL)
     }
@@ -991,13 +991,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var scaleAmountCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_SCALE_AMOUNT_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 8L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_SCALE_AMOUNT_CURVE, NIL)
     }
@@ -1007,13 +1007,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var scaleAmountRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_SCALE_AMOUNT_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_SCALE_AMOUNT_RANDOM, NIL)
     }
@@ -1052,13 +1052,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var tangentialAccel: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_TANGENTIAL_ACCEL,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_TANGENTIAL_ACCEL,
           NIL)
     }
@@ -1068,13 +1068,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var tangentialAccelCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_TANGENTIAL_ACCEL_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 5L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_TANGENTIAL_ACCEL_CURVE, NIL)
     }
@@ -1084,13 +1084,13 @@ public open class CPUParticles : GeometryInstance() {
    */
   public open var tangentialAccelRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_GET_TANGENTIAL_ACCEL_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES_SET_TANGENTIAL_ACCEL_RANDOM, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/CPUParticles2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/CPUParticles2D.kt
@@ -62,12 +62,12 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var angle: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANGLE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANGLE, NIL)
     }
 
@@ -76,13 +76,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var angleCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANGLE_CURVE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 7L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANGLE_CURVE,
           NIL)
     }
@@ -92,13 +92,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var angleRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANGLE_RANDOM,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANGLE_RANDOM,
           NIL)
     }
@@ -108,13 +108,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var angularVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANGULAR_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANGULAR_VELOCITY, NIL)
     }
@@ -124,13 +124,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var angularVelocityCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANGULAR_VELOCITY_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 1L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANGULAR_VELOCITY_CURVE, NIL)
     }
@@ -140,13 +140,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var angularVelocityRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANGULAR_VELOCITY_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANGULAR_VELOCITY_RANDOM, NIL)
     }
@@ -156,13 +156,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var animOffset: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANIM_OFFSET,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 11L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANIM_OFFSET,
           NIL)
     }
@@ -172,13 +172,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var animOffsetCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANIM_OFFSET_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 11L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANIM_OFFSET_CURVE, NIL)
     }
@@ -188,13 +188,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var animOffsetRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANIM_OFFSET_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 11L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANIM_OFFSET_RANDOM, NIL)
     }
@@ -204,13 +204,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var animSpeed: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANIM_SPEED,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 10L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANIM_SPEED,
           NIL)
     }
@@ -220,13 +220,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var animSpeedCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANIM_SPEED_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 10L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANIM_SPEED_CURVE, NIL)
     }
@@ -236,13 +236,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var animSpeedRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ANIM_SPEED_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 10L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ANIM_SPEED_RANDOM, NIL)
     }
@@ -282,13 +282,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_DAMPING,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_DAMPING, NIL)
     }
 
@@ -297,13 +297,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var dampingCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_DAMPING_CURVE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 6L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_DAMPING_CURVE,
           NIL)
     }
@@ -313,13 +313,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var dampingRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_DAMPING_RANDOM,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_DAMPING_RANDOM,
           NIL)
     }
@@ -501,13 +501,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var flagAlignY: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_FLAG_ALIGN_Y,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_FLAG_ALIGN_Y,
           NIL)
     }
@@ -548,13 +548,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var hueVariation: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_HUE_VARIATION,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_HUE_VARIATION,
           NIL)
     }
@@ -564,13 +564,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var hueVariationCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_HUE_VARIATION_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 9L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_HUE_VARIATION_CURVE, NIL)
     }
@@ -580,13 +580,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var hueVariationRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_HUE_VARIATION_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_HUE_VARIATION_RANDOM, NIL)
     }
@@ -596,13 +596,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var initialVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_INITIAL_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_INITIAL_VELOCITY, NIL)
     }
@@ -612,13 +612,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var initialVelocityRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_INITIAL_VELOCITY_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_INITIAL_VELOCITY_RANDOM, NIL)
     }
@@ -659,13 +659,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var linearAccel: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_LINEAR_ACCEL,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_LINEAR_ACCEL,
           NIL)
     }
@@ -675,13 +675,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var linearAccelCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_LINEAR_ACCEL_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 3L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_LINEAR_ACCEL_CURVE, NIL)
     }
@@ -691,13 +691,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var linearAccelRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_LINEAR_ACCEL_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_LINEAR_ACCEL_RANDOM, NIL)
     }
@@ -754,13 +754,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var orbitVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ORBIT_VELOCITY,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ORBIT_VELOCITY,
           NIL)
     }
@@ -770,13 +770,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var orbitVelocityCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ORBIT_VELOCITY_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 2L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ORBIT_VELOCITY_CURVE, NIL)
     }
@@ -786,13 +786,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var orbitVelocityRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_ORBIT_VELOCITY_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_ORBIT_VELOCITY_RANDOM, NIL)
     }
@@ -818,13 +818,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var radialAccel: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_RADIAL_ACCEL,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_RADIAL_ACCEL,
           NIL)
     }
@@ -834,13 +834,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var radialAccelCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_RADIAL_ACCEL_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 4L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_RADIAL_ACCEL_CURVE, NIL)
     }
@@ -850,13 +850,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var radialAccelRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_RADIAL_ACCEL_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_RADIAL_ACCEL_RANDOM, NIL)
     }
@@ -882,13 +882,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var scaleAmount: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_SCALE_AMOUNT,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_SCALE_AMOUNT,
           NIL)
     }
@@ -898,13 +898,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var scaleAmountCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_SCALE_AMOUNT_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 8L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_SCALE_AMOUNT_CURVE, NIL)
     }
@@ -914,13 +914,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var scaleAmountRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_SCALE_AMOUNT_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_SCALE_AMOUNT_RANDOM, NIL)
     }
@@ -960,13 +960,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var tangentialAccel: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_TANGENTIAL_ACCEL, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_TANGENTIAL_ACCEL, NIL)
     }
@@ -976,13 +976,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var tangentialAccelCurve: Curve?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_TANGENTIAL_ACCEL_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Curve?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 5L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_TANGENTIAL_ACCEL_CURVE, NIL)
     }
@@ -992,13 +992,13 @@ public open class CPUParticles2D : Node2D() {
    */
   public open var tangentialAccelRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_GET_TANGENTIAL_ACCEL_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CPUPARTICLES2D_SET_TANGENTIAL_ACCEL_RANDOM, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Camera2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Camera2D.kt
@@ -79,13 +79,13 @@ public open class Camera2D : Node2D() {
    */
   public open var dragMarginBottom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_GET_DRAG_MARGIN_BOTTOM,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_SET_DRAG_MARGIN_BOTTOM,
           NIL)
     }
@@ -111,13 +111,13 @@ public open class Camera2D : Node2D() {
    */
   public open var dragMarginLeft: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_GET_DRAG_MARGIN_LEFT,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_SET_DRAG_MARGIN_LEFT,
           NIL)
     }
@@ -127,13 +127,13 @@ public open class Camera2D : Node2D() {
    */
   public open var dragMarginRight: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_GET_DRAG_MARGIN_RIGHT,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_SET_DRAG_MARGIN_RIGHT,
           NIL)
     }
@@ -143,13 +143,13 @@ public open class Camera2D : Node2D() {
    */
   public open var dragMarginTop: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_GET_DRAG_MARGIN_TOP,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_SET_DRAG_MARGIN_TOP, NIL)
     }
 
@@ -222,12 +222,12 @@ public open class Camera2D : Node2D() {
    */
   public open var limitBottom: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_GET_LIMIT_BOTTOM, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 3L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_SET_LIMIT_BOTTOM, NIL)
     }
 
@@ -236,12 +236,12 @@ public open class Camera2D : Node2D() {
    */
   public open var limitLeft: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_GET_LIMIT_LEFT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 0L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_SET_LIMIT_LEFT, NIL)
     }
 
@@ -250,12 +250,12 @@ public open class Camera2D : Node2D() {
    */
   public open var limitRight: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_GET_LIMIT_RIGHT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 2L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_SET_LIMIT_RIGHT, NIL)
     }
 
@@ -282,12 +282,12 @@ public open class Camera2D : Node2D() {
    */
   public open var limitTop: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_GET_LIMIT_TOP, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 1L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CAMERA2D_SET_LIMIT_TOP, NIL)
     }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/ConeTwistJoint.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/ConeTwistJoint.kt
@@ -8,6 +8,7 @@ package godot
 import godot.`annotation`.GodotBaseType
 import godot.core.TransferContext
 import godot.core.VariantType.DOUBLE
+import godot.core.VariantType.LONG
 import godot.core.VariantType.NIL
 import kotlin.Double
 import kotlin.Long
@@ -33,12 +34,12 @@ public open class ConeTwistJoint : Joint() {
    */
   public open var bias: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONETWISTJOINT_GET_BIAS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONETWISTJOINT_SET_BIAS, NIL)
     }
 
@@ -47,13 +48,13 @@ public open class ConeTwistJoint : Joint() {
    */
   public open var relaxation: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONETWISTJOINT_GET_RELAXATION,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONETWISTJOINT_SET_RELAXATION,
           NIL)
     }
@@ -63,13 +64,13 @@ public open class ConeTwistJoint : Joint() {
    */
   public open var softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONETWISTJOINT_GET_SOFTNESS,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONETWISTJOINT_SET_SOFTNESS, NIL)
     }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Control.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Control.kt
@@ -117,7 +117,7 @@ public open class Control : CanvasItem() {
    */
   public open val anchorBottom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_ANCHOR_BOTTOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
@@ -127,7 +127,7 @@ public open class Control : CanvasItem() {
    */
   public open val anchorLeft: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_ANCHOR_LEFT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
@@ -137,7 +137,7 @@ public open class Control : CanvasItem() {
    */
   public open val anchorRight: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_ANCHOR_RIGHT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
@@ -147,7 +147,7 @@ public open class Control : CanvasItem() {
    */
   public open val anchorTop: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_ANCHOR_TOP, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
@@ -171,13 +171,13 @@ public open class Control : CanvasItem() {
    */
   public open var focusNeighbourBottom: NodePath
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CONTROL_GET_FOCUS_NEIGHBOUR_BOTTOM, NODE_PATH)
       return TransferContext.readReturnValue(NODE_PATH, false) as NodePath
     }
     set(`value`) {
-      TransferContext.writeArguments(NODE_PATH to value)
+      TransferContext.writeArguments(LONG to 3L, NODE_PATH to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_CONTROL_SET_FOCUS_NEIGHBOUR_BOTTOM, NIL)
     }
@@ -187,13 +187,13 @@ public open class Control : CanvasItem() {
    */
   public open var focusNeighbourLeft: NodePath
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_FOCUS_NEIGHBOUR_LEFT,
           NODE_PATH)
       return TransferContext.readReturnValue(NODE_PATH, false) as NodePath
     }
     set(`value`) {
-      TransferContext.writeArguments(NODE_PATH to value)
+      TransferContext.writeArguments(LONG to 0L, NODE_PATH to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_SET_FOCUS_NEIGHBOUR_LEFT,
           NIL)
     }
@@ -203,13 +203,13 @@ public open class Control : CanvasItem() {
    */
   public open var focusNeighbourRight: NodePath
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_FOCUS_NEIGHBOUR_RIGHT,
           NODE_PATH)
       return TransferContext.readReturnValue(NODE_PATH, false) as NodePath
     }
     set(`value`) {
-      TransferContext.writeArguments(NODE_PATH to value)
+      TransferContext.writeArguments(LONG to 2L, NODE_PATH to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_SET_FOCUS_NEIGHBOUR_RIGHT,
           NIL)
     }
@@ -219,13 +219,13 @@ public open class Control : CanvasItem() {
    */
   public open var focusNeighbourTop: NodePath
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_FOCUS_NEIGHBOUR_TOP,
           NODE_PATH)
       return TransferContext.readReturnValue(NODE_PATH, false) as NodePath
     }
     set(`value`) {
-      TransferContext.writeArguments(NODE_PATH to value)
+      TransferContext.writeArguments(LONG to 1L, NODE_PATH to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_SET_FOCUS_NEIGHBOUR_TOP,
           NIL)
     }
@@ -340,12 +340,12 @@ public open class Control : CanvasItem() {
    */
   public open var marginBottom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_MARGIN_BOTTOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_SET_MARGIN_BOTTOM, NIL)
     }
 
@@ -356,12 +356,12 @@ public open class Control : CanvasItem() {
    */
   public open var marginLeft: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_MARGIN_LEFT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_SET_MARGIN_LEFT, NIL)
     }
 
@@ -372,12 +372,12 @@ public open class Control : CanvasItem() {
    */
   public open var marginRight: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_MARGIN_RIGHT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_SET_MARGIN_RIGHT, NIL)
     }
 
@@ -388,12 +388,12 @@ public open class Control : CanvasItem() {
    */
   public open var marginTop: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_GET_MARGIN_TOP, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_CONTROL_SET_MARGIN_TOP, NIL)
     }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/DynamicFont.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/DynamicFont.kt
@@ -47,13 +47,13 @@ public open class DynamicFont : Font() {
    */
   public open var extraSpacingBottom: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_DYNAMICFONT_GET_EXTRA_SPACING_BOTTOM, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 1L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_DYNAMICFONT_SET_EXTRA_SPACING_BOTTOM, NIL)
     }
@@ -65,13 +65,13 @@ public open class DynamicFont : Font() {
    */
   public open var extraSpacingChar: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_DYNAMICFONT_GET_EXTRA_SPACING_CHAR, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 2L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_DYNAMICFONT_SET_EXTRA_SPACING_CHAR, NIL)
     }
@@ -83,13 +83,13 @@ public open class DynamicFont : Font() {
    */
   public open var extraSpacingSpace: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_DYNAMICFONT_GET_EXTRA_SPACING_SPACE, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 3L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_DYNAMICFONT_SET_EXTRA_SPACING_SPACE, NIL)
     }
@@ -99,13 +99,13 @@ public open class DynamicFont : Font() {
    */
   public open var extraSpacingTop: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_DYNAMICFONT_GET_EXTRA_SPACING_TOP,
           LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 0L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_DYNAMICFONT_SET_EXTRA_SPACING_TOP,
           NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Environment.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Environment.kt
@@ -939,91 +939,91 @@ public open class Environment : Resource() {
 
   public open var glowLevels_1: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_GET_GLOW_LEVELS_1,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_SET_GLOW_LEVELS_1,
           NIL)
     }
 
   public open var glowLevels_2: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_GET_GLOW_LEVELS_2,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_SET_GLOW_LEVELS_2,
           NIL)
     }
 
   public open var glowLevels_3: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_GET_GLOW_LEVELS_3,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_SET_GLOW_LEVELS_3,
           NIL)
     }
 
   public open var glowLevels_4: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_GET_GLOW_LEVELS_4,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 3L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_SET_GLOW_LEVELS_4,
           NIL)
     }
 
   public open var glowLevels_5: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_GET_GLOW_LEVELS_5,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_SET_GLOW_LEVELS_5,
           NIL)
     }
 
   public open var glowLevels_6: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_GET_GLOW_LEVELS_6,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 5L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_SET_GLOW_LEVELS_6,
           NIL)
     }
 
   public open var glowLevels_7: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_GET_GLOW_LEVELS_7,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 6L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_ENVIRONMENT_SET_GLOW_LEVELS_7,
           NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Generic6DOFJoint.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Generic6DOFJoint.kt
@@ -9,6 +9,7 @@ import godot.`annotation`.GodotBaseType
 import godot.core.TransferContext
 import godot.core.VariantType.BOOL
 import godot.core.VariantType.DOUBLE
+import godot.core.VariantType.LONG
 import godot.core.VariantType.NIL
 import kotlin.Boolean
 import kotlin.Double
@@ -26,1014 +27,1014 @@ import kotlin.Unit
 public open class Generic6DOFJoint : Joint() {
   public open var angularLimitX_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_X_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 13L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_X_DAMPING, NIL)
     }
 
   public open var angularLimitX_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_X_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_X_ENABLED, NIL)
     }
 
   public open var angularLimitX_erp: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_X_ERP, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 16L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_X_ERP, NIL)
     }
 
   public open var angularLimitX_forceLimit: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_X_FORCE_LIMIT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 15L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_X_FORCE_LIMIT, NIL)
     }
 
   public open var angularLimitX_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_X_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 14L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_X_RESTITUTION, NIL)
     }
 
   public open var angularLimitX_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_X_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 12L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_X_SOFTNESS, NIL)
     }
 
   public open var angularLimitY_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Y_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 13L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Y_DAMPING, NIL)
     }
 
   public open var angularLimitY_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Y_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Y_ENABLED, NIL)
     }
 
   public open var angularLimitY_erp: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Y_ERP, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 16L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Y_ERP, NIL)
     }
 
   public open var angularLimitY_forceLimit: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Y_FORCE_LIMIT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 15L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Y_FORCE_LIMIT, NIL)
     }
 
   public open var angularLimitY_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Y_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 14L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Y_RESTITUTION, NIL)
     }
 
   public open var angularLimitY_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Y_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 12L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Y_SOFTNESS, NIL)
     }
 
   public open var angularLimitZ_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Z_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 13L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Z_DAMPING, NIL)
     }
 
   public open var angularLimitZ_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Z_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Z_ENABLED, NIL)
     }
 
   public open var angularLimitZ_erp: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Z_ERP, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 16L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Z_ERP, NIL)
     }
 
   public open var angularLimitZ_forceLimit: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Z_FORCE_LIMIT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 15L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Z_FORCE_LIMIT, NIL)
     }
 
   public open var angularLimitZ_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Z_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 14L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Z_RESTITUTION, NIL)
     }
 
   public open var angularLimitZ_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_LIMIT_Z_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 12L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_LIMIT_Z_SOFTNESS, NIL)
     }
 
   public open var angularMotorX_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_MOTOR_X_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_MOTOR_X_ENABLED, NIL)
     }
 
   public open var angularMotorX_forceLimit: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_MOTOR_X_FORCE_LIMIT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 18L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_MOTOR_X_FORCE_LIMIT, NIL)
     }
 
   public open var angularMotorX_targetVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_MOTOR_X_TARGET_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 17L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_MOTOR_X_TARGET_VELOCITY, NIL)
     }
 
   public open var angularMotorY_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_MOTOR_Y_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_MOTOR_Y_ENABLED, NIL)
     }
 
   public open var angularMotorY_forceLimit: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_MOTOR_Y_FORCE_LIMIT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 18L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_MOTOR_Y_FORCE_LIMIT, NIL)
     }
 
   public open var angularMotorY_targetVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_MOTOR_Y_TARGET_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 17L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_MOTOR_Y_TARGET_VELOCITY, NIL)
     }
 
   public open var angularMotorZ_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_MOTOR_Z_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_MOTOR_Z_ENABLED, NIL)
     }
 
   public open var angularMotorZ_forceLimit: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_MOTOR_Z_FORCE_LIMIT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 18L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_MOTOR_Z_FORCE_LIMIT, NIL)
     }
 
   public open var angularMotorZ_targetVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_MOTOR_Z_TARGET_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 17L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_MOTOR_Z_TARGET_VELOCITY, NIL)
     }
 
   public open var angularSpringX_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_X_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 20L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_X_DAMPING, NIL)
     }
 
   public open var angularSpringX_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_X_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_X_ENABLED, NIL)
     }
 
   public open var angularSpringX_equilibriumPoint: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_X_EQUILIBRIUM_POINT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 21L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_X_EQUILIBRIUM_POINT, NIL)
     }
 
   public open var angularSpringX_stiffness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_X_STIFFNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 19L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_X_STIFFNESS, NIL)
     }
 
   public open var angularSpringY_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_Y_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 20L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_Y_DAMPING, NIL)
     }
 
   public open var angularSpringY_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_Y_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_Y_ENABLED, NIL)
     }
 
   public open var angularSpringY_equilibriumPoint: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_Y_EQUILIBRIUM_POINT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 21L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_Y_EQUILIBRIUM_POINT, NIL)
     }
 
   public open var angularSpringY_stiffness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_Y_STIFFNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 19L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_Y_STIFFNESS, NIL)
     }
 
   public open var angularSpringZ_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_Z_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 20L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_Z_DAMPING, NIL)
     }
 
   public open var angularSpringZ_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_Z_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_Z_ENABLED, NIL)
     }
 
   public open var angularSpringZ_equilibriumPoint: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_Z_EQUILIBRIUM_POINT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 21L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_Z_EQUILIBRIUM_POINT, NIL)
     }
 
   public open var angularSpringZ_stiffness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_ANGULAR_SPRING_Z_STIFFNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 19L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_ANGULAR_SPRING_Z_STIFFNESS, NIL)
     }
 
   public open var linearLimitX_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_X_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_X_DAMPING, NIL)
     }
 
   public open var linearLimitX_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_X_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_X_ENABLED, NIL)
     }
 
   public open var linearLimitX_lowerDistance: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_X_LOWER_DISTANCE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_X_LOWER_DISTANCE, NIL)
     }
 
   public open var linearLimitX_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_X_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_X_RESTITUTION, NIL)
     }
 
   public open var linearLimitX_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_X_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_X_SOFTNESS, NIL)
     }
 
   public open var linearLimitX_upperDistance: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_X_UPPER_DISTANCE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_X_UPPER_DISTANCE, NIL)
     }
 
   public open var linearLimitY_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Y_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Y_DAMPING, NIL)
     }
 
   public open var linearLimitY_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Y_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Y_ENABLED, NIL)
     }
 
   public open var linearLimitY_lowerDistance: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Y_LOWER_DISTANCE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Y_LOWER_DISTANCE, NIL)
     }
 
   public open var linearLimitY_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Y_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Y_RESTITUTION, NIL)
     }
 
   public open var linearLimitY_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Y_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Y_SOFTNESS, NIL)
     }
 
   public open var linearLimitY_upperDistance: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Y_UPPER_DISTANCE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Y_UPPER_DISTANCE, NIL)
     }
 
   public open var linearLimitZ_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Z_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Z_DAMPING, NIL)
     }
 
   public open var linearLimitZ_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Z_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Z_ENABLED, NIL)
     }
 
   public open var linearLimitZ_lowerDistance: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Z_LOWER_DISTANCE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Z_LOWER_DISTANCE, NIL)
     }
 
   public open var linearLimitZ_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Z_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Z_RESTITUTION, NIL)
     }
 
   public open var linearLimitZ_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Z_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Z_SOFTNESS, NIL)
     }
 
   public open var linearLimitZ_upperDistance: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_LIMIT_Z_UPPER_DISTANCE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_LIMIT_Z_UPPER_DISTANCE, NIL)
     }
 
   public open var linearMotorX_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_MOTOR_X_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 5L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_MOTOR_X_ENABLED, NIL)
     }
 
   public open var linearMotorX_forceLimit: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_MOTOR_X_FORCE_LIMIT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_MOTOR_X_FORCE_LIMIT, NIL)
     }
 
   public open var linearMotorX_targetVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_MOTOR_X_TARGET_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_MOTOR_X_TARGET_VELOCITY, NIL)
     }
 
   public open var linearMotorY_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_MOTOR_Y_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 5L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_MOTOR_Y_ENABLED, NIL)
     }
 
   public open var linearMotorY_forceLimit: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_MOTOR_Y_FORCE_LIMIT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_MOTOR_Y_FORCE_LIMIT, NIL)
     }
 
   public open var linearMotorY_targetVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_MOTOR_Y_TARGET_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_MOTOR_Y_TARGET_VELOCITY, NIL)
     }
 
   public open var linearMotorZ_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_MOTOR_Z_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 5L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_MOTOR_Z_ENABLED, NIL)
     }
 
   public open var linearMotorZ_forceLimit: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_MOTOR_Z_FORCE_LIMIT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_MOTOR_Z_FORCE_LIMIT, NIL)
     }
 
   public open var linearMotorZ_targetVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_MOTOR_Z_TARGET_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_MOTOR_Z_TARGET_VELOCITY, NIL)
     }
 
   public open var linearSpringX_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_X_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_X_DAMPING, NIL)
     }
 
   public open var linearSpringX_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_X_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 3L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_X_ENABLED, NIL)
     }
 
   public open var linearSpringX_equilibriumPoint: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_X_EQUILIBRIUM_POINT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_X_EQUILIBRIUM_POINT, NIL)
     }
 
   public open var linearSpringX_stiffness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_X_STIFFNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_X_STIFFNESS, NIL)
     }
 
   public open var linearSpringY_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_Y_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_Y_DAMPING, NIL)
     }
 
   public open var linearSpringY_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_Y_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 3L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_Y_ENABLED, NIL)
     }
 
   public open var linearSpringY_equilibriumPoint: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_Y_EQUILIBRIUM_POINT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_Y_EQUILIBRIUM_POINT, NIL)
     }
 
   public open var linearSpringY_stiffness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_Y_STIFFNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_Y_STIFFNESS, NIL)
     }
 
   public open var linearSpringZ_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_Z_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_Z_DAMPING, NIL)
     }
 
   public open var linearSpringZ_enabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_Z_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 3L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_Z_ENABLED, NIL)
     }
 
   public open var linearSpringZ_equilibriumPoint: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_Z_EQUILIBRIUM_POINT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_Z_EQUILIBRIUM_POINT, NIL)
     }
 
   public open var linearSpringZ_stiffness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_GET_LINEAR_SPRING_Z_STIFFNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GENERIC6DOFJOINT_SET_LINEAR_SPRING_Z_STIFFNESS, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/GeometryInstance.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/GeometryInstance.kt
@@ -185,13 +185,13 @@ public open class GeometryInstance : VisualInstance() {
    */
   public open var useInBakedLight: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GEOMETRYINSTANCE_GET_USE_IN_BAKED_LIGHT, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_GEOMETRYINSTANCE_SET_USE_IN_BAKED_LIGHT, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/HingeJoint.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/HingeJoint.kt
@@ -9,6 +9,7 @@ import godot.`annotation`.GodotBaseType
 import godot.core.TransferContext
 import godot.core.VariantType.BOOL
 import godot.core.VariantType.DOUBLE
+import godot.core.VariantType.LONG
 import godot.core.VariantType.NIL
 import kotlin.Boolean
 import kotlin.Double
@@ -26,102 +27,102 @@ import kotlin.Unit
 public open class HingeJoint : Joint() {
   public open var angularLimit_bias: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_HINGEJOINT_GET_ANGULAR_LIMIT_BIAS,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_HINGEJOINT_SET_ANGULAR_LIMIT_BIAS,
           NIL)
     }
 
   public open var angularLimit_enable: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_HINGEJOINT_GET_ANGULAR_LIMIT_ENABLE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_HINGEJOINT_SET_ANGULAR_LIMIT_ENABLE, NIL)
     }
 
   public open var angularLimit_relaxation: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_HINGEJOINT_GET_ANGULAR_LIMIT_RELAXATION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_HINGEJOINT_SET_ANGULAR_LIMIT_RELAXATION, NIL)
     }
 
   public open var angularLimit_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_HINGEJOINT_GET_ANGULAR_LIMIT_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_HINGEJOINT_SET_ANGULAR_LIMIT_SOFTNESS, NIL)
     }
 
   public open var motor_enable: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_HINGEJOINT_GET_MOTOR_ENABLE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_HINGEJOINT_SET_MOTOR_ENABLE, NIL)
     }
 
   public open var motor_maxImpulse: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_HINGEJOINT_GET_MOTOR_MAX_IMPULSE,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_HINGEJOINT_SET_MOTOR_MAX_IMPULSE,
           NIL)
     }
 
   public open var motor_targetVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_HINGEJOINT_GET_MOTOR_TARGET_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_HINGEJOINT_SET_MOTOR_TARGET_VELOCITY, NIL)
     }
 
   public open var params_bias: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_HINGEJOINT_GET_PARAMS_BIAS,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_HINGEJOINT_SET_PARAMS_BIAS, NIL)
     }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/KinematicBody.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/KinematicBody.kt
@@ -41,13 +41,13 @@ public open class KinematicBody : PhysicsBody() {
    */
   public open var axisLockMotionX: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_GET_AXIS_LOCK_MOTION_X, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_SET_AXIS_LOCK_MOTION_X, NIL)
     }
@@ -57,13 +57,13 @@ public open class KinematicBody : PhysicsBody() {
    */
   public open var axisLockMotionY: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_GET_AXIS_LOCK_MOTION_Y, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_SET_AXIS_LOCK_MOTION_Y, NIL)
     }
@@ -73,13 +73,13 @@ public open class KinematicBody : PhysicsBody() {
    */
   public open var axisLockMotionZ: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_GET_AXIS_LOCK_MOTION_Z, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_SET_AXIS_LOCK_MOTION_Z, NIL)
     }
@@ -115,13 +115,13 @@ public open class KinematicBody : PhysicsBody() {
    */
   public open var moveLockX: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_GET_MOVE_LOCK_X,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_SET_MOVE_LOCK_X,
           NIL)
     }
@@ -131,13 +131,13 @@ public open class KinematicBody : PhysicsBody() {
    */
   public open var moveLockY: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_GET_MOVE_LOCK_Y,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_SET_MOVE_LOCK_Y,
           NIL)
     }
@@ -147,13 +147,13 @@ public open class KinematicBody : PhysicsBody() {
    */
   public open var moveLockZ: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_GET_MOVE_LOCK_Z,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_KINEMATICBODY_SET_MOVE_LOCK_Z,
           NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Light.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Light.kt
@@ -91,12 +91,12 @@ public open class Light : VisualInstance() {
    */
   public open var lightEnergy: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_GET_LIGHT_ENERGY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_SET_LIGHT_ENERGY, NIL)
     }
 
@@ -105,13 +105,13 @@ public open class Light : VisualInstance() {
    */
   public open var lightIndirectEnergy: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_GET_LIGHT_INDIRECT_ENERGY,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_SET_LIGHT_INDIRECT_ENERGY,
           NIL)
     }
@@ -135,12 +135,12 @@ public open class Light : VisualInstance() {
    */
   public open var lightSize: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_GET_LIGHT_SIZE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_SET_LIGHT_SIZE, NIL)
     }
 
@@ -149,12 +149,12 @@ public open class Light : VisualInstance() {
    */
   public open var lightSpecular: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_GET_LIGHT_SPECULAR, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_SET_LIGHT_SPECULAR, NIL)
     }
 
@@ -163,12 +163,12 @@ public open class Light : VisualInstance() {
    */
   public open var shadowBias: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_GET_SHADOW_BIAS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 14L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_SET_SHADOW_BIAS, NIL)
     }
 
@@ -191,12 +191,12 @@ public open class Light : VisualInstance() {
    */
   public open var shadowContact: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_GET_SHADOW_CONTACT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_LIGHT_SET_SHADOW_CONTACT, NIL)
     }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/NinePatchRect.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/NinePatchRect.kt
@@ -86,13 +86,13 @@ public open class NinePatchRect : Control() {
    */
   public open var patchMarginBottom: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_NINEPATCHRECT_GET_PATCH_MARGIN_BOTTOM, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 3L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_NINEPATCHRECT_SET_PATCH_MARGIN_BOTTOM, NIL)
     }
@@ -102,13 +102,13 @@ public open class NinePatchRect : Control() {
    */
   public open var patchMarginLeft: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_NINEPATCHRECT_GET_PATCH_MARGIN_LEFT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 0L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_NINEPATCHRECT_SET_PATCH_MARGIN_LEFT, NIL)
     }
@@ -118,13 +118,13 @@ public open class NinePatchRect : Control() {
    */
   public open var patchMarginRight: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_NINEPATCHRECT_GET_PATCH_MARGIN_RIGHT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 2L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_NINEPATCHRECT_SET_PATCH_MARGIN_RIGHT, NIL)
     }
@@ -134,13 +134,13 @@ public open class NinePatchRect : Control() {
    */
   public open var patchMarginTop: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_NINEPATCHRECT_GET_PATCH_MARGIN_TOP, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 1L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_NINEPATCHRECT_SET_PATCH_MARGIN_TOP, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Particles.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Particles.kt
@@ -71,12 +71,12 @@ public open class Particles : GeometryInstance() {
    */
   public open var drawPass1: Mesh?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLES_GET_DRAW_PASS_1, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Mesh?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 0L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLES_SET_DRAW_PASS_1, NIL)
     }
 
@@ -85,12 +85,12 @@ public open class Particles : GeometryInstance() {
    */
   public open var drawPass2: Mesh?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLES_GET_DRAW_PASS_2, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Mesh?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 1L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLES_SET_DRAW_PASS_2, NIL)
     }
 
@@ -99,12 +99,12 @@ public open class Particles : GeometryInstance() {
    */
   public open var drawPass3: Mesh?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLES_GET_DRAW_PASS_3, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Mesh?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 2L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLES_SET_DRAW_PASS_3, NIL)
     }
 
@@ -113,12 +113,12 @@ public open class Particles : GeometryInstance() {
    */
   public open var drawPass4: Mesh?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLES_GET_DRAW_PASS_4, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Mesh?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 3L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLES_SET_DRAW_PASS_4, NIL)
     }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/ParticlesMaterial.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/ParticlesMaterial.kt
@@ -41,13 +41,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var angle: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANGLE,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANGLE, NIL)
     }
 
@@ -56,13 +56,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var angleCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANGLE_CURVE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 7L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANGLE_CURVE,
           NIL)
     }
@@ -72,13 +72,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var angleRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANGLE_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANGLE_RANDOM, NIL)
     }
@@ -90,13 +90,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var angularVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANGULAR_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANGULAR_VELOCITY, NIL)
     }
@@ -106,13 +106,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var angularVelocityCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANGULAR_VELOCITY_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 1L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANGULAR_VELOCITY_CURVE, NIL)
     }
@@ -122,13 +122,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var angularVelocityRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANGULAR_VELOCITY_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANGULAR_VELOCITY_RANDOM, NIL)
     }
@@ -138,13 +138,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var animOffset: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANIM_OFFSET,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 11L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANIM_OFFSET,
           NIL)
     }
@@ -154,13 +154,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var animOffsetCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANIM_OFFSET_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 11L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANIM_OFFSET_CURVE, NIL)
     }
@@ -170,13 +170,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var animOffsetRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANIM_OFFSET_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 11L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANIM_OFFSET_RANDOM, NIL)
     }
@@ -186,13 +186,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var animSpeed: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANIM_SPEED,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 10L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANIM_SPEED,
           NIL)
     }
@@ -202,13 +202,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var animSpeedCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANIM_SPEED_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 10L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANIM_SPEED_CURVE, NIL)
     }
@@ -218,13 +218,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var animSpeedRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ANIM_SPEED_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 10L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ANIM_SPEED_RANDOM, NIL)
     }
@@ -265,13 +265,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_DAMPING,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_DAMPING,
           NIL)
     }
@@ -281,13 +281,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var dampingCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_DAMPING_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 6L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_DAMPING_CURVE, NIL)
     }
@@ -297,13 +297,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var dampingRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_DAMPING_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_DAMPING_RANDOM, NIL)
     }
@@ -505,13 +505,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var flagAlignY: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_FLAG_ALIGN_Y, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_FLAG_ALIGN_Y, NIL)
     }
@@ -521,13 +521,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var flagDisableZ: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_FLAG_DISABLE_Z, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_FLAG_DISABLE_Z, NIL)
     }
@@ -537,13 +537,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var flagRotateY: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_FLAG_ROTATE_Y, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_FLAG_ROTATE_Y, NIL)
     }
@@ -585,13 +585,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var hueVariation: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_HUE_VARIATION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_HUE_VARIATION, NIL)
     }
@@ -601,13 +601,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var hueVariationCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_HUE_VARIATION_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 9L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_HUE_VARIATION_CURVE, NIL)
     }
@@ -617,13 +617,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var hueVariationRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_HUE_VARIATION_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_HUE_VARIATION_RANDOM, NIL)
     }
@@ -633,13 +633,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var initialVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_INITIAL_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_INITIAL_VELOCITY, NIL)
     }
@@ -649,13 +649,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var initialVelocityRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_INITIAL_VELOCITY_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_INITIAL_VELOCITY_RANDOM, NIL)
     }
@@ -681,13 +681,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var linearAccel: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_LINEAR_ACCEL, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_LINEAR_ACCEL, NIL)
     }
@@ -697,13 +697,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var linearAccelCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_LINEAR_ACCEL_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 3L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_LINEAR_ACCEL_CURVE, NIL)
     }
@@ -713,13 +713,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var linearAccelRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_LINEAR_ACCEL_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_LINEAR_ACCEL_RANDOM, NIL)
     }
@@ -731,13 +731,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var orbitVelocity: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ORBIT_VELOCITY, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ORBIT_VELOCITY, NIL)
     }
@@ -747,13 +747,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var orbitVelocityCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ORBIT_VELOCITY_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 2L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ORBIT_VELOCITY_CURVE, NIL)
     }
@@ -763,13 +763,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var orbitVelocityRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_ORBIT_VELOCITY_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_ORBIT_VELOCITY_RANDOM, NIL)
     }
@@ -779,13 +779,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var radialAccel: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_RADIAL_ACCEL, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_RADIAL_ACCEL, NIL)
     }
@@ -795,13 +795,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var radialAccelCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_RADIAL_ACCEL_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 4L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_RADIAL_ACCEL_CURVE, NIL)
     }
@@ -811,13 +811,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var radialAccelRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_RADIAL_ACCEL_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_RADIAL_ACCEL_RANDOM, NIL)
     }
@@ -827,13 +827,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var scale: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_SCALE,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_SCALE, NIL)
     }
 
@@ -842,13 +842,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var scaleCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_SCALE_CURVE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 8L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_SCALE_CURVE,
           NIL)
     }
@@ -858,13 +858,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var scaleRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_SCALE_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_SCALE_RANDOM, NIL)
     }
@@ -889,13 +889,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var tangentialAccel: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_TANGENTIAL_ACCEL, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_TANGENTIAL_ACCEL, NIL)
     }
@@ -905,13 +905,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var tangentialAccelCurve: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_TANGENTIAL_ACCEL_CURVE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 5L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_TANGENTIAL_ACCEL_CURVE, NIL)
     }
@@ -921,13 +921,13 @@ public open class ParticlesMaterial : Material() {
    */
   public open var tangentialAccelRandom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_GET_TANGENTIAL_ACCEL_RANDOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_PARTICLESMATERIAL_SET_TANGENTIAL_ACCEL_RANDOM, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/PinJoint.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/PinJoint.kt
@@ -8,6 +8,7 @@ package godot
 import godot.`annotation`.GodotBaseType
 import godot.core.TransferContext
 import godot.core.VariantType.DOUBLE
+import godot.core.VariantType.LONG
 import godot.core.VariantType.NIL
 import kotlin.Double
 import kotlin.Long
@@ -23,36 +24,36 @@ import kotlin.Unit
 public open class PinJoint : Joint() {
   public open var params_bias: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PINJOINT_GET_PARAMS_BIAS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PINJOINT_SET_PARAMS_BIAS, NIL)
     }
 
   public open var params_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PINJOINT_GET_PARAMS_DAMPING,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PINJOINT_SET_PARAMS_DAMPING, NIL)
     }
 
   public open var params_impulseClamp: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PINJOINT_GET_PARAMS_IMPULSE_CLAMP,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_PINJOINT_SET_PARAMS_IMPULSE_CLAMP,
           NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/RigidBody.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/RigidBody.kt
@@ -140,13 +140,13 @@ public open class RigidBody : PhysicsBody() {
    */
   public open var axisLockAngularX: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_GET_AXIS_LOCK_ANGULAR_X,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 8L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_SET_AXIS_LOCK_ANGULAR_X,
           NIL)
     }
@@ -156,13 +156,13 @@ public open class RigidBody : PhysicsBody() {
    */
   public open var axisLockAngularY: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_GET_AXIS_LOCK_ANGULAR_Y,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 16L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_SET_AXIS_LOCK_ANGULAR_Y,
           NIL)
     }
@@ -172,13 +172,13 @@ public open class RigidBody : PhysicsBody() {
    */
   public open var axisLockAngularZ: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 32L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_GET_AXIS_LOCK_ANGULAR_Z,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 32L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_SET_AXIS_LOCK_ANGULAR_Z,
           NIL)
     }
@@ -188,13 +188,13 @@ public open class RigidBody : PhysicsBody() {
    */
   public open var axisLockLinearX: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_GET_AXIS_LOCK_LINEAR_X,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_SET_AXIS_LOCK_LINEAR_X,
           NIL)
     }
@@ -204,13 +204,13 @@ public open class RigidBody : PhysicsBody() {
    */
   public open var axisLockLinearY: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_GET_AXIS_LOCK_LINEAR_Y,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_SET_AXIS_LOCK_LINEAR_Y,
           NIL)
     }
@@ -220,13 +220,13 @@ public open class RigidBody : PhysicsBody() {
    */
   public open var axisLockLinearZ: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_GET_AXIS_LOCK_LINEAR_Z,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_RIGIDBODY_SET_AXIS_LOCK_LINEAR_Z,
           NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/SliderJoint.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/SliderJoint.kt
@@ -8,6 +8,7 @@ package godot
 import godot.`annotation`.GodotBaseType
 import godot.core.TransferContext
 import godot.core.VariantType.DOUBLE
+import godot.core.VariantType.LONG
 import godot.core.VariantType.NIL
 import kotlin.Double
 import kotlin.Long
@@ -24,260 +25,260 @@ import kotlin.Unit
 public open class SliderJoint : Joint() {
   public open var angularLimit_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_ANGULAR_LIMIT_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 15L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_ANGULAR_LIMIT_DAMPING, NIL)
     }
 
   public open var angularLimit_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_ANGULAR_LIMIT_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 14L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_ANGULAR_LIMIT_RESTITUTION, NIL)
     }
 
   public open var angularLimit_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_ANGULAR_LIMIT_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 13L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_ANGULAR_LIMIT_SOFTNESS, NIL)
     }
 
   public open var angularMotion_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_ANGULAR_MOTION_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 18L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_ANGULAR_MOTION_DAMPING, NIL)
     }
 
   public open var angularMotion_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_ANGULAR_MOTION_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 17L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_ANGULAR_MOTION_RESTITUTION, NIL)
     }
 
   public open var angularMotion_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_ANGULAR_MOTION_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 16L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_ANGULAR_MOTION_SOFTNESS, NIL)
     }
 
   public open var angularOrtho_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 21L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_ANGULAR_ORTHO_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 21L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_ANGULAR_ORTHO_DAMPING, NIL)
     }
 
   public open var angularOrtho_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 20L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_ANGULAR_ORTHO_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 20L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_ANGULAR_ORTHO_RESTITUTION, NIL)
     }
 
   public open var angularOrtho_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 19L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_ANGULAR_ORTHO_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 19L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_ANGULAR_ORTHO_SOFTNESS, NIL)
     }
 
   public open var linearLimit_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_LIMIT_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 4L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_LIMIT_DAMPING, NIL)
     }
 
   public open var linearLimit_lowerDistance: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_LIMIT_LOWER_DISTANCE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_LIMIT_LOWER_DISTANCE, NIL)
     }
 
   public open var linearLimit_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_LIMIT_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_LIMIT_RESTITUTION, NIL)
     }
 
   public open var linearLimit_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_LIMIT_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_LIMIT_SOFTNESS, NIL)
     }
 
   public open var linearLimit_upperDistance: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_LIMIT_UPPER_DISTANCE, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_LIMIT_UPPER_DISTANCE, NIL)
     }
 
   public open var linearMotion_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_MOTION_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 7L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_MOTION_DAMPING, NIL)
     }
 
   public open var linearMotion_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_MOTION_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 6L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_MOTION_RESTITUTION, NIL)
     }
 
   public open var linearMotion_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_MOTION_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 5L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_MOTION_SOFTNESS, NIL)
     }
 
   public open var linearOrtho_damping: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_ORTHO_DAMPING, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 10L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_ORTHO_DAMPING, NIL)
     }
 
   public open var linearOrtho_restitution: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_ORTHO_RESTITUTION, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 9L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_ORTHO_RESTITUTION, NIL)
     }
 
   public open var linearOrtho_softness: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_GET_LINEAR_ORTHO_SOFTNESS, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 8L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SLIDERJOINT_SET_LINEAR_ORTHO_SOFTNESS, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/SpatialMaterial.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/SpatialMaterial.kt
@@ -54,13 +54,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var albedoTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_ALBEDO_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 0L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_ALBEDO_TEXTURE, NIL)
     }
@@ -86,13 +86,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var anisotropyEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_ANISOTROPY_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 5L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_ANISOTROPY_ENABLED, NIL)
     }
@@ -102,13 +102,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var anisotropyFlowmap: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_ANISOTROPY_FLOWMAP, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 7L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_ANISOTROPY_FLOWMAP, NIL)
     }
@@ -118,13 +118,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var aoEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_AO_ENABLED,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 6L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_AO_ENABLED,
           NIL)
     }
@@ -150,13 +150,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var aoOnUv2: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_AO_ON_UV2,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 11L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_AO_ON_UV2,
           NIL)
     }
@@ -166,13 +166,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var aoTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_AO_TEXTURE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 8L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_AO_TEXTURE,
           NIL)
     }
@@ -216,13 +216,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var clearcoatEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_CLEARCOAT_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_CLEARCOAT_ENABLED, NIL)
     }
@@ -248,13 +248,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var clearcoatTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_CLEARCOAT_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 6L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_CLEARCOAT_TEXTURE, NIL)
     }
@@ -282,13 +282,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var depthEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_DEPTH_ENABLED,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 7L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_DEPTH_ENABLED,
           NIL)
     }
@@ -378,13 +378,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var depthTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_DEPTH_TEXTURE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 9L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_DEPTH_TEXTURE,
           NIL)
     }
@@ -394,13 +394,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var detailAlbedo: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_DETAIL_ALBEDO,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 14L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_DETAIL_ALBEDO,
           NIL)
     }
@@ -426,13 +426,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var detailEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_DETAIL_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 11L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_DETAIL_ENABLED, NIL)
     }
@@ -442,13 +442,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var detailMask: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_DETAIL_MASK,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 13L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_DETAIL_MASK,
           NIL)
     }
@@ -460,13 +460,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var detailNormal: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_DETAIL_NORMAL,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 15L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_DETAIL_NORMAL,
           NIL)
     }
@@ -559,13 +559,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var emissionEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_EMISSION_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_EMISSION_ENABLED, NIL)
     }
@@ -591,13 +591,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var emissionOnUv2: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_EMISSION_ON_UV2, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 12L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_EMISSION_ON_UV2, NIL)
     }
@@ -623,13 +623,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var emissionTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_EMISSION_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 3L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_EMISSION_TEXTURE, NIL)
     }
@@ -639,13 +639,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsAlbedoTexForceSrgb: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 14L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_ALBEDO_TEX_FORCE_SRGB, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 14L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_ALBEDO_TEX_FORCE_SRGB, NIL)
     }
@@ -655,13 +655,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsDisableAmbientLight: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_DISABLE_AMBIENT_LIGHT, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 17L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_DISABLE_AMBIENT_LIGHT, NIL)
     }
@@ -671,13 +671,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsDoNotReceiveShadows: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 15L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_DO_NOT_RECEIVE_SHADOWS, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 15L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_DO_NOT_RECEIVE_SHADOWS, NIL)
     }
@@ -687,13 +687,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsEnsureCorrectNormals: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 16L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_ENSURE_CORRECT_NORMALS, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 16L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_ENSURE_CORRECT_NORMALS, NIL)
     }
@@ -703,13 +703,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsFixedSize: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 6L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_FIXED_SIZE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 6L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_FIXED_SIZE, NIL)
     }
@@ -719,13 +719,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsNoDepthTest: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_NO_DEPTH_TEST, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_NO_DEPTH_TEST, NIL)
     }
@@ -735,13 +735,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsTransparent: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_TRANSPARENT, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_TRANSPARENT, NIL)
     }
@@ -751,13 +751,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsUnshaded: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_UNSHADED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_UNSHADED, NIL)
     }
@@ -769,13 +769,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsUsePointSize: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_USE_POINT_SIZE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 5L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_USE_POINT_SIZE, NIL)
     }
@@ -785,13 +785,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsUseShadowToOpacity: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 18L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_USE_SHADOW_TO_OPACITY, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 18L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_USE_SHADOW_TO_OPACITY, NIL)
     }
@@ -801,13 +801,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsVertexLighting: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_VERTEX_LIGHTING, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_VERTEX_LIGHTING, NIL)
     }
@@ -817,13 +817,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var flagsWorldTriplanar: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_FLAGS_WORLD_TRIPLANAR, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 10L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_FLAGS_WORLD_TRIPLANAR, NIL)
     }
@@ -866,13 +866,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var metallicTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_METALLIC_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 1L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_METALLIC_TEXTURE, NIL)
     }
@@ -898,13 +898,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var normalEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_NORMAL_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_NORMAL_ENABLED, NIL)
     }
@@ -934,13 +934,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var normalTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_NORMAL_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 4L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_NORMAL_TEXTURE, NIL)
     }
@@ -966,13 +966,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var paramsBillboardKeepScale: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 7L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_PARAMS_BILLBOARD_KEEP_SCALE, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 7L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_PARAMS_BILLBOARD_KEEP_SCALE, NIL)
     }
@@ -1146,13 +1146,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var paramsUseAlphaScissor: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 13L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_PARAMS_USE_ALPHA_SCISSOR, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 13L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_PARAMS_USE_ALPHA_SCISSOR, NIL)
     }
@@ -1242,13 +1242,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var refractionEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_REFRACTION_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 10L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_REFRACTION_ENABLED, NIL)
     }
@@ -1274,13 +1274,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var refractionTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 12L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_REFRACTION_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 12L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_REFRACTION_TEXTURE, NIL)
     }
@@ -1322,13 +1322,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var rimEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_RIM_ENABLED,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 3L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_RIM_ENABLED,
           NIL)
     }
@@ -1338,13 +1338,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var rimTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_RIM_TEXTURE,
           OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 5L, OBJECT to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_RIM_TEXTURE,
           NIL)
     }
@@ -1385,13 +1385,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var roughnessTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_ROUGHNESS_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 2L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_ROUGHNESS_TEXTURE, NIL)
     }
@@ -1417,13 +1417,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var subsurfScatterEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_SUBSURF_SCATTER_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 8L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_SUBSURF_SCATTER_ENABLED, NIL)
     }
@@ -1449,13 +1449,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var subsurfScatterTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 10L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_SUBSURF_SCATTER_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 10L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_SUBSURF_SCATTER_TEXTURE, NIL)
     }
@@ -1481,13 +1481,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var transmissionEnabled: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_TRANSMISSION_ENABLED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 9L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_TRANSMISSION_ENABLED, NIL)
     }
@@ -1497,13 +1497,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var transmissionTexture: Texture?
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 11L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_TRANSMISSION_TEXTURE, OBJECT)
       return TransferContext.readReturnValue(OBJECT, true) as Texture?
     }
     set(`value`) {
-      TransferContext.writeArguments(OBJECT to value)
+      TransferContext.writeArguments(LONG to 11L, OBJECT to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_TRANSMISSION_TEXTURE, NIL)
     }
@@ -1545,13 +1545,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var uv1Triplanar: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_UV1_TRIPLANAR,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 8L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_UV1_TRIPLANAR,
           NIL)
     }
@@ -1609,13 +1609,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var uv2Triplanar: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 9L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_UV2_TRIPLANAR,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 9L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_UV2_TRIPLANAR,
           NIL)
     }
@@ -1641,13 +1641,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var vertexColorIsSrgb: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_VERTEX_COLOR_IS_SRGB, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_VERTEX_COLOR_IS_SRGB, NIL)
     }
@@ -1657,13 +1657,13 @@ public open class SpatialMaterial : Material() {
    */
   public open var vertexColorUseAsAlbedo: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_VERTEX_COLOR_USE_AS_ALBEDO, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 3L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_VERTEX_COLOR_USE_AS_ALBEDO, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/SpriteBase3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/SpriteBase3D.kt
@@ -93,13 +93,13 @@ public open class SpriteBase3D : GeometryInstance() {
    */
   public open var doubleSided: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPRITEBASE3D_GET_DOUBLE_SIDED,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPRITEBASE3D_SET_DOUBLE_SIDED,
           NIL)
     }
@@ -194,12 +194,12 @@ public open class SpriteBase3D : GeometryInstance() {
    */
   public open var shaded: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPRITEBASE3D_GET_SHADED, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPRITEBASE3D_SET_SHADED, NIL)
     }
 
@@ -208,13 +208,13 @@ public open class SpriteBase3D : GeometryInstance() {
    */
   public open var transparent: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPRITEBASE3D_GET_TRANSPARENT,
           BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_SPRITEBASE3D_SET_TRANSPARENT, NIL)
     }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/StyleBox.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/StyleBox.kt
@@ -44,13 +44,13 @@ public open class StyleBox : Resource() {
    */
   public open var contentMarginBottom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOX_GET_CONTENT_MARGIN_BOTTOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOX_SET_CONTENT_MARGIN_BOTTOM, NIL)
     }
@@ -62,13 +62,13 @@ public open class StyleBox : Resource() {
    */
   public open var contentMarginLeft: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOX_GET_CONTENT_MARGIN_LEFT,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOX_SET_CONTENT_MARGIN_LEFT,
           NIL)
     }
@@ -80,13 +80,13 @@ public open class StyleBox : Resource() {
    */
   public open var contentMarginRight: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOX_GET_CONTENT_MARGIN_RIGHT,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOX_SET_CONTENT_MARGIN_RIGHT,
           NIL)
     }
@@ -98,13 +98,13 @@ public open class StyleBox : Resource() {
    */
   public open var contentMarginTop: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOX_GET_CONTENT_MARGIN_TOP,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOX_SET_CONTENT_MARGIN_TOP,
           NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/StyleBoxFlat.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/StyleBoxFlat.kt
@@ -137,13 +137,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var borderWidthBottom: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_BORDER_WIDTH_BOTTOM, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 3L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_BORDER_WIDTH_BOTTOM, NIL)
     }
@@ -153,13 +153,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var borderWidthLeft: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_BORDER_WIDTH_LEFT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 0L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_BORDER_WIDTH_LEFT, NIL)
     }
@@ -169,13 +169,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var borderWidthRight: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_BORDER_WIDTH_RIGHT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 2L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_BORDER_WIDTH_RIGHT, NIL)
     }
@@ -185,13 +185,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var borderWidthTop: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_BORDER_WIDTH_TOP,
           LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 1L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_BORDER_WIDTH_TOP,
           NIL)
     }
@@ -221,13 +221,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var cornerRadiusBottomLeft: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_CORNER_RADIUS_BOTTOM_LEFT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 3L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_CORNER_RADIUS_BOTTOM_LEFT, NIL)
     }
@@ -237,13 +237,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var cornerRadiusBottomRight: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_CORNER_RADIUS_BOTTOM_RIGHT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 2L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_CORNER_RADIUS_BOTTOM_RIGHT, NIL)
     }
@@ -253,13 +253,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var cornerRadiusTopLeft: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_CORNER_RADIUS_TOP_LEFT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 0L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_CORNER_RADIUS_TOP_LEFT, NIL)
     }
@@ -269,13 +269,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var cornerRadiusTopRight: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_CORNER_RADIUS_TOP_RIGHT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 1L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_CORNER_RADIUS_TOP_RIGHT, NIL)
     }
@@ -300,13 +300,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var expandMarginBottom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_EXPAND_MARGIN_BOTTOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_EXPAND_MARGIN_BOTTOM, NIL)
     }
@@ -316,13 +316,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var expandMarginLeft: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_EXPAND_MARGIN_LEFT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_EXPAND_MARGIN_LEFT, NIL)
     }
@@ -332,13 +332,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var expandMarginRight: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_EXPAND_MARGIN_RIGHT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_EXPAND_MARGIN_RIGHT, NIL)
     }
@@ -348,13 +348,13 @@ public open class StyleBoxFlat : StyleBox() {
    */
   public open var expandMarginTop: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_GET_EXPAND_MARGIN_TOP, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXFLAT_SET_EXPAND_MARGIN_TOP, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/StyleBoxTexture.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/StyleBoxTexture.kt
@@ -90,13 +90,13 @@ public open class StyleBoxTexture : StyleBox() {
    */
   public open var expandMarginBottom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_GET_EXPAND_MARGIN_BOTTOM, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_SET_EXPAND_MARGIN_BOTTOM, NIL)
     }
@@ -106,13 +106,13 @@ public open class StyleBoxTexture : StyleBox() {
    */
   public open var expandMarginLeft: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_GET_EXPAND_MARGIN_LEFT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_SET_EXPAND_MARGIN_LEFT, NIL)
     }
@@ -122,13 +122,13 @@ public open class StyleBoxTexture : StyleBox() {
    */
   public open var expandMarginRight: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_GET_EXPAND_MARGIN_RIGHT, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_SET_EXPAND_MARGIN_RIGHT, NIL)
     }
@@ -138,13 +138,13 @@ public open class StyleBoxTexture : StyleBox() {
    */
   public open var expandMarginTop: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_GET_EXPAND_MARGIN_TOP, DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_SET_EXPAND_MARGIN_TOP, NIL)
     }
@@ -158,13 +158,13 @@ public open class StyleBoxTexture : StyleBox() {
    */
   public open var marginBottom: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_GET_MARGIN_BOTTOM,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 3L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_SET_MARGIN_BOTTOM,
           NIL)
     }
@@ -178,13 +178,13 @@ public open class StyleBoxTexture : StyleBox() {
    */
   public open var marginLeft: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_GET_MARGIN_LEFT,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 0L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_SET_MARGIN_LEFT,
           NIL)
     }
@@ -198,13 +198,13 @@ public open class StyleBoxTexture : StyleBox() {
    */
   public open var marginRight: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_GET_MARGIN_RIGHT,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 2L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_SET_MARGIN_RIGHT,
           NIL)
     }
@@ -218,13 +218,13 @@ public open class StyleBoxTexture : StyleBox() {
    */
   public open var marginTop: Double
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_GET_MARGIN_TOP,
           DOUBLE)
       return TransferContext.readReturnValue(DOUBLE, false) as Double
     }
     set(`value`) {
-      TransferContext.writeArguments(DOUBLE to value)
+      TransferContext.writeArguments(LONG to 1L, DOUBLE to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_STYLEBOXTEXTURE_SET_MARGIN_TOP,
           NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/TextureProgress.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/TextureProgress.kt
@@ -117,13 +117,13 @@ public open class TextureProgress : Range() {
    */
   public open var stretchMarginBottom: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_TEXTUREPROGRESS_GET_STRETCH_MARGIN_BOTTOM, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 3L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_TEXTUREPROGRESS_SET_STRETCH_MARGIN_BOTTOM, NIL)
     }
@@ -133,13 +133,13 @@ public open class TextureProgress : Range() {
    */
   public open var stretchMarginLeft: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_TEXTUREPROGRESS_GET_STRETCH_MARGIN_LEFT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 0L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_TEXTUREPROGRESS_SET_STRETCH_MARGIN_LEFT, NIL)
     }
@@ -149,13 +149,13 @@ public open class TextureProgress : Range() {
    */
   public open var stretchMarginRight: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_TEXTUREPROGRESS_GET_STRETCH_MARGIN_RIGHT, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 2L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_TEXTUREPROGRESS_SET_STRETCH_MARGIN_RIGHT, NIL)
     }
@@ -165,13 +165,13 @@ public open class TextureProgress : Range() {
    */
   public open var stretchMarginTop: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_TEXTUREPROGRESS_GET_STRETCH_MARGIN_TOP, LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 1L, LONG to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_TEXTUREPROGRESS_SET_STRETCH_MARGIN_TOP, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Viewport.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Viewport.kt
@@ -394,13 +394,13 @@ public open class Viewport : Node() {
    */
   public open var shadowAtlasQuad0: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_VIEWPORT_GET_SHADOW_ATLAS_QUAD_0,
           LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 0L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_VIEWPORT_SET_SHADOW_ATLAS_QUAD_0,
           NIL)
     }
@@ -410,13 +410,13 @@ public open class Viewport : Node() {
    */
   public open var shadowAtlasQuad1: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_VIEWPORT_GET_SHADOW_ATLAS_QUAD_1,
           LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 1L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_VIEWPORT_SET_SHADOW_ATLAS_QUAD_1,
           NIL)
     }
@@ -426,13 +426,13 @@ public open class Viewport : Node() {
    */
   public open var shadowAtlasQuad2: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_VIEWPORT_GET_SHADOW_ATLAS_QUAD_2,
           LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 2L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_VIEWPORT_SET_SHADOW_ATLAS_QUAD_2,
           NIL)
     }
@@ -442,13 +442,13 @@ public open class Viewport : Node() {
    */
   public open var shadowAtlasQuad3: Long
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_VIEWPORT_GET_SHADOW_ATLAS_QUAD_3,
           LONG)
       return TransferContext.readReturnValue(LONG, false) as Long
     }
     set(`value`) {
-      TransferContext.writeArguments(LONG to value)
+      TransferContext.writeArguments(LONG to 3L, LONG to value)
       TransferContext.callMethod(rawPtr, ENGINEMETHOD_ENGINECLASS_VIEWPORT_SET_SHADOW_ATLAS_QUAD_3,
           NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/VisibilityEnabler.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/VisibilityEnabler.kt
@@ -8,6 +8,7 @@ package godot
 import godot.`annotation`.GodotBaseType
 import godot.core.TransferContext
 import godot.core.VariantType.BOOL
+import godot.core.VariantType.LONG
 import godot.core.VariantType.NIL
 import kotlin.Boolean
 import kotlin.Long
@@ -32,13 +33,13 @@ public open class VisibilityEnabler : VisibilityNotifier() {
    */
   public open var freezeBodies: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER_GET_FREEZE_BODIES, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER_SET_FREEZE_BODIES, NIL)
     }
@@ -48,13 +49,13 @@ public open class VisibilityEnabler : VisibilityNotifier() {
    */
   public open var pauseAnimations: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER_GET_PAUSE_ANIMATIONS, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER_SET_PAUSE_ANIMATIONS, NIL)
     }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/VisibilityEnabler2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/VisibilityEnabler2D.kt
@@ -8,6 +8,7 @@ package godot
 import godot.`annotation`.GodotBaseType
 import godot.core.TransferContext
 import godot.core.VariantType.BOOL
+import godot.core.VariantType.LONG
 import godot.core.VariantType.NIL
 import kotlin.Boolean
 import kotlin.Long
@@ -32,13 +33,13 @@ public open class VisibilityEnabler2D : VisibilityNotifier2D() {
    */
   public open var freezeBodies: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 1L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_GET_FREEZE_BODIES, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 1L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_SET_FREEZE_BODIES, NIL)
     }
@@ -48,13 +49,13 @@ public open class VisibilityEnabler2D : VisibilityNotifier2D() {
    */
   public open var pauseAnimatedSprites: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 5L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_GET_PAUSE_ANIMATED_SPRITES, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 5L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_SET_PAUSE_ANIMATED_SPRITES, NIL)
     }
@@ -64,13 +65,13 @@ public open class VisibilityEnabler2D : VisibilityNotifier2D() {
    */
   public open var pauseAnimations: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 0L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_GET_PAUSE_ANIMATIONS, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 0L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_SET_PAUSE_ANIMATIONS, NIL)
     }
@@ -80,13 +81,13 @@ public open class VisibilityEnabler2D : VisibilityNotifier2D() {
    */
   public open var pauseParticles: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_GET_PAUSE_PARTICLES, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 2L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_SET_PAUSE_PARTICLES, NIL)
     }
@@ -96,13 +97,13 @@ public open class VisibilityEnabler2D : VisibilityNotifier2D() {
    */
   public open var physicsProcessParent: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 4L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_GET_PHYSICS_PROCESS_PARENT, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 4L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_SET_PHYSICS_PROCESS_PARENT, NIL)
     }
@@ -112,13 +113,13 @@ public open class VisibilityEnabler2D : VisibilityNotifier2D() {
    */
   public open var processParent: Boolean
     get() {
-      TransferContext.writeArguments()
+      TransferContext.writeArguments(LONG to 3L)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_GET_PROCESS_PARENT, BOOL)
       return TransferContext.readReturnValue(BOOL, false) as Boolean
     }
     set(`value`) {
-      TransferContext.writeArguments(BOOL to value)
+      TransferContext.writeArguments(LONG to 3L, BOOL to value)
       TransferContext.callMethod(rawPtr,
           ENGINEMETHOD_ENGINECLASS_VISIBILITYENABLER2D_SET_PROCESS_PARENT, NIL)
     }


### PR DESCRIPTION
Some of Godot's property getter/setters have an additional index parameter, specified with the `index` field of the property metadata.

For those properties the `api-generator` within `godot-kotlin-jvm` is not including the index arguments in the generated property code, causing the setters for indexed properties to throw exceptions.

The indexed getters seem to be working without the extra index property.  I'm not sure how that is.

This PR adds code to `api-generator`'s `Property::generate` so that the generated code includes the indexed arguments for properties that need them.

For example, the code generated for `SpatialMaterial::albedoTexture` (which has a hard-coded index of 0) looks like this after the PR:
```kotlin
  public open var albedoTexture: Texture?
    get() {
      TransferContext.writeArguments(JVM_INT to 0)
      TransferContext.callMethod(rawPtr,
          ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_GET_ALBEDO_TEXTURE, OBJECT)
      return TransferContext.readReturnValue(OBJECT, true) as Texture?
    }
    set(`value`) {
      TransferContext.writeArguments(JVM_INT to 0, OBJECT to value)
      TransferContext.callMethod(rawPtr,
          ENGINEMETHOD_ENGINECLASS_SPATIALMATERIAL_SET_ALBEDO_TEXTURE, NIL)
    }
```

Where before those two `writeArguments` lines were:
```kotlin
TransferContext.writeArguments()
```
and
```kotlin
TransferContext.writeArguments(OBJECT to value)
```

Even though only the setters were throwing exceptions, I also added the index parameter to the getter because that seems like the more accurate call.  I haven't been able to verify yet but maybe there is some additional code on the C++ side that is filling in the gaps for the indexed getter calls?

My understanding is that `godot-kotlin-jvm` is using `Long` instead of `Int` for interop, though in this case using `Long` for the indexed properties was failing while using `Int` is working.  I'm guessing maybe that's because the index parameter is not a formally exposed element of the Godot API and is instead a lower-level implementation detail.

For the current version of the API this PR affects 32 generated files.  I left the generated files out of the PR to keep the PR minimal but can add them if needed.

I've tested some of the indexed property cases and everything I have tested is working.  I have not comprehensively tested every property affected by this PR.