### PR TITLE
Update IDE plugin and define a more lenient supported max version

### DIFF
--- a/.github/workflows/check-pr-intellij-plugin.yaml
+++ b/.github/workflows/check-pr-intellij-plugin.yaml
@@ -8,7 +8,7 @@ jobs:
   build-intellij-plugin:
     strategy:
       matrix:
-        ij_sdk: [ IJ211, IJ212, IJ213 ]
+        ij_sdk: [ IJ212, IJ213, IJ221 ]
     runs-on: ubuntu-latest
     steps:
       - name: Clone Godot JVM module.

--- a/.github/workflows/deploy-intellij-plugin.yaml
+++ b/.github/workflows/deploy-intellij-plugin.yaml
@@ -10,7 +10,7 @@ jobs:
   deploy_godot_intellij_plugin:
     strategy:
       matrix:
-        ij_sdk: [ IJ211, IJ212, IJ213 ]
+        ij_sdk: [ IJ212, IJ213, IJ221 ]
     runs-on: ubuntu-latest
     steps:
       - name: Clone Godot JVM module.

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/copy/CopyModificationAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/copy/CopyModificationAnnotator.kt
@@ -80,8 +80,7 @@ class CopyModificationAnnotator : Annotator {
                 receiverType?.getJetTypeFqName(false) != "godot.core.Dictionary" &&
                     receiverType?.getJetTypeFqName(false) != "godot.core.VariantArray" &&
                     receiverType?.isCoreType() == true &&
-                    (((element.selectorExpression as? KtCallExpression)?.calleeExpression as? KtReferenceExpression)?.resolve() as? KtAnnotated)
-                        ?.findAnnotation(FqName(CORE_TYPE_HELPER_ANNOTATION)) != null
+                    (((element.selectorExpression as? KtCallExpression)?.calleeExpression as? KtReferenceExpression)?.resolve() as? KtAnnotated)?.findAnnotation(FqName(CORE_TYPE_HELPER_ANNOTATION)) != null
             }
             else -> false
         }
@@ -127,11 +126,10 @@ class CopyModificationAnnotator : Annotator {
                     receiverExpression
                         .arrayExpression
                         ?.resolveTypeSafe()
-                        ?.isPoolArray() != true &&
-                        expression
-                            .receiverExpression
-                            .resolveTypeSafe()
-                            ?.isCoreType() == true
+                        ?.isPoolArray() != true && expression
+                        .receiverExpression
+                        .resolveTypeSafe()
+                        ?.isCoreType() == true
                 else ->
                     expression
                         .receiverExpression

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/reference/RSetPropertyReferenceChecker.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/reference/RSetPropertyReferenceChecker.kt
@@ -5,7 +5,7 @@ import godot.intellij.plugin.GodotPluginBundle
 import godot.intellij.plugin.data.model.REGISTER_PROPERTY_ANNOTATION
 import godot.intellij.plugin.extension.registerProblem
 import godot.intellij.plugin.quickfix.TargetPropertyNotRegisteredQuickFix
-import org.jetbrains.kotlin.idea.refactoring.fqName.getKotlinFqName
+import org.jetbrains.kotlin.idea.base.utils.fqname.getKotlinFqName
 import org.jetbrains.kotlin.idea.util.findAnnotation
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.nj2k.postProcessing.resolve

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/reference/RpcFunctionReferenceChecker.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/reference/RpcFunctionReferenceChecker.kt
@@ -5,7 +5,7 @@ import godot.intellij.plugin.GodotPluginBundle
 import godot.intellij.plugin.data.model.REGISTER_FUNCTION_ANNOTATION
 import godot.intellij.plugin.extension.registerProblem
 import godot.intellij.plugin.quickfix.TargetFunctionNotRegisteredQuickFix
-import org.jetbrains.kotlin.idea.refactoring.fqName.getKotlinFqName
+import org.jetbrains.kotlin.idea.base.utils.fqname.getKotlinFqName
 import org.jetbrains.kotlin.idea.util.findAnnotation
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.nj2k.postProcessing.resolve

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/listener/KtPsiTreeListener.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/listener/KtPsiTreeListener.kt
@@ -17,7 +17,7 @@ import godot.intellij.plugin.refactor.SceneAction
 import godot.intellij.plugin.wrapper.PsiTreeChangeListenerKt
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.idea.KotlinLanguage
-import org.jetbrains.kotlin.idea.refactoring.fqName.getKotlinFqName
+import org.jetbrains.kotlin.idea.base.utils.fqname.getKotlinFqName
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
 


### PR DESCRIPTION
Resolves #332 

This updates our IDE plugin to support `2022.x` versions of `IDEA`.

This also defines a more lenient supported max version so we hopefully don't have to update the plugin as often.
For more information, see either the Discord discussion or the documented outcome in #332.