### PR TITLE
[3.x] Bump version to `0.6.2`

### DIFF
--- a/docs/src/doc/user-guide/versioning.md
+++ b/docs/src/doc/user-guide/versioning.md
@@ -1,7 +1,7 @@
 The module uses semantic versioning for its own versions but adds a suffix for the supported godot version:
 
-Full version: `0.6.1-3.5.2`
+Full version: `0.6.2-3.5.2`
 
-Module Version: `0.6.1`
+Module Version: `0.6.2`
 
 Supported Godot Version: `3.5.2`

--- a/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
+++ b/kt/buildSrc/src/main/kotlin/godotKotlinJvmVersion.kt
@@ -1,1 +1,1 @@
-const val godotKotlinJvmVersion = "0.6.1"
+const val godotKotlinJvmVersion = "0.6.2"

--- a/kt/plugins/godot-intellij-plugin/src/main/resources/template/gradle-wrapper.properties.template
+++ b/kt/plugins/godot-intellij-plugin/src/main/resources/template/gradle-wrapper.properties.template
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This bumps the version on the 3.x branch to `0.6.2` to prepare for another release.

This also sneaks in a little fix for the generated project from the IDE wizard where the gradle version of the gradle wrapper was too old. This just bumps it to the min version in the template.