### PR TITLE
test resize and set for PoolRealArray, PoolVector2Array, PoolVector3Array

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -570,6 +570,16 @@ class Invocation : Spatial() {
 	fun getRealFromPoolArray(index: Int) = poolRealArray[index]
 
 	@RegisterFunction
+	fun setRealInPoolArray(index: Int, value: Double) {
+		poolRealArray[index] = value
+	}
+
+	@RegisterFunction
+	fun resizeRealPoolArray(newSize: Int) {
+		poolVector2Array.resize(newSize)
+	}
+
+	@RegisterFunction
 	fun addStringToPoolArray(string: String) = poolStringArray.append(string)
 
 	@RegisterFunction
@@ -594,6 +604,16 @@ class Invocation : Spatial() {
 	fun getVector2FromPoolArray(index: Int) = poolVector2Array[index]
 
 	@RegisterFunction
+	fun setVector2InPoolArray(index: Int, vector2: Vector2) {
+		poolVector2Array[index] = vector2
+	}
+
+	@RegisterFunction
+	fun resizeVector2PoolArray(newSize: Int) {
+		poolVector2Array.resize(newSize)
+	}
+
+	@RegisterFunction
 	fun addVector3ToPoolArray(vector3: Vector3) = poolVector3Array.append(vector3)
 
 	@RegisterFunction
@@ -604,6 +624,16 @@ class Invocation : Spatial() {
 
 	@RegisterFunction
 	fun getVector3FromPoolArray(index: Int) = poolVector3Array[index]
+
+	@RegisterFunction
+	fun setVector3InPoolArray(index: Int, vector3: Vector3) {
+		poolVector3Array[index] = vector3
+	}
+
+	@RegisterFunction
+	fun resizeVector3PoolArray(newSize: Int) {
+		poolVector3Array.resize(newSize)
+	}
 
 	// Singleton tests
 

--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -516,6 +516,16 @@ class Invocation : Spatial() {
 	fun getByteFromPoolArray(index: Int) = poolByteArray[index]
 
 	@RegisterFunction
+	fun setByteInPoolArray(index: Byte, value: Byte) {
+		poolByteArray[index] = value
+	}
+
+	@RegisterFunction
+	fun resizeBytePoolArray(newSize: Int) {
+		poolVector2Array.resize(newSize)
+	}
+
+	@RegisterFunction
 	fun addColorToPoolArray(color: Color) = poolColorArray.append(color)
 
 	@RegisterFunction
@@ -528,6 +538,16 @@ class Invocation : Spatial() {
 	fun getColorFromPoolArray(index: Int) = poolColorArray[index]
 
 	@RegisterFunction
+	fun setColorInPoolArray(index: Int, color: Color) {
+		poolColorArray[index] = color
+	}
+
+	@RegisterFunction
+	fun resizeColorPoolArray(newSize: Int) {
+		poolColorArray.resize(newSize)
+	}
+
+	@RegisterFunction
 	fun addIntToPoolArray(int: Int) = poolIntArray.append(int)
 
 	@RegisterFunction
@@ -538,6 +558,16 @@ class Invocation : Spatial() {
 
 	@RegisterFunction
 	fun getIntFromPoolArray(index: Int) = poolIntArray[index]
+
+	@RegisterFunction
+	fun setIntInPoolArray(index: Int, value: Int) {
+		poolIntArray[index] = value
+	}
+
+	@RegisterFunction
+	fun resizeIntPoolArray(newSize: Int) {
+		poolVector2Array.resize(newSize)
+	}
 
 	@RegisterFunction
 	fun addRealToPoolArray(realT: RealT) = poolRealArray.append(realT)
@@ -590,6 +620,16 @@ class Invocation : Spatial() {
 
 	@RegisterFunction
 	fun getStringFromPoolArray(index: Int) = poolStringArray[index]
+
+	@RegisterFunction
+	fun setStringInPoolArray(index: Int, value: String) {
+		poolStringArray[index] = value
+	}
+
+	@RegisterFunction
+	fun resizeStringPoolArray(newSize: Int) {
+		poolVector2Array.resize(newSize)
+	}
 
 	@RegisterFunction
 	fun addVector2ToPoolArray(vector2: Vector2) = poolVector2Array.append(vector2)

--- a/harness/tests/test/unit/test_pool_arrays.gd
+++ b/harness/tests/test/unit/test_pool_arrays.gd
@@ -10,6 +10,19 @@ func test_pool_byte_array_add_delete() -> void:
 	assert_eq(invocation_script.pool_byte_array.size(), 3, "PoolByteArray have 3 elements")
 	invocation_script.delete_byte_from_pool_array(0)
 	assert_eq(invocation_script.pool_byte_array.size(), 2, "PoolByteArray have 2 elements")
+
+	# Test resize + set in particular
+	invocation_script.resize_byte_pool_array(0)
+	assert_eq(invocation_script.pool_byte_array.size(), 0, "PoolByteArray was emptied by resize(0)")
+	invocation_script.resize_byte_pool_array(3)
+	invocation_script.set_byte_in_pool_array(0, 1)
+	invocation_script.set_byte_in_pool_array(1, 2)
+	invocation_script.set_byte_in_pool_array(2, 3)
+	assert_eq(invocation_script.pool_byte_array.size(), 3, "PoolByteArray has size 3 after resize(3) and 3x set(...)")
+	assert_eq(invocation_script.get_byte_from_pool_array(0), 1, "First element of PoolByteArray after resize(3) and 3x set(...) should be 1.")
+	assert_eq(invocation_script.get_byte_from_pool_array(1), 2, "Second element of PoolByteArray after resize(3) and 3x set(...) should be 2.")
+	assert_eq(invocation_script.get_byte_from_pool_array(2), 3, "Third element of PoolByteArray after resize(3) and 3x set(...) should be 3.")
+
 	invocation_script.free()
 
 func test_pool_color_array_add_delete() -> void:
@@ -24,6 +37,19 @@ func test_pool_color_array_add_delete() -> void:
 	assert_eq(invocation_script.get_color_from_pool_array(2), Color(1, 2, 3), "Second element of PoolColorArray should be Color(1, 2, 3).")
 	invocation_script.delete_color_from_pool_array(0)
 	assert_eq(invocation_script.pool_color_array.size(), 2, "PoolColorArray have 2 elements")
+
+	# Test resize + set in particular
+	invocation_script.resize_color_pool_array(0)
+	assert_eq(invocation_script.pool_color_array.size(), 0, "PoolColorArray was emptied by resize(0)")
+	invocation_script.resize_color_pool_array(3)
+	invocation_script.set_color_in_pool_array(0, Color(1, 1, 9))
+	invocation_script.set_color_in_pool_array(1, Color(2, 2, 9))
+	invocation_script.set_color_in_pool_array(2, Color(3, 3, 9))
+	assert_eq(invocation_script.pool_color_array.size(), 3, "PoolColorArray has size 3 after resize(3) and 3x set(...)")
+	assert_eq(invocation_script.get_color_from_pool_array(0), Color(1, 1, 9), "First element of PoolColorArray after resize(3) and 3x set(...) should be Color(1, 1, 9).")
+	assert_eq(invocation_script.get_color_from_pool_array(1), Color(2, 2, 9), "Second element of PoolColorArray after resize(3) and 3x set(...) should be Color(2, 2, 9).")
+	assert_eq(invocation_script.get_color_from_pool_array(2), Color(3, 3, 9), "Third element of PoolColorArray after resize(3) and 3x set(...) should be Color(3, 3, 9).")
+
 	invocation_script.free()
 
 func test_pool_int_array_add_delete() -> void:
@@ -38,6 +64,19 @@ func test_pool_int_array_add_delete() -> void:
 	assert_eq(invocation_script.get_int_from_pool_array(2), 3, "Second element of PoolIntArray should be 3.")
 	invocation_script.delete_int_from_pool_array(0)
 	assert_eq(invocation_script.pool_int_array.size(), 2, "PoolIntArray have 2 elements")
+
+	# Test resize + set in particular
+	invocation_script.resize_int_pool_array(0)
+	assert_eq(invocation_script.pool_int_array.size(), 0, "PoolIntArray was emptied by resize(0)")
+	invocation_script.resize_int_pool_array(3)
+	invocation_script.set_int_in_pool_array(0, 1)
+	invocation_script.set_int_in_pool_array(1, 2)
+	invocation_script.set_int_in_pool_array(2, 3)
+	assert_eq(invocation_script.pool_int_array.size(), 3, "PoolIntArray has size 3 after resize(3) and 3x set(...)")
+	assert_eq(invocation_script.get_int_from_pool_array(0), 1, "First element of PoolIntArray after resize(3) and 3x set(...) should be 1.")
+	assert_eq(invocation_script.get_int_from_pool_array(1), 2, "Second element of PoolIntArray after resize(3) and 3x set(...) should be 2.")
+	assert_eq(invocation_script.get_int_from_pool_array(2), 3, "Third element of PoolIntArray after resize(3) and 3x set(...) should be 3.")
+
 	invocation_script.free()
 
 func test_pool_real_array_add_delete() -> void:
@@ -52,6 +91,19 @@ func test_pool_real_array_add_delete() -> void:
 	assert_eq(invocation_script.get_real_from_pool_array(2), 3.0, "Second element of PoolRealArray should be 3.0.")
 	invocation_script.delete_real_from_pool_array(0)
 	assert_eq(invocation_script.pool_real_array.size(), 2, "PoolRealArray have 2 elements")
+
+	# Test resize + set in particular
+	invocation_script.resize_real_pool_array(0)
+	assert_eq(invocation_script.pool_real_array.size(), 0, "PoolRealArray was emptied by resize(0)")
+	invocation_script.resize_real_pool_array(3)
+	invocation_script.set_real_in_pool_array(0, 1.0)
+	invocation_script.set_real_in_pool_array(1, 2.0)
+	invocation_script.set_real_in_pool_array(2, 3.0)
+	assert_eq(invocation_script.pool_real_array.size(), 3, "PoolRealArray has size 3 after resize(3) and 3x set(...)")
+	assert_eq(invocation_script.get_real_from_pool_array(0), 1.0, "First element of PoolRealArray after resize(3) and 3x set(...) should be 1.0.")
+	assert_eq(invocation_script.get_real_from_pool_array(1), 2.0, "Second element of PoolRealArray after resize(3) and 3x set(...) should be 2.0.")
+	assert_eq(invocation_script.get_real_from_pool_array(2), 3.0, "Third element of PoolRealArray after resize(3) and 3x set(...) should be 3.0.")
+
 	invocation_script.free()
 
 func test_pool_string_array_add_delete() -> void:
@@ -69,15 +121,15 @@ func test_pool_string_array_add_delete() -> void:
 
 	# Test resize + set in particular
 	invocation_script.resize_real_pool_array(0)
-	assert_eq(invocation_script.pool_real_array.size(), 0, "PoolVector2Array was emptied by resize(0)")
+	assert_eq(invocation_script.pool_real_array.size(), 0, "PoolStringArray was emptied by resize(0)")
 	invocation_script.resize_real_pool_array(3)
-	invocation_script.set_real_in_pool_array(0, 1)
-	invocation_script.set_real_in_pool_array(1, 2)
-	invocation_script.set_real_in_pool_array(2, 3)
-	assert_eq(invocation_script.pool_real_array.size(), 3, "PoolVector2Array has size 3 after resze(3) and 3x set(...)")
-	assert_eq(invocation_script.get_real_from_pool_array(0), 1, "First element of PoolVector2Array after resze(3) and 3x set(...) should be 1.")
-	assert_eq(invocation_script.get_real_from_pool_array(1), 2, "Second element of PoolVector2Array after resze(3) and 3x set(...) should be 2.")
-	assert_eq(invocation_script.get_real_from_pool_array(1), 3, "Third element of PoolVector2Array after resze(3) and 3x set(...) should be 3.")
+	invocation_script.set_real_in_pool_array(0, "1")
+	invocation_script.set_real_in_pool_array(1, "2")
+	invocation_script.set_real_in_pool_array(2, "3")
+	assert_eq(invocation_script.pool_real_array.size(), 3, "PoolStringArray has size 3 after resize(3) and 3x set(...)")
+	assert_eq(invocation_script.get_real_from_pool_array(0), "1", "First element of PoolStringArray after resize(3) and 3x set(...) should be 1.")
+	assert_eq(invocation_script.get_real_from_pool_array(1), "2", "Second element of PoolStringArray after resize(3) and 3x set(...) should be 2.")
+	assert_eq(invocation_script.get_real_from_pool_array(2), "3", "Third element of PoolStringArray after resize(3) and 3x set(...) should be 3.")
 
 	invocation_script.free()
 
@@ -101,10 +153,10 @@ func test_pool_vector2_array_add_delete() -> void:
 	invocation_script.set_vector2_in_pool_array(0, Vector2(1, 1))
 	invocation_script.set_vector2_in_pool_array(1, Vector2(2, 2))
 	invocation_script.set_vector2_in_pool_array(2, Vector2(3, 3))
-	assert_eq(invocation_script.pool_vector2_array.size(), 3, "PoolVector2Array has size 3 after resze(3) and 3x set(...)")
-	assert_eq(invocation_script.get_vector2_from_pool_array(0), Vector2(1, 1), "First element of PoolVector2Array after resze(3) and 3x set(...) should be Vector2(1, 1).")
-	assert_eq(invocation_script.get_vector2_from_pool_array(1), Vector2(2, 2), "Second element of PoolVector2Array after resze(3) and 3x set(...) should be Vector2(2, 2).")
-	assert_eq(invocation_script.get_vector2_from_pool_array(1), Vector2(3, 3), "Third element of PoolVector2Array after resze(3) and 3x set(...) should be Vector2(3, 3).")
+	assert_eq(invocation_script.pool_vector2_array.size(), 3, "PoolVector2Array has size 3 after resize(3) and 3x set(...)")
+	assert_eq(invocation_script.get_vector2_from_pool_array(0), Vector2(1, 1), "First element of PoolVector2Array after resize(3) and 3x set(...) should be Vector2(1, 1).")
+	assert_eq(invocation_script.get_vector2_from_pool_array(1), Vector2(2, 2), "Second element of PoolVector2Array after resize(3) and 3x set(...) should be Vector2(2, 2).")
+	assert_eq(invocation_script.get_vector2_from_pool_array(2), Vector2(3, 3), "Third element of PoolVector2Array after resize(3) and 3x set(...) should be Vector2(3, 3).")
 
 	invocation_script.free()
 
@@ -128,10 +180,10 @@ func test_pool_vector3_array_add_delete() -> void:
 	invocation_script.set_vector3_in_pool_array(0, Vector3(1, 1, 9))
 	invocation_script.set_vector3_in_pool_array(1, Vector3(2, 2, 9))
 	invocation_script.set_vector3_in_pool_array(2, Vector3(3, 3, 9))
-	assert_eq(invocation_script.pool_vector3_array.size(), 3, "PoolVector3Array has size 3 after resze(3) and 3x set(...)")
-	assert_eq(invocation_script.get_vector3_from_pool_array(0), Vector3(1, 1, 9), "First element of PoolVector3Array after resze(3) and 3x set(...) should be Vector3(1, 1, 9).")
-	assert_eq(invocation_script.get_vector3_from_pool_array(1), Vector3(2, 2, 9), "Second element of PoolVector3Array after resze(3) and 3x set(...) should be Vector3(2, 2, 9).")
-	assert_eq(invocation_script.get_vector3_from_pool_array(1), Vector3(3, 3, 9), "Third element of PoolVector3Array after resze(3) and 3x set(...) should be Vector3(3, 3, 9).")
+	assert_eq(invocation_script.pool_vector3_array.size(), 3, "PoolVector3Array has size 3 after resize(3) and 3x set(...)")
+	assert_eq(invocation_script.get_vector3_from_pool_array(0), Vector3(1, 1, 9), "First element of PoolVector3Array after resize(3) and 3x set(...) should be Vector3(1, 1, 9).")
+	assert_eq(invocation_script.get_vector3_from_pool_array(1), Vector3(2, 2, 9), "Second element of PoolVector3Array after resize(3) and 3x set(...) should be Vector3(2, 2, 9).")
+	assert_eq(invocation_script.get_vector3_from_pool_array(2), Vector3(3, 3, 9), "Third element of PoolVector3Array after resize(3) and 3x set(...) should be Vector3(3, 3, 9).")
 
 	invocation_script.free()
 

--- a/harness/tests/test/unit/test_pool_arrays.gd
+++ b/harness/tests/test/unit/test_pool_arrays.gd
@@ -66,6 +66,19 @@ func test_pool_string_array_add_delete() -> void:
 	assert_eq(invocation_script.get_string_from_pool_array(2), "3", "Second element of PoolStringArray should be 3.")
 	invocation_script.delete_string_from_pool_array(0)
 	assert_eq(invocation_script.pool_string_array.size(), 2, "PoolStringArray have 2 elements")
+
+	# Test resize + set in particular
+	invocation_script.resize_real_pool_array(0)
+	assert_eq(invocation_script.pool_real_array.size(), 0, "PoolVector2Array was emptied by resize(0)")
+	invocation_script.resize_real_pool_array(3)
+	invocation_script.set_real_in_pool_array(0, 1)
+	invocation_script.set_real_in_pool_array(1, 2)
+	invocation_script.set_real_in_pool_array(2, 3)
+	assert_eq(invocation_script.pool_real_array.size(), 3, "PoolVector2Array has size 3 after resze(3) and 3x set(...)")
+	assert_eq(invocation_script.get_real_from_pool_array(0), 1, "First element of PoolVector2Array after resze(3) and 3x set(...) should be 1.")
+	assert_eq(invocation_script.get_real_from_pool_array(1), 2, "Second element of PoolVector2Array after resze(3) and 3x set(...) should be 2.")
+	assert_eq(invocation_script.get_real_from_pool_array(1), 3, "Third element of PoolVector2Array after resze(3) and 3x set(...) should be 3.")
+
 	invocation_script.free()
 
 func test_pool_vector2_array_add_delete() -> void:
@@ -80,6 +93,19 @@ func test_pool_vector2_array_add_delete() -> void:
 	assert_eq(invocation_script.get_vector2_from_pool_array(2), Vector2(3, 1), "Second element of PoolVector2Array should be Vector2(3, 1).")
 	invocation_script.delete_vector2_from_pool_array(0)
 	assert_eq(invocation_script.pool_vector2_array.size(), 2, "PoolVector2Array have 2 elements")
+
+	# Test resize + set in particular
+	invocation_script.resize_vector2_pool_array(0)
+	assert_eq(invocation_script.pool_vector2_array.size(), 0, "PoolVector2Array was emptied by resize(0)")
+	invocation_script.resize_vector2_pool_array(3)
+	invocation_script.set_vector2_in_pool_array(0, Vector2(1, 1))
+	invocation_script.set_vector2_in_pool_array(1, Vector2(2, 2))
+	invocation_script.set_vector2_in_pool_array(2, Vector2(3, 3))
+	assert_eq(invocation_script.pool_vector2_array.size(), 3, "PoolVector2Array has size 3 after resze(3) and 3x set(...)")
+	assert_eq(invocation_script.get_vector2_from_pool_array(0), Vector2(1, 1), "First element of PoolVector2Array after resze(3) and 3x set(...) should be Vector2(1, 1).")
+	assert_eq(invocation_script.get_vector2_from_pool_array(1), Vector2(2, 2), "Second element of PoolVector2Array after resze(3) and 3x set(...) should be Vector2(2, 2).")
+	assert_eq(invocation_script.get_vector2_from_pool_array(1), Vector2(3, 3), "Third element of PoolVector2Array after resze(3) and 3x set(...) should be Vector2(3, 3).")
+
 	invocation_script.free()
 
 func test_pool_vector3_array_add_delete() -> void:
@@ -94,6 +120,19 @@ func test_pool_vector3_array_add_delete() -> void:
 	assert_eq(invocation_script.get_vector3_from_pool_array(2), Vector3(3, 1, 1), "Second element of PoolVector3Array should be Vector3(3, 1).")
 	invocation_script.delete_vector3_from_pool_array(0)
 	assert_eq(invocation_script.pool_vector3_array.size(), 2, "PoolVector3Array have 2 elements")
+
+	# Test resize + set in particular
+	invocation_script.resize_vector3_pool_array(0)
+	assert_eq(invocation_script.pool_vector3_array.size(), 0, "PoolVector3Array was emptied by resize(0)")
+	invocation_script.resize_vector3_pool_array(3)
+	invocation_script.set_vector3_in_pool_array(0, Vector3(1, 1, 9))
+	invocation_script.set_vector3_in_pool_array(1, Vector3(2, 2, 9))
+	invocation_script.set_vector3_in_pool_array(2, Vector3(3, 3, 9))
+	assert_eq(invocation_script.pool_vector3_array.size(), 3, "PoolVector3Array has size 3 after resze(3) and 3x set(...)")
+	assert_eq(invocation_script.get_vector3_from_pool_array(0), Vector3(1, 1, 9), "First element of PoolVector3Array after resze(3) and 3x set(...) should be Vector3(1, 1, 9).")
+	assert_eq(invocation_script.get_vector3_from_pool_array(1), Vector3(2, 2, 9), "Second element of PoolVector3Array after resze(3) and 3x set(...) should be Vector3(2, 2, 9).")
+	assert_eq(invocation_script.get_vector3_from_pool_array(1), Vector3(3, 3, 9), "Third element of PoolVector3Array after resze(3) and 3x set(...) should be Vector3(3, 3, 9).")
+
 	invocation_script.free()
 
 func test_pool_byte_array_string_conversion() -> void:


### PR DESCRIPTION
Hello,

Filling `PoolVector2Array`/`PoolVector3Array`s with `resize` and `set` throws exceptions for me at `0.3.3-3.4.2` (See https://github.com/utopia-rise/godot-kotlin-jvm/issues/318). 

These tests check if this also happens in `develop`.

In general the `resize` and `set` methods are vital for filling `PoolArray`-Variants in linear time, or Godot will keep resizing the arrays causing crazy spikes of slowness starting at 500k elements upwards (See https://github.com/utopia-rise/godot-kotlin-jvm/issues/318#issuecomment-1140099040).