### PR TITLE
bugfix: android dex jar loading

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageMainDexJarTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageMainDexJarTask.kt
@@ -16,7 +16,7 @@ fun Project.packageMainDexJarTask(
 
             archiveBaseName.set("main-dex")
 
-            from("src/main/resources").include("**/godot.runtime.Entry")
+            from("src/main/resources").include("**/godot.registration.Entry")
             from("${project.buildDir.absolutePath}/libs/").include("*.dex")
 
             dependsOn(createMainDexFileTask)

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -289,6 +289,7 @@ void GDKotlin::init() {
 
 #ifdef __ANDROID__
     String main_jar_file{"main-dex.jar"};
+    _check_and_copy_jar(main_jar_file);
 #else
     String main_jar_file;
     if (configuration.get_vm_type() == jni::Jvm::GRAAL_NATIVE_IMAGE) {


### PR DESCRIPTION
It seems almost a year ago I broke android export.  
`main-dex.jar` was not copied to user dir anymore.  
Service file was not included in android dex main jar anymore.