### PR TITLE
chore: update module version to 0.4.0

### DIFF
--- a/docs/src/doc/user-guide/versioning.md
+++ b/docs/src/doc/user-guide/versioning.md
@@ -1,7 +1,7 @@
 The module uses semantic versioning for its own versions but adds a suffix for the supported godot version:
 
-Full version: `0.3.5-3.4.4`
+Full version: `0.4.0-3.4.4`
 
-Module Version: `0.3.5`
+Module Version: `0.4.0`
 
 Supported Godot Version: `3.4.4`

--- a/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
+++ b/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
@@ -1,1 +1,1 @@
-const val godotKotlinJvmVersion = "0.3.5"
+const val godotKotlinJvmVersion = "0.4.0"


### PR DESCRIPTION
This updates module version to `0.4.0` as we introduce kotlin `1.7.0`.