### PR TITLE
bugfix/enforce msvc for windows ci

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -58,7 +58,7 @@ jobs:
             platform: osx
             arch: arm64
           - name: Windows
-            os: windows-latest
+            os: windows-2019
             platform: windows
             arch: 64
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -25,7 +25,7 @@ jobs:
             platform: osx
             arch: arm64
           - name: Windows
-            os: windows-latest
+            os: windows-2019
             platform: windows
             arch: 64
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -25,7 +25,7 @@ jobs:
             platform: osx
             arch: arm64
           - name: Windows
-            os: windows-latest
+            os: windows-2019
             platform: windows
             arch: 64
           - name: Android

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -25,7 +25,7 @@ jobs:
             platform: osx
             arch: arm64
           - name: Windows
-            os: windows-latest
+            os: windows-2019
             platform: windows
             arch: 64
           - name: Android

--- a/.github/workflows/deploy-export-template-debug.yaml
+++ b/.github/workflows/deploy-export-template-debug.yaml
@@ -27,7 +27,7 @@ jobs:
             binary: godot.osx.opt.debug.64
             cat_command: cat
           - name: Windows
-            os: windows-latest
+            os: windows-2019
             platform: windows
             binary: godot.windows.opt.debug.64.exe
             cat_command: type

--- a/.github/workflows/deploy-export-template-release.yaml
+++ b/.github/workflows/deploy-export-template-release.yaml
@@ -27,7 +27,7 @@ jobs:
             binary: godot.osx.opt.64
             cat_command: cat
           - name: Windows
-            os: windows-latest
+            os: windows-2019
             platform: windows
             binary: godot.windows.opt.64.exe
             cat_command: type

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -27,7 +27,7 @@ jobs:
             binary: godot.osx.opt.tools.64
             cat_command: cat
           - name: Windows
-            os: windows-latest
+            os: windows-2019
             platform: windows
             binary: godot.windows.opt.tools.64.exe
             cat_command: type

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Overview
 
-This is a **Kotlin** language binding for the [**Godot**](https://godotengine.org/) game engine. It is built as a module (like the C# binding) to interact with **Godot**'s core internally. The binding provides you Godot API's as Kotlin classes, so you can write your game logic completely in Kotlin. Your code will be compiled into a .jar which is then executed by an embedded JVM, so you don't have to worry that your users have Java installed. It's already embedded in your games executable.
+This is a **Kotlin** language binding for the [**Godot**](https://godotengine.org/) game engine. It is built as a module (like the C# binding) to interact with **Godot**'s core internally. The binding provides you Godot API's as Kotlin classes, so you can write your game logic completely in Kotlin. Your code will be compiled into a .jar which is then executed by an embedded JVM, so you don't have to worry that your users have Java installed. It's already embedded in your game executable.
 You also don't have to worry about any binding logic. Just write your game scripts like you would for [GDScript](https://docs.godotengine.org/en/3.1/getting_started/scripting/gdscript/gdscript_basics.html) or [C#](https://docs.godotengine.org/en/3.1/getting_started/scripting/c_sharp/) but with all the syntactic sugar of Kotlin.
 
 [![GitHub](https://img.shields.io/github/license/utopia-rise/godot-kotlin-jvm?style=flat-square)](LICENSE)


### PR DESCRIPTION
This enforces windows server 2019 on windows build, as windows server 2022 runner does not find MSVC.