### PR TITLE
Fix wrongly reported ksp error upon compilation error

### DIFF
--- a/harness/tests/build_with_compiler_plugin_debug.sh
+++ b/harness/tests/build_with_compiler_plugin_debug.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+./gradlew build --no-daemon -Dorg.gradle.debug=true -Dkotlin.compiler.execution.strategy="in-process" -Dkotlin.daemon.jvm.options="-Xdebug,-Xrunjdwp:transport=dt_socket,address=5005,server=y,suspend=n"

--- a/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/GodotKotlinSymbolProcessor.kt
+++ b/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/GodotKotlinSymbolProcessor.kt
@@ -42,6 +42,7 @@ class GodotKotlinSymbolProcessor(
             ?: throw IllegalStateException("No projectBasePath option provided")
 
         val registerAnnotationVisitor = RegistrationAnnotationVisitor(
+            logger,
             projectBasePath,
             registeredClassToKSFileMap,
             sourceFilesContainingRegisteredClasses

--- a/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/ext/ksClassDeclarationExt.kt
+++ b/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/ext/ksClassDeclarationExt.kt
@@ -19,6 +19,8 @@ import godot.entrygenerator.model.RegisteredProperty
 import godot.entrygenerator.model.RegisteredSignal
 import java.io.File
 
+fun KSClassDeclaration.hasCompilationErrors(): Boolean = superTypes.toList().any { it.resolve().isError }
+
 fun KSClassDeclaration.getResPath(srcDirs: List<String>, projectDir: String): String = containingFile
     ?.filePath
     ?.let { filePath ->


### PR DESCRIPTION
If a supertype of a class had a compilation error, our symbol processor threw an error as it could not resolve the fully qualified name of said class as it has compilation errors. We then threw a exception in the symbol processor which hides the real problem.

Example:
class with compilation error (note the typo `Nodu` instead of `Node`:
```kotlin
@RegisterClass
class ScriptInOtherSourceDir: Nodu() {

	@RegisterFunction
	fun greeting() = "HelloWorld"
}
```
Previously this printed the following error:
```
[ksp] java.lang.IllegalArgumentException: Qualified name for class declaration of a registered type or it's super types cannot be null
// stack trace ommited for simplicity
```
Which hides the real issue that there is a typo in the supertype declaration.

With these changes we just print a warning that we could not process the declaration because of compilation errors and let the compiler print the actual error.
Now the same example would print the following (note the warning on line 2):
```
> Task :kspKotlin
w: [ksp] /home/cedric/projects/04_godot/3/modules/kotlin_jvm/harness/tests/scripts/ScriptInOtherSourceDir.kt:6: Declaration will not be processed as it seems to have compilation errors.

> Task :processResources UP-TO-DATE

> Task :compileKotlin FAILED

> Task :deleteBuildLock
42 actionable tasks: 11 executed, 31 up-to-date
e: /home/cedric/projects/04_godot/3/modules/kotlin_jvm/harness/tests/scripts/ScriptInOtherSourceDir.kt: (6, 31): Unresolved reference: Nodu

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileKotlin'.
> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.GradleCompilerRunnerWithWorkers$GradleKotlinCompilerWorkAction
   > Compilation error. See log for more details

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 5s
```