### PR TITLE
Make entry gen fully language independent

### DIFF
--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/EntryGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/EntryGenerator.kt
@@ -10,6 +10,7 @@ import godot.entrygenerator.checks.RpcCheck
 import godot.entrygenerator.checks.SignalTypeCheck
 import godot.entrygenerator.filebuilder.ClassRegistrarFileBuilder
 import godot.entrygenerator.filebuilder.MainEntryFileBuilder
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.RegisteredClass
 import godot.entrygenerator.model.SourceFile
 import godot.entrygenerator.utils.Logger
@@ -20,15 +21,22 @@ object EntryGenerator {
     internal val logger: Logger
         get() = _logger ?: throw UninitializedPropertyAccessException("logger not yet initialized. Get logger only after generateEntryFiles was called")
 
+    private var _jvmTypeFqNamesProvider: ((JvmType) -> Set<String>)? = null
+    internal val jvmTypeFqNamesProvider: ((JvmType) -> Set<String>)
+        get() = _jvmTypeFqNamesProvider ?: throw UninitializedPropertyAccessException("jvmTypeFqNamesProvider not yet initialized. Get jvmTypeFqNamesProvider only after generateEntryFiles was called")
+
     fun generateEntryFiles(
         projectDir: String,
         srcDirs: List<String>,
         logger: Logger,
         sourceFiles: List<SourceFile>,
+        jvmTypeFqNamesProvider: (JvmType) -> Set<String>,
         appendableProvider: (RegisteredClass) -> BufferedWriter,
         mainBufferedWriterProvider: () -> BufferedWriter
     ) {
         _logger = logger
+        _jvmTypeFqNamesProvider = jvmTypeFqNamesProvider
+
         executeSanityChecks(projectDir, srcDirs, logger, sourceFiles)
 
         with(MainEntryFileBuilder) {

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/exceptions/WrongAnnotationUsageException.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/exceptions/WrongAnnotationUsageException.kt
@@ -6,7 +6,7 @@ import godot.entrygenerator.model.RegisteredProperty
 class WrongAnnotationUsageException(
     registeredProperty: RegisteredProperty,
     propertyHintAnnotation: PropertyHintAnnotation?,
-    effectiveType: String? = null
+    effectiveTypes: Set<String>? = null
 ) : Exception(
-    "You annotated ${registeredProperty.fqName} with @${propertyHintAnnotation?.let { it::class.qualifiedName }?.substringAfterLast(".")?.removeSuffix("HintAnnotation")} which ${if (effectiveType != null) "is only applicable to properties of type $effectiveType" else "cannot be applied on properties of type ${registeredProperty.type.fqName}"}"
+    "You annotated ${registeredProperty.fqName} with @${propertyHintAnnotation?.let { it::class.qualifiedName }?.substringAfterLast(".")?.removeSuffix("HintAnnotation")} which ${if (effectiveTypes != null) "is only applicable to properties of type $effectiveTypes" else "cannot be applied on properties of type ${registeredProperty.type.fqName}"}"
 )

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/FqNameExtensions.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/FqNameExtensions.kt
@@ -1,0 +1,13 @@
+package godot.entrygenerator.ext
+
+import godot.entrygenerator.EntryGenerator
+import godot.entrygenerator.model.JvmType
+
+fun String.fqNameIsJvmType(vararg jvmTypes: JvmType): Boolean = jvmTypes.any { jvmType ->
+    EntryGenerator
+        .jvmTypeFqNamesProvider(jvmType)
+        .any { jvmTypeFqName -> jvmTypeFqName == this }
+}
+
+val JvmType.fqName: Set<String>
+    get() = EntryGenerator.jvmTypeFqNamesProvider(this)

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/ColorNoAlphaHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/ColorNoAlphaHintStringGenerator.kt
@@ -12,7 +12,7 @@ class ColorNoAlphaHintStringGenerator(
 
     override fun getHintString(): String {
         if (registeredProperty.type.fqName != "$godotCorePackage.${GodotTypes.color}") {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, GodotTypes.color)
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, setOf("${godotCorePackage}.${GodotTypes.color}"))
         }
         return "" //hint string is empty for this typehint
     }

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/DirHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/DirHintStringGenerator.kt
@@ -1,7 +1,9 @@
 package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.ext.fqName
 import godot.entrygenerator.model.DirHintAnnotation
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.RegisteredProperty
 
 class DirHintStringGenerator(
@@ -10,7 +12,7 @@ class DirHintStringGenerator(
 
     override fun getHintString(): String {
         if (registeredProperty.type.fqName != String::class.qualifiedName) {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, String::class.qualifiedName)
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, JvmType.STRING.fqName)
         }
 
         return "" //hint string is empty for this typehint

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/DoubleRangeHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/DoubleRangeHintStringGenerator.kt
@@ -1,7 +1,10 @@
 package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.ext.fqName
+import godot.entrygenerator.ext.fqNameIsJvmType
 import godot.entrygenerator.model.DoubleRangeHintAnnotation
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.Range
 import godot.entrygenerator.model.RegisteredProperty
 import java.util.*
@@ -9,8 +12,8 @@ import java.util.*
 class DoubleRangeHintStringGenerator(registeredProperty: RegisteredProperty):
     PropertyHintStringGenerator<DoubleRangeHintAnnotation>(registeredProperty) {
     override fun getHintString(): String {
-        if (registeredProperty.type.fqName != Double::class.qualifiedName) {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, Double::class.qualifiedName)
+        if (!registeredProperty.type.fqName.fqNameIsJvmType(JvmType.DOUBLE)) {
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, JvmType.DOUBLE.fqName)
         }
         if (propertyHintAnnotation == null) {
             return ""

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/ExpEasingHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/ExpEasingHintStringGenerator.kt
@@ -1,14 +1,17 @@
 package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.ext.fqName
+import godot.entrygenerator.ext.fqNameIsJvmType
 import godot.entrygenerator.model.ExpEasingHintAnnotation
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.RegisteredProperty
 
 class ExpEasingHintStringGenerator(registeredProperty: RegisteredProperty) :
     PropertyHintStringGenerator<ExpEasingHintAnnotation>(registeredProperty) {
     override fun getHintString(): String {
-        if (!listOf(Float::class.qualifiedName, Double::class.qualifiedName).contains(registeredProperty.type.fqName)) {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, "${Float::class.qualifiedName}s and ${Double::class.qualifiedName}s")
+        if (!registeredProperty.type.fqName.fqNameIsJvmType(JvmType.FLOAT, JvmType.DOUBLE)) {
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, setOf(*JvmType.FLOAT.fqName.toTypedArray(), *JvmType.DOUBLE.fqName.toTypedArray()))
         }
 
         if (propertyHintAnnotation == null) {

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/ExpRangeHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/ExpRangeHintStringGenerator.kt
@@ -1,14 +1,17 @@
 package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.ext.fqName
+import godot.entrygenerator.ext.fqNameIsJvmType
 import godot.entrygenerator.model.ExpRangeHintAnnotation
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.RegisteredProperty
 
 class ExpRangeHintStringGenerator(registeredProperty: RegisteredProperty):
     PropertyHintStringGenerator<ExpRangeHintAnnotation>(registeredProperty) {
     override fun getHintString(): String {
-        if (!listOf(Float::class.qualifiedName, Double::class.qualifiedName).contains(registeredProperty.type.fqName)) {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, Float::class.qualifiedName)
+        if (!registeredProperty.type.fqName.fqNameIsJvmType(JvmType.FLOAT, JvmType.DOUBLE)) {
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, JvmType.FLOAT.fqName)
         }
         if (propertyHintAnnotation == null) {
             return ""

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/FileHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/FileHintStringGenerator.kt
@@ -1,14 +1,17 @@
 package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.ext.fqName
+import godot.entrygenerator.ext.fqNameIsJvmType
 import godot.entrygenerator.model.FileHintAnnotation
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.RegisteredProperty
 
 class FileHintStringGenerator(registeredProperty: RegisteredProperty):
     PropertyHintStringGenerator<FileHintAnnotation>(registeredProperty) {
     override fun getHintString(): String {
-        if (registeredProperty.type.fqName != String::class.qualifiedName) {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, String::class.qualifiedName)
+        if (!registeredProperty.type.fqName.fqNameIsJvmType(JvmType.STRING)) {
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, JvmType.STRING.fqName)
         }
 
         return propertyHintAnnotation?.extensions?.joinToString(",") ?: ""

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/FloatRangeHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/FloatRangeHintStringGenerator.kt
@@ -1,7 +1,10 @@
 package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.ext.fqName
+import godot.entrygenerator.ext.fqNameIsJvmType
 import godot.entrygenerator.model.FloatRangeHintAnnotation
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.Range
 import godot.entrygenerator.model.RegisteredProperty
 import java.util.*
@@ -9,8 +12,8 @@ import java.util.*
 class FloatRangeHintStringGenerator(registeredProperty: RegisteredProperty):
     PropertyHintStringGenerator<FloatRangeHintAnnotation>(registeredProperty) {
     override fun getHintString(): String {
-        if (registeredProperty.type.fqName != Float::class.qualifiedName) {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, Float::class.qualifiedName)
+        if (!registeredProperty.type.fqName.fqNameIsJvmType(JvmType.FLOAT)) {
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, JvmType.FLOAT.fqName)
         }
         if (propertyHintAnnotation == null) {
             return ""

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/IntFlagHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/IntFlagHintStringGenerator.kt
@@ -1,7 +1,10 @@
 package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.ext.fqName
+import godot.entrygenerator.ext.fqNameIsJvmType
 import godot.entrygenerator.model.IntFlagHintAnnotation
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.RegisteredProperty
 
 class IntFlagHintStringGenerator(
@@ -9,8 +12,8 @@ class IntFlagHintStringGenerator(
 ) : PropertyHintStringGenerator<IntFlagHintAnnotation>(registeredProperty) {
 
     override fun getHintString(): String {
-        if (registeredProperty.type.fqName != Int::class.qualifiedName) {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, Int::class.qualifiedName)
+        if (!registeredProperty.type.fqName.fqNameIsJvmType(JvmType.INT)) {
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, JvmType.INT.fqName)
         }
 
         return propertyHintAnnotation

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/IntRangeHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/IntRangeHintStringGenerator.kt
@@ -2,6 +2,9 @@ package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.model.IntRangeHintAnnotation
 import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.ext.fqName
+import godot.entrygenerator.ext.fqNameIsJvmType
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.Range
 import godot.entrygenerator.model.RegisteredProperty
 import java.util.*
@@ -9,8 +12,8 @@ import java.util.*
 class IntRangeHintStringGenerator(registeredProperty: RegisteredProperty):
     PropertyHintStringGenerator<IntRangeHintAnnotation>(registeredProperty) {
     override fun getHintString(): String {
-        if (registeredProperty.type.fqName != Int::class.qualifiedName) {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, Int::class.qualifiedName)
+        if (!registeredProperty.type.fqName.fqNameIsJvmType(JvmType.INT)) {
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, JvmType.INT.fqName)
         }
         if (propertyHintAnnotation == null) {
             return ""

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/LongRangeHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/LongRangeHintStringGenerator.kt
@@ -1,6 +1,9 @@
 package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.exceptions.WrongAnnotationUsageException
+import godot.entrygenerator.ext.fqName
+import godot.entrygenerator.ext.fqNameIsJvmType
+import godot.entrygenerator.model.JvmType
 import godot.entrygenerator.model.LongRangeHintAnnotation
 import godot.entrygenerator.model.Range
 import godot.entrygenerator.model.RegisteredProperty
@@ -9,8 +12,8 @@ import java.util.*
 class LongRangeHintStringGenerator(registeredProperty: RegisteredProperty):
     PropertyHintStringGenerator<LongRangeHintAnnotation>(registeredProperty) {
     override fun getHintString(): String {
-        if (registeredProperty.type.fqName != Long::class.qualifiedName) {
-            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, Long::class.qualifiedName)
+        if (!registeredProperty.type.fqName.fqNameIsJvmType(JvmType.LONG)) {
+            throw WrongAnnotationUsageException(registeredProperty, propertyHintAnnotation, JvmType.LONG.fqName)
         }
         if (propertyHintAnnotation == null) {
             return ""

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/model/JvmType.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/model/JvmType.kt
@@ -1,0 +1,13 @@
+package godot.entrygenerator.model
+
+enum class JvmType {
+    INT,
+    LONG,
+    FLOAT,
+    DOUBLE,
+    BOOLEAN,
+    STRING,
+    BYTE,
+    ANY,
+    VOID,
+}

--- a/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/utils/JvmTypeProvider.kt
+++ b/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/utils/JvmTypeProvider.kt
@@ -1,0 +1,38 @@
+package godot.annotation.processor.utils
+
+import godot.entrygenerator.model.JvmType
+
+class JvmTypeProvider: (JvmType) -> Set<String> {
+    override fun invoke(jvmType: JvmType): Set<String> {
+        return when(jvmType) {
+            JvmType.INT -> setOf(
+                requireNotNull(Int::class.qualifiedName),
+                requireNotNull(Short::class.qualifiedName),
+            )
+            JvmType.LONG -> setOf(
+                requireNotNull(Long::class.qualifiedName),
+            )
+            JvmType.FLOAT -> setOf(
+                requireNotNull(Float::class.qualifiedName),
+            )
+            JvmType.DOUBLE -> setOf(
+                requireNotNull(Double::class.qualifiedName),
+            )
+            JvmType.BOOLEAN -> setOf(
+                requireNotNull(Boolean::class.qualifiedName),
+            )
+            JvmType.STRING -> setOf(
+                requireNotNull(String::class.qualifiedName),
+            )
+            JvmType.BYTE -> setOf(
+                requireNotNull(Byte::class.qualifiedName),
+            )
+            JvmType.ANY -> setOf(
+                requireNotNull(Any::class.qualifiedName),
+            )
+            JvmType.VOID -> setOf(
+                requireNotNull(Unit::class.qualifiedName),
+            )
+        }
+    }
+}


### PR DESCRIPTION
Depends on #432 . (I will change the target branch once that one is merged)

Makes entry gen (hopefully) fully language independent by removing all remaining kotlin fqName checks from it and replacing it by a fqName provider provided to the entry gen by the caller.

With this the entry gen retrieves the fqNames it needs for certain language specific type checks (like "is the fqName i got here an fqName of the Int type or not?") from the caller through the provider.

This should allow the language specific symbol processors to provide the entry gen with the language specific fqNames for the needed types.