### PR TITLE
Fix compilation errors for call methods with changed arg counts

### DIFF
--- a/src/kotlin_instance.cpp
+++ b/src/kotlin_instance.cpp
@@ -67,8 +67,8 @@ bool KotlinInstance::has_method(const StringName& p_method) const {
 
 Variant
 KotlinInstance::call(const StringName& p_method, const Variant& p_arg1, const Variant& p_arg2, const Variant& p_arg3,
-                     const Variant& p_arg4, const Variant& p_arg5) {
-    return ScriptInstance::call(p_method, p_arg1, p_arg2, p_arg3, p_arg4, p_arg5);
+                     const Variant& p_arg4, const Variant& p_arg5, const Variant& p_arg6, const Variant& p_arg7, const Variant& p_arg8) {
+    return ScriptInstance::call(p_method, p_arg1, p_arg2, p_arg3, p_arg4, p_arg5, p_arg6, p_arg7, p_arg8);
 }
 
 Variant KotlinInstance::call(const StringName& p_method, const Variant** p_args, int p_argcount, Variant::CallError& r_error) {
@@ -85,8 +85,8 @@ Variant KotlinInstance::call(const StringName& p_method, const Variant** p_args,
 }
 
 void KotlinInstance::call_multilevel(const StringName& p_method, const Variant& p_arg1, const Variant& p_arg2,
-                                     const Variant& p_arg3, const Variant& p_arg4, const Variant& p_arg5) {
-    ScriptInstance::call_multilevel(p_method, p_arg1, p_arg2, p_arg3, p_arg4, p_arg5);
+                                     const Variant& p_arg3, const Variant& p_arg4, const Variant& p_arg5, const Variant& p_arg6, const Variant& p_arg7, const Variant& p_arg8) {
+    ScriptInstance::call_multilevel(p_method, p_arg1, p_arg2, p_arg3, p_arg4, p_arg5, p_arg6, p_arg7, p_arg8);
 }
 
 void KotlinInstance::call_multilevel(const StringName& p_method, const Variant** p_args, int p_argcount) {

--- a/src/kotlin_instance.h
+++ b/src/kotlin_instance.h
@@ -34,14 +34,14 @@ public:
     bool has_method(const StringName& p_method) const override;
 
     Variant call(const StringName& p_method, const Variant& p_arg1, const Variant& p_arg2, const Variant& p_arg3,
-                 const Variant& p_arg4, const Variant& p_arg5) override;
+                 const Variant& p_arg4, const Variant& p_arg5, const Variant& p_arg6, const Variant& p_arg7, const Variant& p_arg8) override;
 
     Variant
     call(const StringName& p_method, const Variant** p_args, int p_argcount, Variant::CallError& r_error) override;
 
     void
     call_multilevel(const StringName& p_method, const Variant& p_arg1, const Variant& p_arg2, const Variant& p_arg3,
-                    const Variant& p_arg4, const Variant& p_arg5) override;
+                    const Variant& p_arg4, const Variant& p_arg5, const Variant& p_arg6, const Variant& p_arg7, const Variant& p_arg8) override;
 
     void call_multilevel(const StringName& p_method, const Variant** p_args, int p_argcount) override;
 


### PR DESCRIPTION
Fixes compilation errors.

Only relevant for Godot 3.x branch (so next 3.x release) hence the merge target is develop.
In Godot 3.x branch the arg count of these methods have changed and were moved to the macro `VARIANT_ARG_LIST`
