### PR TITLE
Security: Update shadow plugin dependency to 7.1.2

### DIFF
--- a/kt/buildSrc/src/main/kotlin/DependenciesVersions.kt
+++ b/kt/buildSrc/src/main/kotlin/DependenciesVersions.kt
@@ -1,6 +1,6 @@
 object DependenciesVersions {
     const val godotVersion: String = "3.4.4"
-    const val shadowJarPluginVersion: String = "6.1.0"
+    const val shadowJarPluginVersion: String = "7.1.2"
     const val kotlinPoetVersion: String = "1.8.0"
     const val kspVersion: String = "1.6.0-1.0.1"
     const val supportedKotlinVersion: String = "1.6.0"

--- a/kt/plugins/godot-gradle-plugin/build.gradle.kts
+++ b/kt/plugins/godot-gradle-plugin/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("gradle-plugin-api"))
-    implementation("com.github.jengelman.gradle.plugins:shadow:${DependenciesVersions.shadowJarPluginVersion}")
+    implementation("gradle.plugin.com.github.johnrengelman:shadow:${DependenciesVersions.shadowJarPluginVersion}")
     implementation("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:${DependenciesVersions.kspVersion}")
 
     implementation(project(":godot-build-props"))


### PR DESCRIPTION
Security: Update shadow plugin dependency to 7.1.2, in order to address [CVE-2021-45105](https://github.com/advisories/GHSA-p6xc-xr62-6r2g) and [CVE-2021-44832](https://github.com/advisories/GHSA-8489-44mv-ggj8)