### PR TITLE
Set Godot to 4.0 beta 5 instead of master

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -154,7 +154,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-godot-kotlin-symbol-processor.yaml
+++ b/.github/workflows/check-pr-godot-kotlin-symbol-processor.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-export-template.yaml
+++ b/.github/workflows/deploy-export-template.yaml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
@@ -257,7 +257,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
@@ -356,7 +356,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
 
       - name: Get release export template binary
         uses: actions/download-artifact@v3

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-godot-kotlin-symbol-processor.yaml
+++ b/.github/workflows/deploy-godot-kotlin-symbol-processor.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-godot-library.yaml
+++ b/.github/workflows/deploy-godot-library.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: master
+          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Godot master branch is always receiving new commit, making code in the module instable as it can break when we pull the master.
From now, we use commit 89a33d28f, the one Godot 4.0 beta 5 is based on.