### PR TITLE
Support exporting of types extending node

### DIFF
--- a/harness/tests/Spatial.tscn
+++ b/harness/tests/Spatial.tscn
@@ -12,11 +12,13 @@
 
 [sub_resource type="NavigationMesh" id="NavigationMesh_abcao"]
 
-[node name="Spatial" type="Node3D"]
+[node name="Spatial" type="Node3D" node_paths=PackedStringArray("button")]
 script = ExtResource("1")
+button = NodePath("CanvasLayer/Button")
 nullable_long = 2
 lateinit_string = "works also from inspector"
 resource_test = SubResource("NavigationMesh_prd4u")
+jvm_id = 1783463798
 nav_meshes = Array[NavigationMesh]([SubResource("NavigationMesh_tuyoa")])
 nullable_array = Array[NavigationMesh]([SubResource("NavigationMesh_bh4po"), null])
 nav_meshes_dictionary = {

--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -34,7 +34,6 @@ import godot.core.PackedStringArray
 import godot.core.PackedVector2Array
 import godot.core.PackedVector3Array
 import godot.core.RID
-import godot.core.StringName
 import godot.core.VariantArray
 import godot.core.Vector2
 import godot.core.Vector3
@@ -55,6 +54,9 @@ enum class TestEnum {
 
 @RegisterClass
 class Invocation : Node3D() {
+	@Export
+	@RegisterProperty
+	lateinit var button: Button
 
 	@Export
 	@RegisterProperty

--- a/harness/tests/test/unit/test_object_node_paths.gd
+++ b/harness/tests/test/unit/test_object_node_paths.gd
@@ -1,0 +1,7 @@
+extends "res://addons/gut/test.gd"
+
+func test_signal_connection_scene_instantiation():
+	var invocation_script = load("res://Spatial.tscn").instantiate()
+	assert_not_null(invocation_script.button, "button should have been assigned in the inspector")
+	assert_is(invocation_script.button, Button, "button is not of type Button")
+	invocation_script.free()

--- a/harness/tests/test/unit/test_object_node_paths.gd
+++ b/harness/tests/test/unit/test_object_node_paths.gd
@@ -1,6 +1,6 @@
 extends "res://addons/gut/test.gd"
 
-func test_signal_connection_scene_instantiation():
+func test_object_node_path_instantiation():
 	var invocation_script = load("res://Spatial.tscn").instantiate()
 	assert_not_null(invocation_script.button, "button should have been assigned in the inspector")
 	assert_is(invocation_script.button, Button, "button is not of type Button")

--- a/harness/tests/test/unit/test_signals.gd
+++ b/harness/tests/test/unit/test_signals.gd
@@ -18,7 +18,7 @@ func test_signal_connection_code():
 	var invocation_script = load("res://Spatial.tscn").instantiate()
 	get_tree().root.add_child(invocation_script)
 	await get_tree().create_timer(1).timeout
-	assert_eq(invocation_script.get_node("CanvasLayer/Button").is_connected("pressed", Callable(invocation_script.invocation, "hook_no_param")), true, "signal \"pressed\" of button should be connected to \"invocation_script.invocation::hook_no_param\"")
+	assert_eq(invocation_script.button.is_connected("pressed", Callable(invocation_script.invocation, "hook_no_param")), true, "signal \"pressed\" of button should be connected to \"invocation_script.invocation::hook_no_param\"")
 	invocation_script.free()
 
 func test_signal_emitted_with_multiple_targets():

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
@@ -62,6 +62,18 @@ fun Type.isCoreType(): Boolean {
     ).contains(fqName)
 }
 
+fun Type.isNodeType(): Boolean {
+    return fqName == "$godotApiPackage.${GodotTypes.node}" || supertypes.any { supertype -> supertype.isNodeType() }
+}
+
+fun Type.baseGodotType(): Type? {
+    return if (fqName.startsWith(godotApiPackage)) {
+        this
+    } else {
+        supertypes.firstNotNullOfOrNull { supertype -> supertype.baseGodotType() }
+    }
+}
+
 fun Type.toTypeName(): TypeName = ClassName(
     fqName.substringBeforeLast("."),
     fqName.substringAfterLast(".")

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/NodeTypeHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/NodeTypeHintStringGenerator.kt
@@ -1,0 +1,13 @@
+package godot.entrygenerator.generator.hintstring
+
+import godot.entrygenerator.ext.baseGodotType
+import godot.entrygenerator.model.PropertyHintAnnotation
+import godot.entrygenerator.model.RegisteredProperty
+
+class NodeTypeHintStringGenerator(
+    registeredProperty: RegisteredProperty
+) : PropertyHintStringGenerator<PropertyHintAnnotation>(registeredProperty) {
+    override fun getHintString(): String {
+        return registeredProperty.type.baseGodotType()?.fqName?.substringAfterLast(".") ?: ""
+    }
+}

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/PropertyHintStringGeneratorProvider.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/PropertyHintStringGeneratorProvider.kt
@@ -2,6 +2,7 @@ package godot.entrygenerator.generator.hintstring
 
 import godot.entrygenerator.EntryGenerator
 import godot.entrygenerator.ext.isCompatibleList
+import godot.entrygenerator.ext.isNodeType
 import godot.entrygenerator.ext.isReference
 import godot.entrygenerator.model.ColorNoAlphaHintAnnotation
 import godot.entrygenerator.model.DirHintAnnotation
@@ -41,6 +42,7 @@ object PropertyHintStringGeneratorProvider {
             PlaceHolderTextHintAnnotation -> PlaceHolderTextHintStringGenerator(registeredProperty)
             is RangeHintAnnotation<*> -> RangeHintStringGenerator(registeredProperty)
             null -> when {
+                registeredProperty.type.isNodeType() -> NodeTypeHintStringGenerator(registeredProperty)
                 registeredProperty.type.isReference() -> ResourceHintStringGenerator(registeredProperty)
                 registeredProperty.type.isCompatibleList() -> ArrayHintStringGenerator(registeredProperty)
                 else -> object : PropertyHintStringGenerator<PropertyHintAnnotation>(registeredProperty) {

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/typehint/PropertyTypeHintProvider.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/typehint/PropertyTypeHintProvider.kt
@@ -1,10 +1,7 @@
 package godot.entrygenerator.generator.typehint
 
 import com.squareup.kotlinpoet.ClassName
-import godot.entrygenerator.ext.hasAnnotation
-import godot.entrygenerator.ext.isCompatibleList
-import godot.entrygenerator.ext.isCoreType
-import godot.entrygenerator.ext.isReference
+import godot.entrygenerator.ext.*
 import godot.entrygenerator.generator.typehint.array.JvmArrayTypeHintGenerator
 import godot.entrygenerator.generator.typehint.coretypes.JvmCoreTypeTypeHintGenerator
 import godot.entrygenerator.generator.typehint.primitives.JvmPrimitivesTypeHintGenerator
@@ -65,6 +62,11 @@ object PropertyTypeHintProvider {
             registeredProperty.type.fqName.matches(Regex("^kotlin\\.collections\\..*Set\$")) -> ClassName(
                 "$godotCorePackage.${GodotTypes.propertyHint}",
                 "RESOURCE_TYPE"
+            )
+
+            registeredProperty.type.isNodeType() -> ClassName(
+                "$godotCorePackage.${GodotTypes.propertyHint}",
+                "NODE_TYPE"
             )
 
             else -> ClassName("$godotCorePackage.${GodotTypes.propertyHint}", "NONE")


### PR DESCRIPTION
**Note:** depends on https://github.com/utopia-rise/godot-kotlin-jvm/pull/439. I will change the base of this PR once that one is merged

Resolves: #221 

This adds support for exporting properties with types extending `Node`.

With this a user can directly write
```kotlin
@Export
@RegisterProperty
lateinit var button: Button
```

instead of something like this:
```kotlin
@Export
@RegisterProperty
lateinit var buttonNodePath: NodePath
private val button by lazy { requireNotNull(getNodeAs<Button>(buttonNodePath)) }
```

**Note:** the api checks need to be updated. This will be done together with all other changes in the IDE plugin with #446 