### PR TITLE
Fix resource property type hint

### DIFF
--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
@@ -54,7 +54,7 @@ fun Type.toTypeName(): TypeName = ClassName(
 
 fun Type.isCompatibleList(): Boolean = when (fqName) {
     "godot.core.GodotArray", "godot.core.VariantArray" -> true
-    else -> supertypes.any { it.fqName == "godot.core.GodotArray" || it.fqName == "godot.core.VariantArray" }
+    else -> supertypes.any { it.isCompatibleList() }
 }
 
 fun Type.isReference(): Boolean = fqName == "godot.Reference" ||
@@ -62,6 +62,9 @@ fun Type.isReference(): Boolean = fqName == "godot.Reference" ||
         .supertypes
         .map { it.fqName }
         .any { it == "godot.Reference" }
+    || this
+    .supertypes
+    .any { it.isReference() }
 
 fun Type.isGodotPrimitive(): Boolean = when (fqName) {
     "kotlin.Int",

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
@@ -53,7 +53,7 @@ fun Type.toTypeName(): TypeName = ClassName(
 )
 
 fun Type.isCompatibleList(): Boolean = when (fqName) {
-    "godot.core.GodotArray", "godot.core.VariantArray" -> true
+    "godot.core.VariantArray" -> true
     else -> supertypes.any { it.isCompatibleList() }
 }
 

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
@@ -60,11 +60,7 @@ fun Type.isCompatibleList(): Boolean = when (fqName) {
 fun Type.isReference(): Boolean = fqName == "godot.Reference" ||
     this
         .supertypes
-        .map { it.fqName }
-        .any { it == "godot.Reference" }
-    || this
-    .supertypes
-    .any { it.isReference() }
+        .any { it.isReference() }
 
 fun Type.isGodotPrimitive(): Boolean = when (fqName) {
     "kotlin.Int",

--- a/kt/godot-library/src/main/kotlin/godot/core/Functions.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Functions.kt
@@ -17,8 +17,10 @@ enum class PropertyHint {
     FLAGS, ///< hint_text= "flag1,flag2,etc" (as bit flags)
     LAYERS_2D_RENDER,
     LAYERS_2D_PHYSICS,
+    LAYERS_2D_NAVIGATION,
     LAYERS_3D_RENDER,
     LAYERS_3D_PHYSICS,
+    LAYERS_3D_NAVIGATION,
     FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,"
     DIR, ///< a directory path must be passed
     GLOBAL_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,"
@@ -43,6 +45,7 @@ enum class PropertyHint {
     OBJECT_TOO_BIG, ///< object is too big to send
     NODE_PATH_VALID_TYPES,
     SAVE_FILE, ///< a file path must be passed, hint_text (optionally) is a filter "*.png,*.wav,*.doc,". This opens a save dialog
+    ENUM_SUGGESTION,
     MAX,
     // When updating PropertyHint, also sync the hardcoded list in VisualScriptEditorVariableEdit
 };

--- a/kt/godot-library/src/main/kotlin/godot/core/VariantArray.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/VariantArray.kt
@@ -468,7 +468,7 @@ inline fun <reified T> VariantArray(): VariantArray<T> {
 inline fun <reified T> variantArrayOf(vararg args: T) = VariantArray<T>().also { it.addAll(args) }
 
 /**
- * Convert an iterable into a GodotArray
+ * Convert an iterable into a VariantArray
  * Warning: Might be slow if the iterable contains a lot of items because can only append items one by one
  */
 inline fun <reified T> Iterable<T>.toVariantArray() = VariantArray<T>().also { arr ->


### PR DESCRIPTION
Fixes #394

This fixes the type hints for resource types.
The issue we were having was two fold:
- For once we did not check the supertypes recursively to detect whether the property was a resource type (in fact the relevant type is `Reference`). We also had that problem for list types. I fixed it there too as well.
- Secondly, since we initially implemented this, two new type hints were added, which meant that the ordinal was not correct anymore. By adding the missing typehints, the ordinal we send to the cpp code is correct again. **Note:** We should investigate if we can either automatically generate these typehint enums, or automatically test whether they are still correct. But I think this is out of the scope for this fix.