### PR TITLE
Feature/4.0/default values from instance

### DIFF
--- a/src/jni/types.cpp
+++ b/src/jni/types.cpp
@@ -99,6 +99,10 @@ namespace jni {
         env.check_exceptions();
     }
 
+    void JObject::call_void_method_noexcept(Env& env, MethodId method, jvalue* args) const {
+        env.env->CallVoidMethodA((jclass) obj, method, args);
+    }
+
     MethodId JClass::get_method_id(Env& env, const char* name, const char* signature) {
         auto id = env.env->GetMethodID((jclass) obj, name, signature);
         JVM_CRASH_COND_MSG(id == nullptr, vformat("Method not found: %s with signature: %s", name, signature));

--- a/src/jni/types.h
+++ b/src/jni/types.h
@@ -76,6 +76,8 @@ namespace jni {
 
         void call_void_method(Env& env, MethodId method, jvalue* args = {}) const;
 
+        void call_void_method_noexcept(Env& env, MethodId method, jvalue* args = {}) const;
+
         bool is_null();
     };
 

--- a/src/kotlin_instance.cpp
+++ b/src/kotlin_instance.cpp
@@ -23,7 +23,7 @@ bool KotlinInstance::set(const StringName& p_name, const Variant& p_value) {
 
     KtProperty* ktProperty {kt_class->get_property(p_name)};
     if (ktProperty) {
-        ktProperty->setCall(binding->kt_object, p_value);
+        ktProperty->call_set(binding->kt_object, p_value);
         return true;
     } else {
         return false;
@@ -35,12 +35,26 @@ bool KotlinInstance::get(const StringName& p_name, Variant& r_ret) const {
 
     KtProperty* ktProperty {kt_class->get_property(p_name)};
     if (ktProperty) {
-        ktProperty->callGet(binding->kt_object, r_ret);
+        ktProperty->call_get(binding->kt_object, r_ret);
         return true;
     } else {
         return false;
     }
 }
+
+#ifdef TOOLS_ENABLED
+bool KotlinInstance::get_or_default(const StringName& p_name, Variant& r_ret) const {
+    jni::LocalFrame localFrame(1000);
+
+    KtProperty* ktProperty {kt_class->get_property(p_name)};
+    if (ktProperty) {
+        ktProperty->safe_call_get(binding->kt_object, r_ret);
+        return true;
+    } else {
+        return false;
+    }
+}
+#endif
 
 void KotlinInstance::get_property_list(List<PropertyInfo>* p_properties) const {
     kt_class->get_property_list(p_properties);

--- a/src/kotlin_instance.h
+++ b/src/kotlin_instance.h
@@ -21,6 +21,10 @@ public:
 
     bool get(const StringName& p_name, Variant& r_ret) const override;
 
+#ifdef TOOLS_ENABLED
+    bool get_or_default(const StringName& p_name, Variant& r_ret) const;
+#endif
+
     void get_property_list(List<PropertyInfo>* p_properties) const override;
 
     Variant::Type get_property_type(const StringName& p_name, bool* r_is_valid) const override;

--- a/src/kotlin_script.cpp
+++ b/src/kotlin_script.cpp
@@ -227,16 +227,18 @@ void KotlinScript::update_exports() {
 
 void KotlinScript::_update_exports(PlaceHolderScriptInstance* placeholder) {
 #ifdef TOOLS_ENABLED
+    exported_members_default_value_cache.clear();
     if (KtClass * kt_class {get_kotlin_class()}) {
         Object* tmp_object {ClassDB::instantiate(kt_class->base_godot_class)};
-        ScriptInstance* script_instance { _instance_create({}, 0, tmp_object) };
-        
+        KotlinInstance* script_instance {
+          dynamic_cast<KotlinInstance*>(_instance_create({}, 0, tmp_object))};
+
         List<PropertyInfo> properties;
         get_script_property_list(&properties);
         for (int i = 0; i < properties.size(); ++i) {
             Variant default_value;
             const String& property_name{ properties[i].name };
-            script_instance->get(property_name, default_value);
+            script_instance->get_or_default(property_name, default_value);
             exported_members_default_value_cache[property_name] = default_value;
         }
         placeholder->update(properties, exported_members_default_value_cache);

--- a/src/kotlin_script.cpp
+++ b/src/kotlin_script.cpp
@@ -112,14 +112,15 @@ void KotlinScript::get_script_signal_list(List<MethodInfo>* r_signals) const {
 }
 
 bool KotlinScript::get_property_default_value(const StringName& p_property, Variant& r_value) const {
-    bool has_default {false};
-    if (KtClass * kt_class {get_kotlin_class()}) {
-        if (KtProperty * property {kt_class->get_property(p_property)}) {
-            property->get_default_value(r_value);
-            has_default = true;
-        }
+#ifdef TOOLS_ENABLED
+    HashMap<StringName, Variant>::ConstIterator it { exported_members_default_value_cache.find(p_property) };
+    if (it) {
+        r_value = it->value;
+        return true;
     }
-    return has_default;
+#endif
+
+    return false;
 }
 
 void KotlinScript::get_script_method_list(List<MethodInfo>* p_list) const {
@@ -224,18 +225,23 @@ void KotlinScript::update_exports() {
 #endif
 }
 
-void KotlinScript::_update_exports(PlaceHolderScriptInstance* placeholder) const {
+void KotlinScript::_update_exports(PlaceHolderScriptInstance* placeholder) {
 #ifdef TOOLS_ENABLED
-    List<PropertyInfo> properties;
-    HashMap<StringName, Variant> default_values;
-    get_script_property_list(&properties);
-    for (int i = 0; i < properties.size(); ++i) {
-        StringName property_name {properties[i].name};
-        Variant ret;
-        get_property_default_value(property_name, ret);
-        default_values[property_name] = ret;
+    if (KtClass * kt_class {get_kotlin_class()}) {
+        Object* tmp_object {ClassDB::instantiate(kt_class->base_godot_class)};
+        ScriptInstance* script_instance { _instance_create({}, 0, tmp_object) };
+        
+        List<PropertyInfo> properties;
+        get_script_property_list(&properties);
+        for (int i = 0; i < properties.size(); ++i) {
+            Variant default_value;
+            const String& property_name{ properties[i].name };
+            script_instance->get(property_name, default_value);
+            exported_members_default_value_cache[property_name] = default_value;
+        }
+        placeholder->update(properties, exported_members_default_value_cache);
+        memdelete(tmp_object);
     }
-    placeholder->update(properties, default_values);
 #endif
 }
 
@@ -247,4 +253,10 @@ void KotlinScript::_placeholder_erased(PlaceHolderScriptInstance* p_placeholder)
 
 void KotlinScript::_bind_methods() {
     ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "new", &KotlinScript::_new, MethodInfo("new"));
+}
+
+KotlinScript::~KotlinScript() {
+#ifdef TOOLS_ENABLED
+    exported_members_default_value_cache.clear();
+#endif
 }

--- a/src/kotlin_script.h
+++ b/src/kotlin_script.h
@@ -19,7 +19,7 @@ private:
 public:
     KotlinScript();
 
-    ~KotlinScript() override = default;
+    ~KotlinScript() override;
 
     KtClass* get_kotlin_class() const;
 
@@ -79,9 +79,13 @@ public:
 private:
     HashSet<PlaceHolderScriptInstance*> placeholders;
 
+#ifdef TOOLS_ENABLED
+    HashMap<StringName, Variant> exported_members_default_value_cache;
+#endif
+
     void _placeholder_erased(PlaceHolderScriptInstance* p_placeholder) override;
 
-    void _update_exports(PlaceHolderScriptInstance* placeholder) const;
+    void _update_exports(PlaceHolderScriptInstance* placeholder);
 
 public:
     PlaceHolderScriptInstance* placeholder_instance_create(Object* p_this) override;

--- a/src/kt_property.cpp
+++ b/src/kt_property.cpp
@@ -75,11 +75,3 @@ void KtProperty::setCall(KtObject* instance, const Variant& p_value) {
     jvalue args[1] = {jni::to_jni_arg(instance->get_wrapped())};
     wrapped.call_void_method(env, setCallMethodId, args);
 }
-
-void KtProperty::get_default_value(Variant& r_value) {
-    jni::Env env {jni::Jvm::current_env()};
-    GDKotlin::get_instance().transfer_context->write_args(env, nullptr, 0);
-    jni::MethodId get_default_value_method {get_method_id(env, jni_methods.GET_DEFAULT_VALUE)};
-    wrapped.call_void_method(env, get_default_value_method);
-    GDKotlin::get_instance().transfer_context->read_return_value(env, r_value);
-}

--- a/src/kt_property.cpp
+++ b/src/kt_property.cpp
@@ -59,7 +59,7 @@ PropertyInfo KtProperty::get_member_info() {
     return propertyInfo->toPropertyInfo();
 }
 
-void KtProperty::callGet(KtObject* instance, Variant& r_ret) {
+void KtProperty::call_get(KtObject* instance, Variant& r_ret) {
     jni::Env env {jni::Jvm::current_env()};
     jni::MethodId get_call_method_id {get_method_id(env, jni_methods.CALL_GET)};
     jvalue call_args[1] = {jni::to_jni_arg(instance->get_wrapped())};
@@ -67,7 +67,7 @@ void KtProperty::callGet(KtObject* instance, Variant& r_ret) {
     GDKotlin::get_instance().transfer_context->read_return_value(env, r_ret);
 }
 
-void KtProperty::setCall(KtObject* instance, const Variant& p_value) {
+void KtProperty::call_set(KtObject* instance, const Variant& p_value) {
     jni::Env env {jni::Jvm::current_env()};
     jni::MethodId setCallMethodId {get_method_id(env, jni_methods.CALL_SET)};
     const Variant* arg[1] = {&p_value};
@@ -75,3 +75,19 @@ void KtProperty::setCall(KtObject* instance, const Variant& p_value) {
     jvalue args[1] = {jni::to_jni_arg(instance->get_wrapped())};
     wrapped.call_void_method(env, setCallMethodId, args);
 }
+
+#ifdef TOOLS_ENABLED
+void KtProperty::safe_call_get(KtObject* instance, Variant& r_ret) {
+    jni::Env env {jni::Jvm::current_env()};
+    jni::MethodId get_call_method_id {get_method_id(env, jni_methods.CALL_GET)};
+    jvalue call_args[1] = {jni::to_jni_arg(instance->get_wrapped())};
+    wrapped.call_void_method_noexcept(env, get_call_method_id, call_args);
+    if (env.exception_check()) {
+        Callable::CallError error;
+        Variant::construct(propertyInfo->type, r_ret, {}, 0, error);
+        env.exception_clear();
+        return;
+    }
+    GDKotlin::get_instance().transfer_context->read_return_value(env, r_ret);
+}
+#endif

--- a/src/kt_property.h
+++ b/src/kt_property.h
@@ -45,8 +45,12 @@ public:
 
     PropertyInfo get_member_info();
 
-    void callGet(KtObject* instance, Variant& r_ret);
-    void setCall(KtObject* instance, const Variant& p_value);
+    void call_get(KtObject* instance, Variant& r_ret);
+    void call_set(KtObject* instance, const Variant& p_value);
+
+#ifdef TOOLS_ENABLED
+    void safe_call_get(KtObject* instance, Variant& r_ret);
+#endif
 
     // clang-format off
     DECLARE_JNI_METHODS(

--- a/src/kt_property.h
+++ b/src/kt_property.h
@@ -48,15 +48,12 @@ public:
     void callGet(KtObject* instance, Variant& r_ret);
     void setCall(KtObject* instance, const Variant& p_value);
 
-    void get_default_value(Variant& r_value);
-
     // clang-format off
     DECLARE_JNI_METHODS(
             JNI_METHOD(GET_KT_PROPERTY_INFO, "getKtPropertyInfo", "()Lgodot/core/KtPropertyInfo;")
             JNI_METHOD(IS_REF, "isRef", "()Z")
             JNI_METHOD(CALL_GET, "callGet", "(Lgodot/core/KtObject;)V")
             JNI_METHOD(CALL_SET, "callSet", "(Lgodot/core/KtObject;)V")
-            JNI_METHOD(GET_DEFAULT_VALUE, "getDefaultValue", "()V")
     )
     // clang-format on
 };


### PR DESCRIPTION
This cause troubles with exported `lateinit`.  
When it tries to get it, it throws an exception because it is not initialized.  
```
Godot-JVM: Try to create res://src/main/kotlin/godot/tests/Invocation.kt instance.
Hello Invocation!
Godot-JVM: Instantiated an object of type res://src/main/kotlin/godot/tests/Invocation.kt
kotlin.UninitializedPropertyAccessException: lateinit property lateinitString has not been initialized
        at godot.tests.Invocation.getLateinitString(Invocation.kt:77)
        at godot.godot.tests.InvocationRegistrar$register$1$1$87.get(InvocationRegistrar.kt:279)
        at godot.core.KtProperty.callGet(Properties.kt:33)
ERROR: Godot-JVM: An exception has occurred!
   at: (modules\kotlin_jvm\src\jni\env.cpp:68)
kotlin.UninitializedPropertyAccessException: lateinit property registerObject has not been initialized
        at godot.tests.Invocation.getRegisterObject(Invocation.kt:80)
        at godot.godot.tests.InvocationRegistrar$register$1$1$89.get(InvocationRegistrar.kt:280)
        at godot.core.KtProperty.callGet(Properties.kt:33)
ERROR: Godot-JVM: An exception has occurred!
   at: (modules\kotlin_jvm\src\jni\env.cpp:68)
Godot-JVM: Try to create res://src/main/kotlin/godot/tests/Invocation.kt instance.
Hello Invocation!
Godot-JVM: Instantiated an object of type res://src/main/kotlin/godot/tests/Invocation.kt
kotlin.UninitializedPropertyAccessException: lateinit property lateinitString has not been initialized
        at godot.tests.Invocation.getLateinitString(Invocation.kt:77)
        at godot.godot.tests.InvocationRegistrar$register$1$1$87.get(InvocationRegistrar.kt:279)
        at godot.core.KtProperty.callGet(Properties.kt:33)
ERROR: Godot-JVM: An exception has occurred!
   at: (modules\kotlin_jvm\src\jni\env.cpp:68)
```
The default value is set to null (as it is not initialized it results in a NIL variant), even if property type is not nullable.
I think this is misleading for user and can lead to big troubles.

When thinking with @CedNaru  we went to a point that's a non sense to export lateinit. As exports needs default values that should be resolved during construct time of Object.

----
Edit @chippmann:
**Documentation:** after some discussion on discord we decided to keep the lateinit case for exported properties. There are still some valid usecases where it makes sense to export a lateinit property. Like exporting nodepaths where one expects them to be set from the inspector.
To circumvent the problem described in the PR description, this PR now catches exceptions while creating the instance of the class and while retrieving the default values from it. If an exception arises, the types default value is used instead.
This also gives some safety when the user does something fishy during the constructing phase of the class which leads to an exception if the class is being constructed outside of its intended usage (like here in the editor)
