### PR TITLE
Feature/update to kotlin 1.6.21 and add deployment IJ213 intellij plugin

### DIFF
--- a/.github/workflows/check-pr-intellij-plugin.yaml
+++ b/.github/workflows/check-pr-intellij-plugin.yaml
@@ -8,7 +8,7 @@ jobs:
   build-intellij-plugin:
     strategy:
       matrix:
-        ij_sdk: [IJ203, IJ211, IJ212]
+        ij_sdk: [ IJ211, IJ212, IJ213 ]
     runs-on: ubuntu-latest
     steps:
       - name: Clone Godot JVM module.

--- a/.github/workflows/deploy-intellij-plugin.yaml
+++ b/.github/workflows/deploy-intellij-plugin.yaml
@@ -10,7 +10,7 @@ jobs:
   deploy_godot_intellij_plugin:
     strategy:
       matrix:
-        ij_sdk: [ IJ203, IJ211, IJ212, IJ213 ]
+        ij_sdk: [ IJ211, IJ212, IJ213 ]
     runs-on: ubuntu-latest
     steps:
       - name: Clone Godot JVM module.

--- a/.github/workflows/deploy-intellij-plugin.yaml
+++ b/.github/workflows/deploy-intellij-plugin.yaml
@@ -10,7 +10,7 @@ jobs:
   deploy_godot_intellij_plugin:
     strategy:
       matrix:
-        ij_sdk: [ IJ203, IJ211, IJ212 ]
+        ij_sdk: [ IJ203, IJ211, IJ212, IJ213 ]
     runs-on: ubuntu-latest
     steps:
       - name: Clone Godot JVM module.

--- a/docs/src/doc/index.md
+++ b/docs/src/doc/index.md
@@ -24,7 +24,7 @@ The only language currently supported is Kotlin. That said it is possible to sup
 ## Supported kotlin version
 This module relies on a kotlin compiler plugin for registering your classes and members to godot. As the compiler api from kotlin is not yet stable, we can only support specific kotlin version per release for now. 
 
-The current latest release is compatible with kotlin version `1.6.0`.
+The current latest release is compatible with kotlin version `1.6.21`.
 
 ## Custom engine builds
 Get our pre built engine builds and export templates from the latest [github release](https://github.com/utopia-rise/godot-kotlin-jvm/releases).

--- a/docs/src/doc/user-guide/versioning.md
+++ b/docs/src/doc/user-guide/versioning.md
@@ -1,7 +1,7 @@
 The module uses semantic versioning for its own versions but adds a suffix for the supported godot version:
 
-Full version: `0.3.4-3.4.4`
+Full version: `0.3.5-3.4.4`
 
-Module Version: `0.3.4`
+Module Version: `0.3.5`
 
 Supported Godot Version: `3.4.4`

--- a/harness/tests/build.gradle.kts
+++ b/harness/tests/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     // no need to apply kotlin jvm plugin. Our plugin already applies the correct version for you
-//    kotlin("jvm") version "1.6.0"
+//    kotlin("jvm") version "1.6.21"
     id("com.utopia-rise.godot-kotlin-jvm")
 }
 

--- a/kt/api-generator/build.gradle.kts
+++ b/kt/api-generator/build.gradle.kts
@@ -24,7 +24,7 @@ gradlePlugin {
 }
 
 dependencies {
-    implementation(kotlin("gradle-plugin", version = "1.6.0"))
+    implementation(kotlin("gradle-plugin", version = "1.6.21"))
     implementation("com.squareup:kotlinpoet:1.8.0")
     implementation("com.fasterxml.jackson.core:jackson-databind:2.11.0")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.10.1")

--- a/kt/buildSrc/build.gradle.kts
+++ b/kt/buildSrc/build.gradle.kts
@@ -25,5 +25,5 @@ gradlePlugin {
 }
 
 dependencies {
-    implementation(kotlin("gradle-plugin", version = "1.6.0"))
+    implementation(kotlin("gradle-plugin", version = "1.6.21"))
 }

--- a/kt/buildSrc/src/main/kotlin/DependenciesVersions.kt
+++ b/kt/buildSrc/src/main/kotlin/DependenciesVersions.kt
@@ -2,6 +2,6 @@ object DependenciesVersions {
     const val godotVersion: String = "3.4.4"
     const val shadowJarPluginVersion: String = "7.1.2"
     const val kotlinPoetVersion: String = "1.8.0"
-    const val kspVersion: String = "1.6.0-1.0.1"
-    const val supportedKotlinVersion: String = "1.6.0"
+    const val kspVersion: String = "1.6.21-1.0.5"
+    const val supportedKotlinVersion: String = "1.6.21"
 }

--- a/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
+++ b/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
@@ -1,1 +1,1 @@
-const val godotKotlinJvmVersion = "0.3.4"
+const val godotKotlinJvmVersion = "0.3.5"

--- a/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/compiler/KtCallExpressionExtractor.kt
+++ b/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/compiler/KtCallExpressionExtractor.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.bindingContextUtil.getReferenceTargets
-import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedClassConstructorDescriptor
 import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedSimpleFunctionDescriptor

--- a/kt/plugins/godot-intellij-plugin/build.gradle.kts
+++ b/kt/plugins/godot-intellij-plugin/build.gradle.kts
@@ -19,38 +19,29 @@ plugins {
 //sdk version: https://github.com/JetBrains/intellij-community/tags
 //kotlin plugin version: https://plugins.jetbrains.com/plugin/6954-kotlin/versions
 val buildMatrix: Map<String, BuildConfig> = mapOf(
-    "IJ203" to BuildConfig(
-        sdk = "203.8084.24",
-        prefix = "IJ2020.3",
-        extraSource = "IJ183",
-        version = VersionRange("203.1", "203.*"),
-        ideVersionsForVerifierTask = listOf("2020.1.4", "2020.2.3", "2020.3"),
-        deps = listOf("java", "org.jetbrains.kotlin:203-1.5.21-release-316-IJ7717.8", "gradle")
-    ),
     "IJ211" to BuildConfig(
-        sdk = "211.7628.21",
+        sdk = "211.7442.40",
         prefix = "IJ2021.1",
         extraSource = "IJ183",
-        version = VersionRange("211.1", "211.*"),
+        version = VersionRange("211.2", "211.*"),
         ideVersionsForVerifierTask = listOf("2021.1.1", "2021.1.2", "2021.1.3"),
-        deps = listOf("java", "org.jetbrains.kotlin:211-1.5.21-release-317-IJ7442.40", "gradle")
+        deps = listOf("java", "org.jetbrains.kotlin:211-1.6.21-release-334-IJ7442.40", "gradle")
     ),
     "IJ212" to BuildConfig(
-        sdk = "212.5080.55",
+        sdk = "212.5457.46",
         prefix = "IJ2021.2",
         extraSource = "IJ183",
-        version = VersionRange("212.1", "212.*"),
+        version = VersionRange("212.3", "212.*"),
         ideVersionsForVerifierTask = listOf("2021.2.1"),
-        deps = listOf("java", "org.jetbrains.kotlin:212-1.5.30-release-409-IJ4638.7", "gradle")
+        deps = listOf("java", "org.jetbrains.kotlin:212-1.6.21-release-334-IJ5457.46", "gradle")
     ),
     "IJ213" to BuildConfig(
-        sdk = "213.5744.223",
+        sdk = "213.6777.52",
         prefix = "IJ2021.3",
         extraSource = "IJ213",
-        version = VersionRange("212.1", "213.*"),
+        version = VersionRange("213.2", "213.*"),
         ideVersionsForVerifierTask = listOf("2021.3"),
-        //TODO: replace kotlin plugin version with release channel once released by Jetbrains
-        deps = listOf("java", "org.jetbrains.kotlin:213-1.5.10-release-IJ5333@Ideadev", "gradle")
+        deps = listOf("java", "org.jetbrains.kotlin:213-1.6.21-release-334-IJ6777.52", "gradle")
     )
 )
 

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/KtExpressionConstantChecker.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/KtExpressionConstantChecker.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtOperationReferenceExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.psiUtil.referenceExpression
 import org.jetbrains.kotlin.resolve.bindingContextUtil.getReferenceTargets
-import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.resolve.calls.util.getType
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.isCompanionObject
 import org.jetbrains.kotlin.resolve.lazy.BodyResolveMode


### PR DESCRIPTION
This updates module to kotlin `1.6.21`.  
This adds deployment of intellij plugin for version `2021.3`.  
This bumps module version to `0.3.5`