### PR TITLE
Export headless editor and server builds

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -47,12 +47,17 @@ jobs:
   build-editor-debug:
     strategy:
       matrix:
-        name: [ Linux, OSX-x64, OSX-arm64, Windows ]
+        name: [ Linux, Linux-Editor-Headless, OSX-x64, OSX-arm64, Windows ]
         include:
           # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
             os: ubuntu-20.04
             platform: x11
+            arch: 64
+          # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
+          - name: Linux-Editor-Headless
+            os: ubuntu-20.04
+            platform: server
             arch: 64
           - name: OSX-x64
             os: macos-latest
@@ -79,7 +84,7 @@ jobs:
           path: modules/kotlin_jvm
           submodules: recursive
       - name: Linux dependencies
-        if: matrix.platform == 'x11'
+        if: matrix.platform == 'x11' || matrix.platform == 'server'
         shell: bash
         run: |
           # Azure repositories are not reliable, we need to prevent azure giving us packages.
@@ -100,19 +105,38 @@ jobs:
       - name: Get number of CPU cores
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@v1
+
       - name: Build with editor debug
+        if: matrix.platform != 'server'
         uses: ./.github/actions/godot-build
         with:
           sconsflags: arch=${{ matrix.arch }} -j${{ steps.cpu-cores.outputs.count }}
           platform: ${{ matrix.platform }}
           target: debug
           tools: true
+
+      - name: Build with headless editor debug
+        if: matrix.platform == 'server'
+        uses: ./.github/actions/godot-build
+        with:
+          sconsflags: arch=${{ matrix.arch }} -j${{ steps.cpu-cores.outputs.count }}
+          platform: ${{ matrix.platform }}
+          target: release_debug
+          tools: true
+
       - name: Upload OSX binary
         if: matrix.platform == 'osx'
         uses: actions/upload-artifact@v3
         with:
           name: osx-editor-debug-app-${{ matrix.arch }}
           path: bin/godot.osx.tools.${{ matrix.arch }}
+
+      - name: Upload headless editor binary
+        if: matrix.platform == 'server'
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux-editor-headless-${{ matrix.arch }}
+          path: bin/godot_server.x11.opt.tools.${{ matrix.arch }}
   create-macos-universal:
     needs: [build-editor-debug]
     strategy:

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -14,12 +14,18 @@ jobs:
   build-export-debug:
     strategy:
       matrix:
-        name: [ Linux, OSX-x64, OSX-arm64, Windows, Android-armv7, Android-armv8, Android-x86_64 ]
+        name: [ Linux, Linux-Server, OSX-x64, OSX-arm64, Windows, Android-armv7, Android-armv8, Android-x86_64 ]
         include:
           # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
             os: ubuntu-20.04
             platform: x11
+            arch: 64
+            output_folder: bin/
+          # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
+          - name: Linux-Server
+            os: ubuntu-20.04
+            platform: server
             arch: 64
             output_folder: bin/
           - name: OSX-x64
@@ -65,7 +71,7 @@ jobs:
           path: modules/kotlin_jvm
           submodules: recursive
       - name: Linux dependencies
-        if: matrix.platform == 'x11'
+        if: matrix.platform == 'x11' || matrix.platform == 'server'
         shell: bash
         run: |
           # Azure repositories are not reliable, we need to prevent azure giving us packages.

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -13,12 +13,18 @@ jobs:
   build-export-release:
     strategy:
       matrix:
-        name: [ Linux, OSX-x64, OSX-arm64, Windows, Android-armv7, Android-armv8, Android-x86_64 ]
+        name: [ Linux, Linux-Server, OSX-x64, OSX-arm64, Windows, Android-armv7, Android-armv8, Android-x86_64 ]
         include:
           # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
             os: ubuntu-20.04
             platform: x11
+            arch: 64
+            output_folder: bin/
+          # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
+          - name: Linux-Server
+            os: ubuntu-20.04
+            platform: server
             arch: 64
             output_folder: bin/
           - name: OSX-x64
@@ -64,7 +70,7 @@ jobs:
           path: modules/kotlin_jvm
           submodules: recursive
       - name: Linux dependencies
-        if: matrix.platform == 'x11'
+        if: matrix.platform == 'x11' || matrix.platform == 'server'
         shell: bash
         run: |
           # Azure repositories are not reliable, we need to prevent azure giving us packages.

--- a/.github/workflows/deploy-export-template.yaml
+++ b/.github/workflows/deploy-export-template.yaml
@@ -13,13 +13,21 @@ jobs:
   deploy-export-template:
     strategy:
       matrix:
-        name: [ Linux-release, OSX-x64-release, OSX-arm64-release, Windows-release, Android-armv7-release, Android-armv8-release, Android-x86_64-release, Linux-debug, OSX-x64-debug, OSX-arm64-debug, Windows-debug, Android-armv7-debug, Android-armv8-debug, Android-x86_64-debug ]
+        name: [ Linux-release, Linux-Server-release, OSX-x64-release, OSX-arm64-release, Windows-release, Android-armv7-release, Android-armv8-release, Android-x86_64-release, Linux-debug, Linux-Server-debug, OSX-x64-debug, OSX-arm64-debug, Windows-debug, Android-armv7-debug, Android-armv8-debug, Android-x86_64-debug ]
         include:
           - name: Linux-release
             # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
             os: ubuntu-20.04
             platform: x11
             binary: godot.x11.opt.64
+            cat_command: cat
+            arch: 64
+            target: release
+          - name: Linux-Server-release
+            # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
+            os: ubuntu-20.04
+            platform: server
+            binary: godot_server.x11.opt.64
             cat_command: cat
             arch: 64
             target: release
@@ -73,6 +81,14 @@ jobs:
             os: ubuntu-20.04
             platform: x11
             binary: godot.x11.opt.debug.64
+            cat_command: cat
+            arch: 64
+            target: release_debug
+          - name: Linux-Server-debug
+            # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
+            os: ubuntu-20.04
+            platform: server
+            binary: godot_server.x11.opt.debug.64
             cat_command: cat
             arch: 64
             target: release_debug
@@ -160,7 +176,7 @@ jobs:
           submodules: recursive
 
       - name: Linux dependencies
-        if: matrix.platform == 'x11'
+        if: matrix.platform == 'x11' || matrix.platform == 'server'
         shell: bash
         run: |
           # Azure repositories are not reliable, we need to prevent azure giving us packages.

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -13,13 +13,21 @@ jobs:
   deploy-editor-release:
     strategy:
       matrix:
-        name: [ Linux, OSX-x64, OSX-arm64, Windows ]
+        name: [ Linux, Linux-Headless, OSX-x64, OSX-arm64, Windows ]
         include:
           - name: Linux
             # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
             os: ubuntu-20.04
             platform: x11
             binary: godot.x11.opt.tools.64
+            cat_command: cat
+            arch: 64
+            target: release_debug
+          - name: Linux-Headless
+            # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
+            os: ubuntu-20.04
+            platform: server
+            binary: godot_server.x11.opt.tools.64
             cat_command: cat
             arch: 64
             target: release_debug
@@ -83,7 +91,7 @@ jobs:
           submodules: recursive
 
       - name: Linux dependencies
-        if: matrix.platform == 'x11'
+        if: matrix.platform == 'x11' || matrix.platform == 'server'
         shell: bash
         run: |
           # Azure repositories are not reliable, we need to prevent azure giving us packages.
@@ -136,7 +144,7 @@ jobs:
           dest: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
 
       - name: Upload zip release
-        if: matrix.platform != 'osx'
+        if: matrix.platform != 'osx' && matrix.platform != 'server'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -144,6 +152,17 @@ jobs:
           upload_url: ${{ steps.save_release_info.outputs.upload_url }}
           asset_path: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
           asset_name: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
+          asset_content_type: application/zip
+
+      - name: Upload zip release
+        if: matrix.platform == 'server'
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.save_release_info.outputs.upload_url }}
+          asset_path: godot-kotlin-jvm_editor_headless_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
+          asset_name: godot-kotlin-jvm_editor_headless_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
           asset_content_type: application/zip
 
       - name: Upload bootstrap jar

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -137,21 +137,14 @@ jobs:
           arguments: godot-library:build
 
       - name: Zip release
-        if: matrix.platform != 'osx' && matrix.platform != 'server'
+        if: matrix.platform != 'osx'
         uses: vimtor/action-zip@v1
         with:
           files: bin/${{ matrix.binary }} modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
           dest: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
 
-      - name: Zip release
-        if: matrix.platform != 'osx' && matrix.platform == 'server'
-        uses: vimtor/action-zip@v1
-        with:
-          files: bin/${{ matrix.binary }} modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
-          dest: godot-kotlin-jvm_editor_headless_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
-
       - name: Upload zip release
-        if: matrix.platform != 'osx' && matrix.platform != 'server'
+        if: matrix.platform != 'osx'
         uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -159,17 +152,6 @@ jobs:
           upload_url: ${{ steps.save_release_info.outputs.upload_url }}
           asset_path: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
           asset_name: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
-          asset_content_type: application/zip
-
-      - name: Upload zip release
-        if: matrix.platform == 'server'
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.save_release_info.outputs.upload_url }}
-          asset_path: godot-kotlin-jvm_editor_headless_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
-          asset_name: godot-kotlin-jvm_editor_headless_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
           asset_content_type: application/zip
 
       - name: Upload bootstrap jar

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -137,11 +137,18 @@ jobs:
           arguments: godot-library:build
 
       - name: Zip release
-        if: matrix.platform != 'osx'
+        if: matrix.platform != 'osx' && matrix.platform != 'server'
         uses: vimtor/action-zip@v1
         with:
           files: bin/${{ matrix.binary }} modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
           dest: godot-kotlin-jvm_editor_${{ matrix.platform }}_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
+
+      - name: Zip release
+        if: matrix.platform != 'osx' && matrix.platform == 'server'
+        uses: vimtor/action-zip@v1
+        with:
+          files: bin/${{ matrix.binary }} modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
+          dest: godot-kotlin-jvm_editor_headless_${{ steps.save_release_info.outputs.godot_kotlin_jvm_version }}.zip
 
       - name: Upload zip release
         if: matrix.platform != 'osx' && matrix.platform != 'server'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,5 +27,6 @@ add_compile_definitions(DEBUG_ENABLED)
 # platforms
 #add_compile_definitions(WINDOWS_ENABLED)
 #add_compile_definitions(X11_ENABLED)
-add_compile_definitions(OSX_ENABLED)
+add_compile_definitions(SERVER_ENABLED)
+#add_compile_definitions(OSX_ENABLED)
 #add_compile_definitions(__ANDROID__)

--- a/src/jni/platforms/init_args_desktop.cpp
+++ b/src/jni/platforms/init_args_desktop.cpp
@@ -1,4 +1,4 @@
-#if defined WINDOWS_ENABLED || defined X11_ENABLED || defined OSX_ENABLED
+#if defined WINDOWS_ENABLED || defined X11_ENABLED || defined OSX_ENABLED || defined SERVER_ENABLED
 
 #include "../init_args.h"
 

--- a/src/jni/platforms/jvm_desktop.cpp
+++ b/src/jni/platforms/jvm_desktop.cpp
@@ -1,4 +1,4 @@
-#if defined WINDOWS_ENABLED || defined X11_ENABLED || defined OSX_ENABLED
+#if defined WINDOWS_ENABLED || defined X11_ENABLED || defined OSX_ENABLED || defined SERVER_ENABLED
 
 #include <cassert>
 #include <modules/kotlin_jvm/src/logging.h>


### PR DESCRIPTION
This adds support for:
- headless editor builds (useful and needed for exporting games in CI/CD)
- server builds

This PR is a requirement for #370