### PR TITLE
Bugfix/basis is equal approx

### DIFF
--- a/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
@@ -418,17 +418,17 @@ class Basis() : CoreType {
      *
      */
     fun isEqualApprox(a: Basis, epsilon: RealT = CMP_EPSILON): Boolean {
-        if (isEqualApprox(this._x.x, a._x.x, epsilon)) return false
-        if (isEqualApprox(this._x.y, a._x.y, epsilon)) return false
-        if (isEqualApprox(this._x.z, a._x.z, epsilon)) return false
+        if (!isEqualApprox(this._x.x, a._x.x, epsilon)) return false
+        if (!isEqualApprox(this._x.y, a._x.y, epsilon)) return false
+        if (!isEqualApprox(this._x.z, a._x.z, epsilon)) return false
 
-        if (isEqualApprox(this._y.x, a._y.x, epsilon)) return false
-        if (isEqualApprox(this._y.y, a._y.y, epsilon)) return false
-        if (isEqualApprox(this._y.x, a._y.x, epsilon)) return false
+        if (!isEqualApprox(this._y.x, a._y.x, epsilon)) return false
+        if (!isEqualApprox(this._y.y, a._y.y, epsilon)) return false
+        if (!isEqualApprox(this._y.z, a._y.z, epsilon)) return false
 
-        if (isEqualApprox(this._z.x, a._z.x, epsilon)) return false
-        if (isEqualApprox(this._z.y, a._z.y, epsilon)) return false
-        if (isEqualApprox(this._z.z, a._z.z, epsilon)) return false
+        if (!isEqualApprox(this._z.x, a._z.x, epsilon)) return false
+        if (!isEqualApprox(this._z.y, a._z.y, epsilon)) return false
+        if (!isEqualApprox(this._z.z, a._z.z, epsilon)) return false
 
         return true
     }

--- a/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
@@ -277,7 +277,7 @@ class Basis() : CoreType {
 
     private fun isOrthogonal(): Boolean {
         val id = Basis()
-        val m = this.transposed()
+        val m = this.transposed().times(this)
         return m.isEqualApprox(id)
     }
 

--- a/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
@@ -25,7 +25,7 @@ class Basis() : CoreType {
         _y.y = 1.0
         _y.z = 0.0
         _z.x = 0.0
-        _z.y = 0.1
+        _z.y = 0.0
         _z.z = 1.0
     }
 


### PR DESCRIPTION
`basis.getRotationQuat()` and `basis.orthonormalized().getQuat()` are currently throwing 

```
java.lang.IllegalArgumentException: Basis must be normalized in order to be casted to a Quaternion. Use get_rotation_quat() or call orthonormalized() instead.
```

