### PR TITLE
Implement generics check in IDE plugin

### DIFF
--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/clazz/RegisterClassAnnotator.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.annotator.general.checkNotGeneric
 import godot.intellij.plugin.data.cache.classname.RegisteredClassNameCacheProvider
 import godot.intellij.plugin.data.model.REGISTER_CLASS_ANNOTATION
 import godot.intellij.plugin.data.model.REGISTER_CONSTRUCTOR_ANNOTATION
@@ -72,6 +73,7 @@ class RegisterClassAnnotator : Annotator {
                         )
                     }
                 } else {
+                    checkNotGeneric(element, holder)
                     checkExtendsGodotType(element, holder)
                     checkDefaultConstructorExistence(element, holder)
                     checkConstructorParameterCount(element, holder)

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/function/RegisterFunctionAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/function/RegisterFunctionAnnotator.kt
@@ -5,6 +5,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.annotator.general.checkNotGeneric
 import godot.intellij.plugin.data.model.REGISTER_CLASS_ANNOTATION
 import godot.intellij.plugin.data.model.REGISTER_FUNCTION_ANNOTATION
 import godot.intellij.plugin.extension.isInGodotRoot
@@ -35,6 +36,10 @@ class RegisterFunctionAnnotator : Annotator {
                     functionNotRegisteredQuickFix,
                     problemHighlightType = ProblemHighlightType.WEAK_WARNING
                 )
+            }
+
+            if (element.findAnnotation(FqName(REGISTER_FUNCTION_ANNOTATION)) != null) {
+                checkNotGeneric(element, holder)
             }
         }
     }

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/general/checkNotGeneric.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/general/checkNotGeneric.kt
@@ -1,0 +1,28 @@
+package godot.intellij.plugin.annotator.general
+
+import com.intellij.lang.annotation.AnnotationHolder
+import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.extension.registerProblem
+import org.jetbrains.kotlin.nj2k.postProcessing.type
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
+import org.jetbrains.kotlin.types.typeUtil.containsTypeParameter
+
+fun checkNotGeneric(ktTypeParameterListOwner: KtTypeParameterListOwner, holder: AnnotationHolder) {
+    if (ktTypeParameterListOwner.typeParameters.isNotEmpty()) {
+        holder.registerProblem(
+            GodotPluginBundle.message("problem.general.cannotRegisterGenerics"),
+            ktTypeParameterListOwner.typeParameterList
+                ?: ktTypeParameterListOwner.nameIdentifier
+                ?: ktTypeParameterListOwner.navigationElement
+        )
+    } else if (ktTypeParameterListOwner is KtProperty && ktTypeParameterListOwner.type()?.containsTypeParameter() == true) {
+        holder.registerProblem(
+            GodotPluginBundle.message("problem.general.cannotRegisterGenerics"),
+            ktTypeParameterListOwner.typeParameterList
+                ?: ktTypeParameterListOwner.typeReference
+                ?: ktTypeParameterListOwner.nameIdentifier
+                ?: ktTypeParameterListOwner.navigationElement
+        )
+    }
+}

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/RegisterPropertiesAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/property/RegisterPropertiesAnnotator.kt
@@ -4,6 +4,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.annotator.general.checkNotGeneric
 import godot.intellij.plugin.data.model.EXPORT_ANNOTATION
 import godot.intellij.plugin.data.model.REGISTER_PROPERTY_ANNOTATION
 import godot.intellij.plugin.extension.isInGodotRoot
@@ -32,6 +33,7 @@ class RegisterPropertiesAnnotator : Annotator {
 
         if (element is KtProperty) {
             if (element.findAnnotation(FqName(REGISTER_PROPERTY_ANNOTATION)) != null) {
+                checkNotGeneric(element, holder)
                 checkMutability(element, holder)
                 checkRegisteredType(element, holder)
                 checkIfDefaultValueIsConstantWhenExported(element, holder)

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/signal/RegisterSignalAnnotator.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/annotator/signal/RegisterSignalAnnotator.kt
@@ -5,6 +5,7 @@ import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
 import godot.intellij.plugin.GodotPluginBundle
+import godot.intellij.plugin.annotator.general.checkNotGeneric
 import godot.intellij.plugin.data.model.REGISTER_SIGNAL_ANNOTATION
 import godot.intellij.plugin.extension.isInGodotRoot
 import godot.intellij.plugin.extension.registerProblem
@@ -24,6 +25,7 @@ class RegisterSignalAnnotator : Annotator {
         if (!element.isInGodotRoot()) return
 
         if (element is KtProperty && element.findAnnotation(FqName(REGISTER_SIGNAL_ANNOTATION)) != null) {
+            checkNotGeneric(element, holder)
             checkMutability(element, holder)
             checkRegisteredType(element, holder)
         }

--- a/kt/plugins/godot-intellij-plugin/src/main/resources/messages/generalLabels.properties
+++ b/kt/plugins/godot-intellij-plugin/src/main/resources/messages/generalLabels.properties
@@ -52,6 +52,7 @@ problem.rpc.calledFunctionNotRegistered=Function not registered. Functions calle
 problem.rpc.calledPropertyNotRegistered=Property not registered. Properties set with rset have to be registered
 problem.rpc.calledFunctionNotAccessible=Function not accessible. Functions called by rpc cannot have RPCMode.DISABLED
 problem.rpc.calledPropertyNotAccessible=Property not accessible. Properties set with rset cannot have RPCMode.DISABLED
+problem.general.cannotRegisterGenerics=Generic elements cannot be registered
 problem.general.calledFunctionNotRegistered=Target function not registered
 problem.general.modificationOfCoreTypeCopy=You're modifying a copy of a CoreType. Either re assign this copy to it's parent or use it elsewhere after the modification.\
 For more information's, visit the documentation.\


### PR DESCRIPTION
This check verifies that the user does not try to register any generic types as these won't compile.

Resolves #372 