### PR TITLE
Update to latest beta commit

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -158,7 +158,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -72,7 +72,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -158,7 +158,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -121,7 +121,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -120,7 +120,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-godot-kotlin-symbol-processor.yaml
+++ b/.github/workflows/check-pr-godot-kotlin-symbol-processor.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-godot-kotlin-symbol-processor.yaml
+++ b/.github/workflows/check-pr-godot-kotlin-symbol-processor.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-export-template.yaml
+++ b/.github/workflows/deploy-export-template.yaml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
@@ -262,7 +262,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
@@ -361,7 +361,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
 
       - name: Get release export template binary
         uses: actions/download-artifact@v3

--- a/.github/workflows/deploy-export-template.yaml
+++ b/.github/workflows/deploy-export-template.yaml
@@ -135,7 +135,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
@@ -262,7 +262,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
@@ -361,7 +361,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
 
       - name: Get release export template binary
         uses: actions/download-artifact@v3

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-godot-kotlin-symbol-processor.yaml
+++ b/.github/workflows/deploy-godot-kotlin-symbol-processor.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-godot-kotlin-symbol-processor.yaml
+++ b/.github/workflows/deploy-godot-kotlin-symbol-processor.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-godot-library.yaml
+++ b/.github/workflows/deploy-godot-library.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 89a33d28f00fec579184fb7193790d40aa09b45b
+          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-godot-library.yaml
+++ b/.github/workflows/deploy-godot-library.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 7f8ecffa56834dce3ccbd736738b613d51133dea
+          ref: 0ff8742919af72c7412e63ef0f646cb4e7bd7d8f
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/src/bridges/variant_array_bridge.cpp
+++ b/src/bridges/variant_array_bridge.cpp
@@ -338,7 +338,7 @@ void VariantArrayBridge::engine_call_findLast(JNIEnv* p_raw_env, jobject p_insta
     Variant args[1] = {};
     TransferContext* transfer_context = GDKotlin::get_instance().transfer_context;
     transfer_context->read_args(env, args);
-    Variant variant{from_uint_to_ptr<Array>(p_raw_ptr)->find_last(args[0])};
+    Variant variant{from_uint_to_ptr<Array>(p_raw_ptr)->rfind(args[0])};
     transfer_context->write_return_value(env, variant);
 }
 


### PR DESCRIPTION
This updates the ref's inside the workflow to the latest beta release commit hash [7f8ecffa56834dce3ccbd736738b613d51133dea](https://github.com/godotengine/godot/commit/7f8ecffa56834dce3ccbd736738b613d51133dea)