### PR TITLE
feat: Create MacOs editor app on release

### DIFF
--- a/.github/workflows/deploy-export-template.yaml
+++ b/.github/workflows/deploy-export-template.yaml
@@ -358,7 +358,6 @@ jobs:
           repository: godotengine/godot
           ref: 3.5.1-stable
 
-      # has to be the first step as the download url is only valid for 1 minute! See: https://stackoverflow.com/a/65049722
       - name: Get release export template binary
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -13,24 +13,37 @@ jobs:
   deploy-editor-release:
     strategy:
       matrix:
-        name: [ Linux ]
+        name: [ Linux, OSX-x64, OSX-arm64, Windows ]
         include:
           - name: Linux
             # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             platform: x11
             binary: godot.x11.opt.tools.64
             cat_command: cat
-          - name: OSX
+            arch: 64
+            target: release_debug
+          - name: OSX-x64
             os: macos-latest
             platform: osx
             binary: godot.osx.opt.tools.64
             cat_command: cat
+            arch: 64
+            target: release_debug
+          - name: OSX-arm64
+            os: macos-latest
+            platform: osx
+            binary: godot.osx.opt.tools.arm64
+            cat_command: cat
+            arch: arm64
+            target: release_debug
           - name: Windows
             os: windows-2019
             platform: windows
             binary: godot.windows.opt.tools.64.exe
             cat_command: type
+            arch: 64
+            target: release_debug
     runs-on: ${{ matrix.os }}
     steps:
       # has to be the first step as the download url is only valid for 1 minute! See: https://stackoverflow.com/a/65049722
@@ -40,18 +53,22 @@ jobs:
           workflow: create-draft-release.yaml
           workflow_conclusion: success
 
+      - name: Create release information artifact
+        if: matrix.platform == 'x11'
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-informations
+          path: |
+            release_url/release_url.txt
+            godot_version/godot_version.txt
+            godot_kotlin_jvm_version/godot_kotlin_jvm_version.txt
+
       - name: Save release infos as variables
         id: save_release_info
         run: |
           echo "::set-output name=upload_url::$(${{ matrix.cat_command }} release_url/release_url.txt)"
           echo "::set-output name=godot_version::$(${{ matrix.cat_command }} godot_version/godot_version.txt)"
           echo "::set-output name=godot_kotlin_jvm_version::$(${{ matrix.cat_command }} godot_kotlin_jvm_version/godot_kotlin_jvm_version.txt)"
-
-      - name: Configure dependencies
-        if: matrix.platform == 'x11'
-        run: |
-          sudo apt-get update && sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
 
       - name: Clone Godot Engine
         uses: actions/checkout@v2
@@ -65,28 +82,27 @@ jobs:
           path: modules/kotlin_jvm
           submodules: recursive
 
-      # Upload cache on completion and check it out now
-      - name: Load .scons_cache directory
-        id: template-release-cache
-        uses: actions/cache@v2
-        with:
-          path: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
-          key: ${{github.job}}-${{ steps.save_release_info.outputs.godot_version }}-${{github.ref}}-${{github.sha}}
-          restore-keys: |
-            ${{github.job}}-${{ steps.save_release_info.outputs.godot_version }}-${{github.ref}}-${{github.sha}}
-            ${{github.job}}-${{ steps.save_release_info.outputs.godot_version }}-${{github.ref}}
-            ${{github.job}}-${{ steps.save_release_info.outputs.godot_version }}
-
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
-          architecture: 'x64'
-
-      - name: Configuring Python packages
+      - name: Linux dependencies
+        if: matrix.platform == 'x11'
+        shell: bash
         run: |
-          python -c "import sys; print(sys.version)"
-          python -m pip install -r modules/kotlin_jvm/requirements.txt
+          # Azure repositories are not reliable, we need to prevent azure giving us packages.
+          sudo rm -f /etc/apt/sources.list.d/*
+          sudo cp -f misc/ci/sources.list /etc/apt/sources.list
+          sudo apt-get update
+          # The actual dependencies
+          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
+              libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev \
+              libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip
+
+      - name: Setup Godot dependencies
+        uses: ./.github/actions/godot-deps
+
+      # Upload cache on completion and check it out now
+      - name: Setup Godot build cache
+        uses: ./.github/actions/godot-cache
+        with:
+          cache-name: ${{ github.job }}-${{ matrix.platform }}-${{ matrix.arch }}-${{ matrix.target }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v1
@@ -97,10 +113,13 @@ jobs:
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@v1
 
-      - name: Build with editor release
-        env:
-          SCONS_CACHE: ${{github.workspace}}/${{matrix.platform}}/.scons_cache/
-        run: scons platform=${{ matrix.platform }} target=release_debug -j${{ steps.cpu-cores.outputs.count }}
+      - name: Build ${{ matrix.target }} editor release app
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: arch=${{ matrix.arch }} -j${{ steps.cpu-cores.outputs.count }}
+          platform: ${{ matrix.platform }}
+          target: ${{ matrix.target }}
+          tools: true
 
       - name: Build godot-bootstrap
         uses: eskatos/gradle-command-action@v1
@@ -110,12 +129,14 @@ jobs:
           arguments: godot-library:build
 
       - name: Zip release
+        if: matrix.platform != 'osx'
         uses: vimtor/action-zip@v1
         with:
           files: bin/${{ matrix.binary }} modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
           dest: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
 
       - name: Upload zip release
+        if: matrix.platform != 'osx'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -124,3 +145,122 @@ jobs:
           asset_path: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
           asset_name: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
           asset_content_type: application/zip
+
+      - name: Upload bootstrap jar
+        if: matrix.platform == 'osx'
+        uses: actions/upload-artifact@v3
+        with:
+          name: bootstrap-jar
+          path: modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
+
+      - name: Upload OSX binary
+        if: matrix.platform == 'osx'
+        uses: actions/upload-artifact@v3
+        with:
+          name: osx-editor-${{ matrix.target }}-binary-${{ matrix.arch }}
+          path: bin/${{ matrix.binary }}
+
+  create-macos-universal:
+    needs: [ deploy-editor-release ]
+    strategy:
+      matrix:
+        name: [ MacOs ]
+        include:
+          - name: MacOs
+            os: macos-latest
+            java-version: 11
+            target: release_debug
+            binary-suffix: opt.tools
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Download release informations
+        uses: actions/download-artifact@v3
+        with:
+          name: release-informations
+
+      - name: Save release infos as variables
+        id: save_release_info
+        run: |
+          echo "::set-output name=upload_url::$(cat release_url/release_url.txt)"
+          echo "::set-output name=godot_version::$(cat godot_version/godot_version.txt)"
+          echo "::set-output name=godot_kotlin_jvm_version::$(cat godot_kotlin_jvm_version/godot_kotlin_jvm_version.txt)"
+
+      - name: Clone Godot JVM module.
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      - name: Create OSX universal binary
+        uses: ./.github/actions/create-osx-universal-binary
+        with:
+          amd-64-binary-artifact: osx-editor-${{ matrix.target }}-binary-64
+          amd-64-binary-name: godot.osx.${{ matrix.binary-suffix }}.64
+          arm-64-binary-artifact: osx-editor-${{ matrix.target }}-binary-arm64
+          arm-64-binary-name: godot.osx.${{ matrix.binary-suffix }}.arm64
+          universal-output-binary-name: godot.osx.${{ matrix.binary-suffix }}.universal
+
+      - name: Upload ${{ matrix.target }} osx universal artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: osx-editor-${{ matrix.target }}-binary-universal
+          path: godot.osx.${{ matrix.binary-suffix }}.universal
+
+  create-macos-editor-app:
+    needs: [ create-macos-universal ]
+    strategy:
+      matrix:
+        os: [ macos-latest ]
+        include:
+          - os: macos-latest
+            java-version: 11
+            target: release_debug
+            binary-suffix: opt.tools
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Download release informations
+        uses: actions/download-artifact@v3
+        with:
+          name: release-informations
+
+      - name: Save release infos as variables
+        id: save_release_info
+        run: |
+          echo "::set-output name=upload_url::$(cat release_url/release_url.txt)"
+          echo "::set-output name=godot_version::$(cat godot_version/godot_version.txt)"
+          echo "::set-output name=godot_kotlin_jvm_version::$(cat godot_kotlin_jvm_version/godot_kotlin_jvm_version.txt)"
+
+      - name: Clone Godot Engine
+        uses: actions/checkout@v2
+        with:
+          repository: godotengine/godot
+          ref: 3.5.1-stable
+
+      - name: Get editor binary
+        uses: actions/download-artifact@v3
+        with:
+          name: osx-editor-${{ matrix.target }}-binary-universal
+
+      - name: Get bootstrap jar
+        uses: actions/download-artifact@v3
+        with:
+          name: bootstrap-jar
+
+      - name: Create MacOs editor app
+        run: |
+          cp -r misc/dist/osx_tools.app ./Godot.app
+          mkdir -p Godot.app/Contents/MacOS
+          cp godot.osx.${{ matrix.binary-suffix }}.universal Godot.app/Contents/MacOS/Godot
+          chmod +x Godot.app/Contents/MacOS/Godot
+          cp godot-bootstrap.jar Godot.app/Contents/MacOS/
+          chmod +x Godot.app/Contents/MacOS/godot-bootstrap.jar
+          zip -q -9 -r godot-editor-macos.zip Godot.app
+
+      - name: Upload MacOs editor app
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.save_release_info.outputs.upload_url }}
+          asset_path: godot-editor-macos.zip
+          asset_name: godot-editor-macos.zip
+          asset_content_type: application/octet-stream

--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -2,7 +2,7 @@ import org.ajoberstar.grgit.Commit
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 plugins {
-    id("org.ajoberstar.grgit") version "4.1.0"
+    id("org.ajoberstar.grgit") version "4.1.1"
 }
 
 val currentCommit: Commit = grgit.head()


### PR DESCRIPTION
This creates macOs editor universal app on release instead of binaries per architecture.