### PR TITLE
Fix reflection usage in usercode

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -97,6 +97,9 @@ jobs:
               libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip
       - name: Setup Godot dependencies
         uses: ./.github/actions/godot-deps
+      - name: Fix scons version
+        run: |
+          python -m pip install scons==4.4.0
       # Upload cache on completion and check it out now
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -59,6 +59,9 @@ jobs:
               libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip
       - name: Setup Godot dependencies
         uses: ./.github/actions/godot-deps
+      - name: Fix scons version
+        run: |
+          python -m pip install scons==4.4.0
       # Upload cache on completion and check it out now
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -84,6 +84,9 @@ jobs:
               libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip
       - name: Setup Godot dependencies
         uses: ./.github/actions/godot-deps
+      - name: Fix scons version
+        run: |
+          python -m pip install scons==4.4.0
       # Upload cache on completion and check it out now
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -83,6 +83,9 @@ jobs:
               libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip
       - name: Setup Godot dependencies
         uses: ./.github/actions/godot-deps
+      - name: Fix scons version
+        run: |
+          python -m pip install scons==4.4.0
       # Upload cache on completion and check it out now
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/.github/workflows/deploy-export-template.yaml
+++ b/.github/workflows/deploy-export-template.yaml
@@ -191,6 +191,10 @@ jobs:
       - name: Setup Godot dependencies
         uses: ./.github/actions/godot-deps
 
+      - name: Fix scons version
+        run: |
+          python -m pip install scons==4.4.0
+
       # Upload cache on completion and check it out now
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -106,6 +106,10 @@ jobs:
       - name: Setup Godot dependencies
         uses: ./.github/actions/godot-deps
 
+      - name: Fix scons version
+        run: |
+          python -m pip install scons==4.4.0
+
       # Upload cache on completion and check it out now
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/harness/tests/build.gradle.kts
+++ b/harness/tests/build.gradle.kts
@@ -16,7 +16,17 @@ godot {
 
     //uncomment to test graal vm native image
 //    isGraalNativeImageExportEnabled.set(true)
-//    nativeImageToolPath.set(File("${System.getenv("GRAALVM_HOME")}/bin/native-image"))
+//    nativeImageToolPath.set(File("${System.getenv("JAVA_HOME")}/bin/native-image"))
+//    additionalGraalResourceConfigurationFiles.set(
+//        arrayOf(
+//            projectDir.resolve("graal").resolve("resource-config.json").absolutePath,
+//        )
+//    )
+//    additionalGraalReflectionConfigurationFiles.set(
+//        arrayOf(
+//            projectDir.resolve("graal").resolve("reflect-config.json").absolutePath,
+//        )
+//    )
 //    windowsDeveloperVCVarsPath.set(System.getenv("VC_VARS_PATH"))
 }
 

--- a/harness/tests/export_presets.cfg
+++ b/harness/tests/export_presets.cfg
@@ -320,3 +320,28 @@ notarization/apple_team_id=""
 texture_format/s3tc=true
 texture_format/etc=false
 texture_format/etc2=false
+
+[preset.3]
+
+name="Linux/X11"
+platform="Linux/X11"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter="*.txt, *.cfg"
+exclude_filter=""
+export_path="./Godot Kotlin Tests.x86_64"
+script_export_mode=0
+script_encryption_key=""
+
+[preset.3.options]
+
+custom_template/debug="../../../../bin/godot.x11.opt.debug.64"
+custom_template/release=""
+binary_format/64_bits=true
+binary_format/embed_pck=false
+texture_format/bptc=false
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+texture_format/no_bptc_fallbacks=true

--- a/harness/tests/graal/reflect-config.json
+++ b/harness/tests/graal/reflect-config.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "kotlin.reflect.jvm.internal.ReflectionFactoryImpl",
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "kotlin.KotlinVersion",
+    "allPublicMethods": true,
+    "allDeclaredFields":true,
+    "allDeclaredMethods":true,
+    "allDeclaredConstructors":true
+  },
+  {
+    "name": "kotlin.KotlinVersion[]"
+  },
+  {
+    "name": "kotlin.KotlinVersion$Companion"
+  },
+  {
+    "name": "kotlin.KotlinVersion$Companion[]"
+  }
+]

--- a/harness/tests/graal/resource-config.json
+++ b/harness/tests/graal/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources":[
+    {"pattern":"META-INF/.*.kotlin_module$"},
+    {"pattern":"META-INF/services/.*"},
+    {"pattern":".*.kotlin_builtins"}
+  ]
+}

--- a/harness/tests/src/main/kotlin/godot/tests/reflection/BaseReflectionTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/reflection/BaseReflectionTest.kt
@@ -1,0 +1,15 @@
+package godot.tests.reflection
+
+import godot.Node
+import godot.annotation.RegisterClass
+import godot.annotation.RegisterFunction
+import kotlin.reflect.full.hasAnnotation
+
+@RegisterClass
+class BaseReflectionTest: Node() {
+
+    @RegisterFunction
+    fun hasRegisterClassAnnotation(): Boolean {
+        return BaseReflectionTest::class.hasAnnotation<RegisterClass>()
+    }
+}

--- a/harness/tests/test/unit/test_reflection.gd
+++ b/harness/tests/test/unit/test_reflection.gd
@@ -1,0 +1,7 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_reflection_working() -> void:
+	var reflection_test_script = load("res://src/main/kotlin/godot/tests/reflection/BaseReflectionTest.kt").new()
+	assert_true(reflection_test_script.has_register_class_annotation(), "Should return true without throwing an exception")
+	reflection_test_script.free()

--- a/kt/godot-library/build.gradle.kts
+++ b/kt/godot-library/build.gradle.kts
@@ -13,6 +13,12 @@ apiGenerator {
     docsDir.set(project.file("$projectDir/../../../../doc/classes"))
 }
 
+dependencies {
+    // added here as a transitive dependency so the user can use reflection
+    // we need to add it here so reflection is available where the code is loaded (Bootstrap.kt) otherwise it will not work
+    api(kotlin("reflect"))
+}
+
 tasks {
     compileKotlin {
         dependsOn(generateAPI)

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
@@ -56,11 +56,18 @@ open class GodotExtension(objects: ObjectFactory) {
     val windowsDeveloperVCVarsPath = objects.property(String::class.java)
 
     /**
-     * Additional Graal JNI/reflection configurations.
+     * Additional Graal JNI configurations.
      *
      * example: arrayOf("my-jni-configuration-file.json", "another-conf.json")
      */
     val additionalGraalJniConfigurationFiles = objects.property(Array<String>::class.java)
+
+    /**
+     * Additional Graal reflection configurations.
+     *
+     * example: arrayOf("my-reflection-configuration-file.json", "another-conf.json")
+     */
+    val additionalGraalReflectionConfigurationFiles = objects.property(Array<String>::class.java)
 
     /**
      * enable verbose mode on native image generation.
@@ -100,6 +107,7 @@ open class GodotExtension(objects: ObjectFactory) {
         isGraalNativeImageExportEnabled.set(false)
         nativeImageToolPath.set(System.getenv("native-image")?.let { File(it) })
         additionalGraalJniConfigurationFiles.set(arrayOf())
+        additionalGraalReflectionConfigurationFiles.set(arrayOf())
         isGraalVmNativeImageGenerationVerbose.set(false)
         windowsDeveloperVCVarsPath.set("\"%VC_VARS_PATH%\"")
     }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
@@ -70,6 +70,13 @@ open class GodotExtension(objects: ObjectFactory) {
     val additionalGraalReflectionConfigurationFiles = objects.property(Array<String>::class.java)
 
     /**
+     * Additional Graal resource configurations.
+     *
+     * example: arrayOf("my-resource-configuration-file.json", "another-conf.json")
+     */
+    val additionalGraalResourceConfigurationFiles = objects.property(Array<String>::class.java)
+
+    /**
      * enable verbose mode on native image generation.
      *
      * if set to true, native-image tool will be in verbose mode.
@@ -108,6 +115,7 @@ open class GodotExtension(objects: ObjectFactory) {
         nativeImageToolPath.set(System.getenv("native-image")?.let { File(it) })
         additionalGraalJniConfigurationFiles.set(arrayOf())
         additionalGraalReflectionConfigurationFiles.set(arrayOf())
+        additionalGraalResourceConfigurationFiles.set(arrayOf())
         isGraalVmNativeImageGenerationVerbose.set(false)
         windowsDeveloperVCVarsPath.set("\"%VC_VARS_PATH%\"")
     }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/graal/createGraalNativeImage.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/graal/createGraalNativeImage.kt
@@ -60,6 +60,13 @@ fun Project.createGraalNativeImageTask(
 
                 val reflectionConfigurationFilesArgument = "-H:ReflectionConfigurationFiles=$reflectionConfigurationFilesString"
 
+                val resourceConfigurationFilesString = godotJvmExtension
+                    .additionalGraalResourceConfigurationFiles
+                    .getOrElse(arrayOf())
+                    .joinToString(",")
+
+                val resourceConfigurationFilesArgument = "-H:ResourceConfigurationFiles=$resourceConfigurationFilesString"
+
                 val verboseArgument = if (godotJvmExtension.isGraalVmNativeImageGenerationVerbose.get()) {
                     "--verbose"
                 } else {
@@ -84,6 +91,7 @@ fun Project.createGraalNativeImageTask(
                         "-H:Name=usercode",
                         jniConfigurationFilesArgument,
                         reflectionConfigurationFilesArgument,
+                        resourceConfigurationFilesArgument,
                         "-H:IncludeResources=${
                             resourcesDir.absolutePath.replace(
                                 '\\',
@@ -104,6 +112,7 @@ fun Project.createGraalNativeImageTask(
                         "-H:Name=usercode",
                         jniConfigurationFilesArgument,
                         reflectionConfigurationFilesArgument,
+                        resourceConfigurationFilesArgument,
                         "-H:IncludeResources=${resourcesDir.absolutePath}/main/META-INF/services/*.*",
                         "--no-fallback",
                         verboseArgument,

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/graal/createGraalNativeImage.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/graal/createGraalNativeImage.kt
@@ -53,6 +53,13 @@ fun Project.createGraalNativeImageTask(
                     graalDirectory.resolve("godot-kotlin-graal-jni-config.json").absolutePath +
                     additionalJoinedJniConfiguration
 
+                val reflectionConfigurationFilesString = godotJvmExtension
+                    .additionalGraalReflectionConfigurationFiles
+                    .getOrElse(arrayOf())
+                    .joinToString(",")
+
+                val reflectionConfigurationFilesArgument = "-H:ReflectionConfigurationFiles=$reflectionConfigurationFilesString"
+
                 val verboseArgument = if (godotJvmExtension.isGraalVmNativeImageGenerationVerbose.get()) {
                     "--verbose"
                 } else {
@@ -76,6 +83,7 @@ fun Project.createGraalNativeImageTask(
                         "--shared",
                         "-H:Name=usercode",
                         jniConfigurationFilesArgument,
+                        reflectionConfigurationFilesArgument,
                         "-H:IncludeResources=${
                             resourcesDir.absolutePath.replace(
                                 '\\',
@@ -95,6 +103,7 @@ fun Project.createGraalNativeImageTask(
                         "--shared",
                         "-H:Name=usercode",
                         jniConfigurationFilesArgument,
+                        reflectionConfigurationFilesArgument,
                         "-H:IncludeResources=${resourcesDir.absolutePath}/main/META-INF/services/*.*",
                         "--no-fallback",
                         verboseArgument,


### PR DESCRIPTION
Resolves #201 

This adds the kotlin reflect library as a transitive dependency to the `godot-library` and thus to the `bootstrap.jar`.
This enables reflection usage in usercode.

It needs to be added to the `godot-library` as the reflection library must be present where the usercode is loaded (`Bootstrap.kt`) in order to work.

Downside is a slight increase in size of the shipped ` bootstrap.jar`  but with around 2MB it's negligible enough IMO.

We could introduce a setting in our gradle plugin which strips the reflection library classes from the final `bootstrap.jar` for exported games but TBH I don't think it's worth the effort and should be "fixed" with #443 anyways.