### PR TITLE
Fix reloading

### DIFF
--- a/src/kotlin_script_cache.cpp
+++ b/src/kotlin_script_cache.cpp
@@ -1,0 +1,41 @@
+#ifdef TOOLS_ENABLED
+
+#include "kotlin_script_cache.h"
+
+KotlinScriptCache& KotlinScriptCache::get_instance() {
+    static KotlinScriptCache instance;
+    return instance;
+}
+
+Ref<KotlinScript> KotlinScriptCache::get_or_create_script(const String &p_path) {
+    MutexLock lock(KotlinScriptCache::get_instance().mutex);
+
+    Ref<KotlinScript> ref;
+
+    if (KotlinScriptCache::get_instance().script_cache.has(p_path)) {
+        ref = KotlinScriptCache::get_instance().script_cache[p_path];
+    } else {
+        Ref<KotlinScript> ref_new {memnew(KotlinScript) };
+        KotlinScriptCache::get_instance().script_cache[p_path] = ref_new;
+        ref = ref_new;
+    }
+
+    return ref;
+}
+
+void KotlinScriptCache::invalidate() {
+    MutexLock lock(KotlinScriptCache::get_instance().mutex);
+    KotlinScriptCache::get_instance().script_cache.clear();
+}
+
+const Vector<Ref<KotlinScript>> KotlinScriptCache::get_cached_scripts() {
+    MutexLock lock(KotlinScriptCache::get_instance().mutex);
+
+    Vector<Ref<KotlinScript>> ret;
+    for (const KeyValue<String, Ref<KotlinScript>>& E : KotlinScriptCache::get_instance().script_cache) {
+        ret.append(E.value);
+    }
+    return ret;
+}
+
+#endif

--- a/src/kotlin_script_cache.h
+++ b/src/kotlin_script_cache.h
@@ -1,0 +1,33 @@
+#ifndef GODOT_KOTLIN_SCRIPT_CACHE_H
+#define GODOT_KOTLIN_SCRIPT_CACHE_H
+
+#include <core/string/ustring.h>
+#include "kotlin_script.h"
+
+#ifdef TOOLS_ENABLED
+
+class KotlinScriptCache {
+private:
+    KotlinScriptCache() = default;
+
+    ~KotlinScriptCache() = default;
+
+    HashMap<String, Ref<KotlinScript>> script_cache;
+
+    Mutex mutex;
+
+public:
+    KotlinScriptCache(const KotlinScriptCache&) = delete;
+
+    static KotlinScriptCache& get_instance();
+
+    KotlinScriptCache& operator=(const KotlinScriptCache&) = delete;
+
+    static Ref<KotlinScript> get_or_create_script(const String &p_path);
+    static void invalidate();
+    static const Vector<Ref<KotlinScript>> get_cached_scripts();
+};
+
+#endif
+
+#endif //GODOT_KOTLIN_SCRIPT_CACHE_H

--- a/src/kt_resource_format_loader.cpp
+++ b/src/kt_resource_format_loader.cpp
@@ -3,6 +3,7 @@
 #include "kotlin_language.h"
 #include "kotlin_script.h"
 #include "logging.h"
+#include "kotlin_script_cache.h"
 
 Error kt_read_all_file_utf8(const String& p_path, String& r_content) {
     Vector<uint8_t> sourcef;
@@ -25,7 +26,13 @@ Error kt_read_all_file_utf8(const String& p_path, String& r_content) {
 }
 
 Ref<Resource> KtResourceFormatLoader::load(const String& p_path, const String& p_original_path, Error* r_error, bool p_use_sub_threads, float* r_progress, CacheMode p_cache_mode) {
-    Ref<KotlinScript> ref {memnew(KotlinScript)};
+#ifdef TOOLS_ENABLED
+    // TODO: check if we need to take CacheMode into account like GDScript does
+    Ref<KotlinScript> ref = KotlinScriptCache::get_or_create_script(p_path);
+#else
+    Ref<KotlinScript> ref { memnew(KotlinScript) };
+#endif
+
     ref->set_path(p_original_path, true);
     ref->reload(false);
 

--- a/src/kt_resource_format_loader.h
+++ b/src/kt_resource_format_loader.h
@@ -1,8 +1,12 @@
 #ifndef GODOT_JVM_KT_RESOURCE_LOADER_H
 #define GODOT_JVM_KT_RESOURCE_LOADER_H
 #include <core/io/resource_loader.h>
+#include "kotlin_script.h"
 
 class KtResourceFormatLoader : public ResourceFormatLoader {
+private:
+    HashMap<String, Ref<KotlinScript>> cache;
+
 public:
     KtResourceFormatLoader() = default;
     ~KtResourceFormatLoader() = default;


### PR DESCRIPTION
This fixes multiple bugs with class reloading in the godot editor:

# Fixed Issues
## Reloading of code changes or new classes
We had one issue which was already present in our 3.x releases:
If a scripts resource file was reloaded before our the registration process finished, the editor would not update the displayed value until the scene was closed and reopened (and sometimes not even then).
This case could happen if the user either edited the script from within the godot editor rather than IDEA or returned to the godot editor before the build was done. Or even without building and then building from within the godot editor.
In these cases the resource file was loaded and the exports updated before the changes were registered in the engine. Leading to outdated data be displayed.

This is fixed by manually updating the exports after we're  finished with the registration process.
This fix requires the second fix listed below as we need the loaded `KotlinScript` instances to update them.

This fix could be back ported to the 3.x releases if we so desire

## Fix 4.0 scene corruption issue
With our current 4.0 adaptation branch we have the following issue: when the user edits a script and builds while said script is open in the godot editor (either via scene or in the script editor), the script instance would change upon reloading in the editor. This leads to the current script being marked as "not saved" and the new script treated as separate script. So we now have two different scripts in memory. When the user now saves the old (marked as "not saved") script, godot treats it as a scene local script as the former resource path was taken over by the new script.
As that's not possible, godot corrupts the scene file, by marking the the referenced script as scene local and deleting the resource path:
![2023-03-09-163525_2560x1414_scrot](https://user-images.githubusercontent.com/22662033/224120505-9f19c3d0-51b1-4fca-9502-9ca5356a6880.png)

This is fixed by introducing a `KotlinScriptCache` like GDScript does. This cache keeps all loaded `KotlinScript` references and only updates them rather than replacing them.
