### PR TITLE
Fix constructor with generic args registration

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/constructor/ConstructorRegistrationTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/constructor/ConstructorRegistrationTest.kt
@@ -1,0 +1,14 @@
+package godot.tests.constructor
+
+import godot.Node
+import godot.annotation.RegisterClass
+import godot.annotation.RegisterConstructor
+import godot.core.Dictionary
+import godot.core.VariantArray
+
+@RegisterClass
+class ConstructorRegistrationTest(): Node() {
+
+    @RegisterConstructor
+    constructor(param1: Dictionary<Any, Any?>, param2: VariantArray<Long>): this()
+}

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/ConstructorRegistrationGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/ConstructorRegistrationGenerator.kt
@@ -39,18 +39,21 @@ object ConstructorRegistrationGenerator {
 
                             if (valueParameter.typeArguments.isNotEmpty()) {
                                 append("<")
-                                valueParameter.typeArguments.forEach { typeArgument ->
-                                    append("%T")
-                                    templateArgs.add(
-                                        ClassName(
-                                            typeArgument.fqName.substringBeforeLast("."),
-                                            typeArgument.fqName.substringAfterLast(".")
+                                append(
+                                    valueParameter.typeArguments.joinToString(",·") { typeArgument ->
+                                        templateArgs.add(
+                                            ClassName(
+                                                typeArgument.fqName.substringBeforeLast("."),
+                                                typeArgument.fqName.substringAfterLast(".")
+                                            )
                                         )
-                                    )
-                                    if (typeArgument.isNullable) {
-                                        append("?")
+                                        if (typeArgument.isNullable) {
+                                            "%T?"
+                                        } else {
+                                            "%T"
+                                        }
                                     }
-                                }
+                                )
                                 append(">")
                             }
 


### PR DESCRIPTION
The registration of constructors which have generic type parameters like `Dictionary` was broken.

The following class:
```kotlin
@RegisterClass
class ConstructorRegistrationTest(): Node() {
    @RegisterConstructor
    constructor(param1: Dictionary<Any, Any?>, param2: VariantArray<Long>): this()
}
```
produced the following invalid constructor registration:
```kotlin
constructor(KtConstructor2({param1: Dictionary<AnyAny?>, param2: VariantArray<Long> -> ConstructorRegistrationTest(param1, param2)}, DICTIONARY to false, ARRAY to false))
```

The reason was that i forgot to add `,` for generic type parameters while assembling the kotlin poet template for the constructor registration. This PR fixes this.