### PR TITLE
Support abstract classes

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
     - Versioning: user-guide/versioning.md
     - Supported platforms: user-guide/supported-platforms.md
     - Advanced:
+      - Abstract Classes: user-guide/advanced/abstract_classes.md
       - Custom src dirs: user-guide/advanced/custom-src-dirs.md
       - Custom gradle wrapper path: user-guide/advanced/custom_gradle_wrapper_path.md
       - Gradle plugin configuration: user-guide/advanced/gradle-plugin-configuration.md

--- a/docs/src/doc/user-guide/advanced/abstract_classes.md
+++ b/docs/src/doc/user-guide/advanced/abstract_classes.md
@@ -1,0 +1,51 @@
+You can define and derive from any abstract class you define, as long as any of your superclasses is a godot class.
+
+This allows you to define default functions for your inheriting classes and override them in some, but not all subclasses if you want.
+
+You can define a abstract class and register it's members the same way as you do for normal classes.
+
+Under the hood, we only register your normal classes, and let them register all members your abstract class defines.
+
+!!! info
+    For this reason, the `@RegisterClass` annotation is optional for abstract classes.
+
+!!! warning
+    As in kotlin, you cannot instantiate abstract classes directly from any other scripting language like GDScript! In fact, godot does not even know (or care) that your abstract class exists.
+
+# Example
+
+Abstract class definition:
+```kotlin
+// register class annotation is optional for abstract classes
+abstract class AbstractClassInheritanceParent: Node() {
+
+    @Export
+    @RegisterProperty
+    var registeredExportedPropertyInAbstractClass = false
+
+    @RegisterSignal
+    val signalInAbstractClass by signal<String>("blubb")
+
+    @RegisterFunction
+    fun functionInAbstractClassWithDefaultImplementation() {
+        // some implementation
+    }
+
+    @RegisterFunction
+    abstract fun abstractFunction()
+}
+```
+
+Child class definition:
+```kotlin
+@RegisterClass
+class AbstractClassInheritanceChild: AbstractClassInheritanceParent() {
+    @RegisterFunction
+    override fun abstractFunction() {
+        // some implementation
+    }
+}
+```
+
+!!! warning "Registration of overridden members"
+    As you can see in the example; you need to explicitly register any member in the child class which you override from the abstract parent class. Otherwise they will not be registered and thus are not known to godot.

--- a/harness/tests/project.godot
+++ b/harness/tests/project.godot
@@ -60,6 +60,11 @@ _global_script_classes=[ {
 "path": "res://src/main/kotlin/godot/tests/coretypes/Vector3Test.kt"
 }, {
 "base": "Node",
+"class": "godot_tests_inheritance_AbstractClassInheritanceChild",
+"language": "Kotlin",
+"path": "res://src/main/kotlin/godot/tests/inheritance/AbstractClassInheritanceChild.kt"
+}, {
+"base": "Node",
 "class": "godot_tests_inheritance_ClassInheritanceChild",
 "language": "Kotlin",
 "path": "res://src/main/kotlin/godot/tests/inheritance/ClassInheritanceChild.kt"
@@ -85,6 +90,7 @@ _global_script_class_icons={
 "godot_tests_coretypes_BasisTest": "",
 "godot_tests_coretypes_StringTest": "",
 "godot_tests_coretypes_Vector3Test": "",
+"godot_tests_inheritance_AbstractClassInheritanceChild": "",
 "godot_tests_inheritance_ClassInheritanceChild": "",
 "godot_tests_inheritance_ClassInheritanceParent": "",
 "godot_tests_subpackage_OtherScript": ""

--- a/harness/tests/src/main/kotlin/godot/tests/inheritance/AbstractClassInheritanceChild.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/inheritance/AbstractClassInheritanceChild.kt
@@ -1,0 +1,28 @@
+package godot.tests.inheritance
+
+import godot.annotation.RegisterClass
+import godot.annotation.RegisterFunction
+import godot.annotation.RegisterProperty
+import godot.annotation.RegisterSignal
+import godot.signals.signal
+
+@RegisterClass
+class AbstractClassInheritanceChild: AbstractClassInheritanceParent() {
+
+    @RegisterSignal
+    override val signalTestOverridden by signal<String, Int>("blubb", "habbalubbb")
+
+    //---------------- Here to check ------------------
+
+    @RegisterProperty
+    var childOpenFunctionHasBeenCalled = false
+
+    //-------------------------------------------------
+
+    override var openVar: Int = 100
+
+    @RegisterFunction
+    override fun openFunction() {
+        childOpenFunctionHasBeenCalled = true
+    }
+}

--- a/harness/tests/src/main/kotlin/godot/tests/inheritance/AbstractClassInheritanceParent.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/inheritance/AbstractClassInheritanceParent.kt
@@ -25,9 +25,6 @@ abstract class AbstractClassInheritanceParent: Node() {
     @RegisterProperty
     var closedFunctionHasBeenCalled = false
 
-    @RegisterProperty
-    var parentOpenFunctionHasBeenCalled = false
-
     //-------------------------------------------------
 
     @RegisterProperty
@@ -42,7 +39,5 @@ abstract class AbstractClassInheritanceParent: Node() {
     }
 
     @RegisterFunction
-    open fun openFunction() {
-        parentOpenFunctionHasBeenCalled = true
-    }
+    abstract fun openFunction()
 }

--- a/harness/tests/src/main/kotlin/godot/tests/inheritance/AbstractClassInheritanceParent.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/inheritance/AbstractClassInheritanceParent.kt
@@ -1,0 +1,48 @@
+package godot.tests.inheritance
+
+import godot.Node
+import godot.annotation.Export
+import godot.annotation.RegisterFunction
+import godot.annotation.RegisterProperty
+import godot.annotation.RegisterSignal
+import godot.signals.signal
+
+// register class annotation is optional for abstract classes
+abstract class AbstractClassInheritanceParent: Node() {
+
+    @Export
+    @RegisterProperty
+    var registeredExportedPropertyInParent = false
+
+    @RegisterSignal
+    val signalTestNotOverridden by signal<String>("blubb")
+
+    @RegisterSignal
+    open val signalTestOverridden by signal<String, Int>("blubb", "habbalubb")
+
+    //---------------- Here to check ------------------
+
+    @RegisterProperty
+    var closedFunctionHasBeenCalled = false
+
+    @RegisterProperty
+    var parentOpenFunctionHasBeenCalled = false
+
+    //-------------------------------------------------
+
+    @RegisterProperty
+    var closedVar = 0
+
+    @RegisterProperty
+    open var openVar = 0
+
+    @RegisterFunction
+    fun closedFunction() {
+        closedFunctionHasBeenCalled = true
+    }
+
+    @RegisterFunction
+    open fun openFunction() {
+        parentOpenFunctionHasBeenCalled = true
+    }
+}

--- a/harness/tests/test/unit/test_inheritance_abstract.gd
+++ b/harness/tests/test/unit/test_inheritance_abstract.gd
@@ -10,7 +10,6 @@ func test_call_parent_closed_method_from_child() -> void:
 func test_call_parent_open_method_from_child() -> void:
 	var child_script = godot_tests_inheritance_AbstractClassInheritanceChild.new()
 	child_script.open_function()
-	assert_false(child_script.parent_open_function_has_been_called)
 	assert_true(child_script.child_open_function_has_been_called)
 	child_script.free()
 

--- a/harness/tests/test/unit/test_inheritance_abstract.gd
+++ b/harness/tests/test/unit/test_inheritance_abstract.gd
@@ -1,0 +1,29 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_call_parent_closed_method_from_child() -> void:
+	var child_script = godot_tests_inheritance_AbstractClassInheritanceChild.new()
+	child_script.closed_function()
+	assert_true(child_script.closed_function_has_been_called)
+	child_script.free()
+
+func test_call_parent_open_method_from_child() -> void:
+	var child_script = godot_tests_inheritance_AbstractClassInheritanceChild.new()
+	child_script.open_function()
+	assert_false(child_script.parent_open_function_has_been_called)
+	assert_true(child_script.child_open_function_has_been_called)
+	child_script.free()
+
+func test_call_parent_closed_var_from_child() -> void:
+	var child_script = godot_tests_inheritance_AbstractClassInheritanceChild.new()
+	assert_eq(child_script.closed_var, 0, "Parent's closed var should be 0")
+	child_script.closed_var = 1
+	assert_eq(child_script.closed_var, 1, "Parent's closed var should be set to 1")
+	child_script.free()
+
+func test_call_parent_open_var_from_child() -> void:
+	var child_script = godot_tests_inheritance_AbstractClassInheritanceChild.new()
+	assert_eq(child_script.open_var, 100, "Open var inherited from parent should be to 100 by default.")
+	child_script.open_var = 101
+	assert_eq(child_script.open_var, 101, "Open var inherited from parent should now be 101")
+	child_script.free()

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/PropertyRegistrationGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/PropertyRegistrationGenerator.kt
@@ -61,6 +61,17 @@ object PropertyRegistrationGenerator {
             }
     }
 
+    fun generateForAbstractClass(
+        registeredClass: RegisteredClass,
+        classRegistrarBuilder: TypeSpec.Builder
+    ) {
+        registeredClass
+            .properties
+            .forEach { registeredProperty ->
+                generateAndProvideDefaultValueProvider(registeredProperty, classRegistrarBuilder)
+            }
+    }
+
     private fun registerProperty(
         registeredProperty: RegisteredProperty,
         className: ClassName,

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/model/Clazz.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/model/Clazz.kt
@@ -5,7 +5,8 @@ import godot.entrygenerator.ext.hasAnnotation
 open class Clazz(
     open val fqName: String,
     open val supertypes: List<Clazz> = emptyList(),
-    open val annotations: List<ClassAnnotation> = emptyList()
+    open val annotations: List<ClassAnnotation> = emptyList(),
+    open val isAbstract: Boolean = false
 ) : GodotJvmSourceElement {
     val name: String
         get() = fqName.substringAfterLast(".")

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/model/RegisteredClass.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/model/RegisteredClass.kt
@@ -11,8 +11,9 @@ data class RegisteredClass(
     val constructors: List<RegisteredConstructor> = emptyList(),
     val functions: List<RegisteredFunction> = emptyList(),
     val signals: List<RegisteredSignal> = emptyList(),
-    val properties: List<RegisteredProperty> = emptyList()
-) : Clazz(fqName, supertypes) {
+    val properties: List<RegisteredProperty> = emptyList(),
+    override val isAbstract: Boolean = false
+) : Clazz(fqName, supertypes, isAbstract = isAbstract) {
     internal val registeredName: String
         get() {
             val customName = annotations

--- a/kt/plugins/godot-intellij-plugin/detekt-config.yml
+++ b/kt/plugins/godot-intellij-plugin/detekt-config.yml
@@ -53,3 +53,5 @@ complexity:
         '**/godot/intellij/plugin/module/GodotModuleBuilder.kt',
         '**/godot/intellij/plugin/codevision/RegisteredNameInlayHint.kt',
     ]
+  LongParameterList:
+    ignoreDefaultParameters: true

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.allConstructors
+import org.jetbrains.kotlin.psi.psiUtil.isAbstract
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperclassesWithoutAny
 
@@ -49,21 +50,21 @@ class RegisterClassAnnotator : Annotator {
                             classNotRegisteredQuickFix
                         )
                     }
-                    if (element.anyPropertyHasAnnotation(REGISTER_PROPERTY_ANNOTATION)) {
+                    if (!element.isAbstract() && element.anyPropertyHasAnnotation(REGISTER_PROPERTY_ANNOTATION)) {
                         holder.registerProblem(
                             GodotPluginBundle.message("problem.class.notRegistered.properties"),
                             errorLocation,
                             classNotRegisteredQuickFix
                         )
                     }
-                    if (element.anyPropertyHasAnnotation(REGISTER_SIGNAL_ANNOTATION)) {
+                    if (!element.isAbstract() && element.anyPropertyHasAnnotation(REGISTER_SIGNAL_ANNOTATION)) {
                         holder.registerProblem(
                             GodotPluginBundle.message("problem.class.notRegistered.signals"),
                             errorLocation,
                             classNotRegisteredQuickFix
                         )
                     }
-                    if (element.anyFunctionHasAnnotation(REGISTER_FUNCTION_ANNOTATION)) {
+                    if (!element.isAbstract() && element.anyFunctionHasAnnotation(REGISTER_FUNCTION_ANNOTATION)) {
                         holder.registerProblem(
                             GodotPluginBundle.message("problem.class.notRegistered.functions"),
                             errorLocation,

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/FunctionNotRegisteredQuickFix.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/quickfix/FunctionNotRegisteredQuickFix.kt
@@ -9,11 +9,13 @@ import org.jetbrains.kotlin.idea.util.addAnnotation
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
-class NotificationFunctionNotRegisteredQuickFix : LocalQuickFix {
+class FunctionNotRegisteredQuickFix : LocalQuickFix {
     override fun getFamilyName(): String = GodotPluginBundle.message("quickFix.function.notificationFunctionNotRegistered.familyName")
 
     override fun applyFix(project: Project, descriptor: ProblemDescriptor) {
-        val ktNamedFunction = descriptor.psiElement as KtNamedFunction
+        val ktNamedFunction = descriptor.psiElement as? KtNamedFunction
+            ?: descriptor.psiElement.parent as? KtNamedFunction
+            ?: return
         ktNamedFunction.addAnnotation(FqName(REGISTER_FUNCTION_ANNOTATION))
     }
 }

--- a/kt/plugins/godot-intellij-plugin/src/main/resources/messages/generalLabels.properties
+++ b/kt/plugins/godot-intellij-plugin/src/main/resources/messages/generalLabels.properties
@@ -76,3 +76,4 @@ codeVision.name=[GodotKotlinJVM] Registered name inlay hint
 codeVision.settings.enableCheckbox=[GodotKotlinJVM] Display registered name above element
 codeVision.registeredName.tooltip=Click to copy registered name
 codeVision.registeredName.text=Registered as {0}
+codeVision.registeredName.notRegisteredBecauseIsAbstract.text=Will not be registered, as it's abstract. Members are registered through inheriting classes

--- a/kt/plugins/godot-intellij-plugin/src/main/resources/messages/generalLabels.properties
+++ b/kt/plugins/godot-intellij-plugin/src/main/resources/messages/generalLabels.properties
@@ -34,6 +34,7 @@ problem.class.wrongPackagePath=Package path has to match actual directory path
 problem.function.notificationFunctionNotRegistered=Overridden notification function which is not registered will not be called by Godot.\n\
 Using notification functions for other purposes than to be called from Godot is considered a bad practise.\n\
 Either register it or move your logic to a custom function you defined
+problem.function.overriddenAbstractFunctionNotRegistered=Overrides registered abstract function without registering itself. Without explicit @RegisterFunction annotation on overridden functions, they cannot be called from godot.
 problem.property.hint.wrongType=Property must be of type {0}
 problem.property.hint.notRegistered=Property has a type hint but is not registered
 problem.property.hint.notExported=Property has a type hint but is not exported. This type hint will do nothing


### PR DESCRIPTION
This adds support for member registration in abstract classes.

Now one can define abstract classes which inherit from a godot type and register default members in it.
Upon registration of inheriting classes, the inheriting class registers the member of the abstract class as well.

To godot, the abstract class does not exist as it's not registered. But on the jvm side, it exists and all calls to the default members are properly propagated through normal inheritance.

Example:
```kotlin
// register class annotation is optional for abstract classes
abstract class AbstractClassInheritanceParent: Node() {

    @Export
    @RegisterProperty
    var registeredExportedPropertyInAbstractClass = false

    @RegisterSignal
    val signalInAbstractClass by signal<String>("blubb")

    @RegisterFunction
    fun functionInAbstractClassWithDefaultImplementation() {
        // some implementation
    }

    @RegisterFunction
    abstract fun abstractFunction()
}
```
```kotlin
@RegisterClass
class AbstractClassInheritanceChild: AbstractClassInheritanceParent() {
    @RegisterFunction
    override fun abstractFunction() {
        // some implementation
    }
}
```

**Limitations:**
Currently a user **must** explicitly register any member he overrides even if that member is marked as registered in the abstract class.
This could be changed though in the future, but personally i would opt against it, to force users to be explicit about what is exported and what not.

**Note to self:** If this PR is accepted, it needs to be cherry picked to the 4.0 branches