### PR TITLE
Fix invalid comment sequence in doc gen

### DIFF
--- a/kt/api-generator/src/main/kotlin/godot/docgen/rawXmlPojos.kt
+++ b/kt/api-generator/src/main/kotlin/godot/docgen/rawXmlPojos.kt
@@ -146,7 +146,7 @@ private fun String.getFormattedDescription(): String = trim()
 /**
  * Replaces wrong comment characters sequence to avoid invalid comment syntax.
  */
-fun String.replaceInvalidCommentSequences(): String = this.replace("*/", "* / ")
+fun String.replaceInvalidCommentSequences(): String = this.replace("*/", "* / ").replace("/*", "/ *")
 
 /**
  * Replaces new line chars with two new line chars so they are rendered on an new line in kdoc


### PR DESCRIPTION
Fixes generation of invalid doc generation.

Only relevant for Godot `3.x` branch (so next 3.x release) hence the merge target is develop.
In Godot `3.x` branch this new invalid comment sequence appears in the `InputMap.getActionList` documentation.