### PR TITLE
Export android x86_64 target

### DIFF
--- a/.github/actions/create-android-export-template/action.yaml
+++ b/.github/actions/create-android-export-template/action.yaml
@@ -22,6 +22,10 @@ runs:
       uses: actions/download-artifact@v3
       with:
         name: android-export-${{ inputs.target }}-binary-arm64v8
+    - name: Download android ${{ inputs.target }} export x86_64 binary
+      uses: actions/download-artifact@v3
+      with:
+        name: android-export-${{ inputs.target }}-binary-x86_64
     - name: Build android ${{ inputs.target }} export template
       shell: bash
       run: |

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -14,7 +14,7 @@ jobs:
   build-export-debug:
     strategy:
       matrix:
-        name: [ Linux, OSX-x64, OSX-arm64, Windows, Android-armv7, Android-armv8 ]
+        name: [ Linux, OSX-x64, OSX-arm64, Windows, Android-armv7, Android-armv8, Android-x86_64 ]
         include:
           # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
@@ -41,12 +41,17 @@ jobs:
             os: ubuntu-latest
             platform: android
             arch: armv7
-            output_folder: platform/android/java/lib/libs/dev/armeabi-v7a/
+            output_folder: platform/android/java/lib/libs/debug/armeabi-v7a/
           - name: Android-armv8
             os: ubuntu-latest
             platform: android
             arch: arm64v8
-            output_folder: platform/android/java/lib/libs/dev/arm64-v8a/
+            output_folder: platform/android/java/lib/libs/debug/arm64-v8a/
+          - name: Android-x86_64
+            os: ubuntu-latest
+            platform: android
+            arch: x86_64
+            output_folder: platform/android/java/lib/libs/debug/x86_64/
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone Godot Engine

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -41,17 +41,17 @@ jobs:
             os: ubuntu-latest
             platform: android
             arch: armv7
-            output_folder: platform/android/java/lib/libs/debug/armeabi-v7a/
+            output_folder: platform/android/java/lib/libs/dev/armeabi-v7a/
           - name: Android-armv8
             os: ubuntu-latest
             platform: android
             arch: arm64v8
-            output_folder: platform/android/java/lib/libs/debug/arm64-v8a/
+            output_folder: platform/android/java/lib/libs/dev/arm64-v8a/
           - name: Android-x86_64
             os: ubuntu-latest
             platform: android
             arch: x86_64
-            output_folder: platform/android/java/lib/libs/debug/x86_64/
+            output_folder: platform/android/java/lib/libs/dev/x86_64/
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone Godot Engine

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -13,7 +13,7 @@ jobs:
   build-export-release:
     strategy:
       matrix:
-        name: [ Linux, OSX-x64, OSX-arm64, Windows, Android-armv7, Android-armv8 ]
+        name: [ Linux, OSX-x64, OSX-arm64, Windows, Android-armv7, Android-armv8, Android-x86_64 ]
         include:
           # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
           - name: Linux
@@ -46,6 +46,11 @@ jobs:
             platform: android
             arch: arm64v8
             output_folder: platform/android/java/lib/libs/release/arm64-v8a/
+          - name: Android-x86_64
+            os: ubuntu-latest
+            platform: android
+            arch: x86_64
+            output_folder: platform/android/java/lib/libs/release/x86_64/
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone Godot Engine

--- a/.github/workflows/deploy-export-template.yaml
+++ b/.github/workflows/deploy-export-template.yaml
@@ -13,7 +13,7 @@ jobs:
   deploy-export-template:
     strategy:
       matrix:
-        name: [ Linux-release, OSX-x64-release, OSX-arm64-release, Windows-release, Android-armv7-release, Android-armv8-release, Linux-debug, OSX-x64-debug, OSX-arm64-debug, Windows-debug, Android-armv7-debug, Android-armv8-debug ]
+        name: [ Linux-release, OSX-x64-release, OSX-arm64-release, Windows-release, Android-armv7-release, Android-armv8-release, Android-x86_64-release, Linux-debug, OSX-x64-debug, OSX-arm64-debug, Windows-debug, Android-armv7-debug, Android-armv8-debug, Android-x86_64-debug ]
         include:
           - name: Linux-release
             # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
@@ -60,6 +60,14 @@ jobs:
             arch: arm64v8
             output_folder: platform/android/java/lib/libs/release/arm64-v8a/
             target: release
+          - name: Android-x86_64-release
+            os: ubuntu-latest
+            platform: android
+            binary: android_release.apk
+            cat_command: cat
+            arch: x86_64
+            output_folder: platform/android/java/lib/libs/release/x86_64/
+            target: release
           - name: Linux-debug
             # always use the oldest still supported LTS version of github actions. See: https://github.com/utopia-rise/godot-kotlin-jvm/issues/224
             os: ubuntu-20.04
@@ -104,6 +112,14 @@ jobs:
             cat_command: cat
             arch: arm64v8
             output_folder: platform/android/java/lib/libs/debug/arm64-v8a/
+            target: release_debug
+          - name: Android-x86_64-debug
+            os: ubuntu-latest
+            platform: android
+            binary: android_debug.apk
+            cat_command: cat
+            arch: x86_64
+            output_folder: platform/android/java/lib/libs/debug/x86_64/
             target: release_debug
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The android x86_64 target is today mainly used for android emulators during development on x86 based host machines because of the increased emulation performance.

They are also a requirement for android apps on windows atm.