### PR TITLE
Fix idea plugin

### DIFF
--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/module/GodotModuleBuilder.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/module/GodotModuleBuilder.kt
@@ -90,7 +90,7 @@ class GodotModuleBuilder : ModuleBuilder(), ModuleBuilderListener {
                                     .columns(COLUMNS_MEDIUM)
                                     .applyToComponent {
                                         text = "0.0.1-SNAPSHOT"
-                                        artifactIdTextField = this
+                                        versionTextField = this
                                     }
                             }
                         }


### PR DESCRIPTION
This fixes an uninitialized property access exception which occurred when trying to create a new GodotJvm project from the idea project wizard.

Fixes #464