### PR TITLE
Feature/use kotlin preprocessors plugin

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -14,10 +14,16 @@ jobs:
   build-godot-bootstrap:
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        name: [ Debug, Release ]
         include:
-          - os: ubuntu-latest
+          - name: Debug
+            os: ubuntu-latest
             java-version: 11
+            target: debug
+          - name: Release
+            os: ubuntu-latest
+            java-version: 11
+            target: release
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone Godot Engine
@@ -38,11 +44,11 @@ jobs:
         with:
           wrapper-directory: modules/kotlin_jvm/kt/
           build-root-directory: modules/kotlin_jvm/kt/
-          arguments: godot-library:build
+          arguments: godot-library:build -P${{ matrix.target }}
       - name: Upload godot-bootstrap jar
         uses: actions/upload-artifact@v3
         with:
-          name: godot-bootstrap
+          name: godot-bootstrap-${{ matrix.target }}
           path: modules/kotlin_jvm/kt/godot-library/build/libs/godot-bootstrap.jar
   build-editor-debug:
     strategy:
@@ -138,10 +144,16 @@ jobs:
     needs: [create-macos-universal, build-godot-bootstrap]
     strategy:
       matrix:
-        os: [macos-latest]
+        name: [ Debug, Release ]
         include:
-          - os: macos-latest
+          - name: Debug
+            os: macos-latest
             java-version: 11
+            target: debug
+          - name: Release
+            os: macos-latest
+            java-version: 11
+            target: release
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone Godot Engine
@@ -163,7 +175,7 @@ jobs:
         with:
           wrapper-directory: modules/kotlin_jvm/harness/tests/
           build-root-directory: modules/kotlin_jvm/harness/tests/
-          arguments: build
+          arguments: build -P${{ matrix.target }}
       - name: Download MacOs Editor Debug App
         uses: actions/download-artifact@v1
         with:
@@ -171,10 +183,10 @@ jobs:
       - name: Download godot-bootstrap
         uses: actions/download-artifact@v1
         with:
-          name: godot-bootstrap
+          name: godot-bootstrap-${{ matrix.target }}
       - name: Run Tests
         run: |
-          cp godot-bootstrap/godot-bootstrap.jar macos-editor-debug-app/
+          cp godot-bootstrap-${{ matrix.target }}/godot-bootstrap.jar macos-editor-debug-app/
           cd modules/kotlin_jvm/harness/tests/
           chmod +x run_godot_kotlin_tests.sh
           chmod +x ../../../../macos-editor-debug-app/godot.macos.editor.universal

--- a/.github/workflows/check-pr-jvm-godot-library.yaml
+++ b/.github/workflows/check-pr-jvm-godot-library.yaml
@@ -5,10 +5,16 @@ jobs:
   build-godot-library:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        name: [Debug, Release]
         include:
-          - os: ubuntu-latest
+          - name: Debug
+            os: ubuntu-latest
             java-version: 11
+            target: debug
+          - name: Release
+            os: ubuntu-latest
+            java-version: 11
+            target: release
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone Godot Engine
@@ -29,7 +35,7 @@ jobs:
         with:
           wrapper-directory: modules/kotlin_jvm/kt/
           build-root-directory: modules/kotlin_jvm/kt/
-          arguments: godot-library:build
+          arguments: godot-library:build -P${{ matrix.target }}
         env:
           GODOT_KOTLIN_GPG_PRIVATE_KEY_ASCII: ${{ secrets.GODOT_KOTLIN_GPG_PRIVATE_KEY_ASCII }}
           GODOT_KOTLIN_GPG_KEY_PASSPHRASE: ${{ secrets.GODOT_KOTLIN_GPG_KEY_PASSPHRASE }}

--- a/.github/workflows/deploy-godot-library.yaml
+++ b/.github/workflows/deploy-godot-library.yaml
@@ -8,7 +8,19 @@ on:
 
 jobs:
   deploy_godot_library:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        name: [ Debug, Release ]
+        include:
+          - name: Debug
+            os: ubuntu-latest
+            java-version: 11
+            target: debug
+          - name: Release
+            os: ubuntu-latest
+            java-version: 11
+            target: release
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Get godot version from tag
         id: get_godot_version
@@ -23,15 +35,15 @@ jobs:
         with:
           path: modules/kotlin_jvm
           submodules: recursive
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          java-version: ${{ matrix.java-version }}
       - uses: eskatos/gradle-command-action@v1
         with:
           wrapper-directory: modules/kotlin_jvm/kt/
           build-root-directory: modules/kotlin_jvm/kt/
-          arguments: godot-library:publish
+          arguments: godot-library:publish -P${{ matrix.target }}
         env:
           GODOT_KOTLIN_GPG_PRIVATE_KEY_ASCII: ${{ secrets.GODOT_KOTLIN_GPG_PRIVATE_KEY_ASCII }}
           GODOT_KOTLIN_GPG_KEY_PASSPHRASE: ${{ secrets.GODOT_KOTLIN_GPG_KEY_PASSPHRASE }}

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
   - User guide:
     - API differences: user-guide/api-differences.md
     - Classes: user-guide/classes.md
+    - Compiling your project: user-guide/compiling-your-project.md
     - Properties: user-guide/properties.md
     - Signals: user-guide/signals.md
     - Functions: user-guide/functions.md

--- a/docs/src/doc/user-guide/compiling-your-project.md
+++ b/docs/src/doc/user-guide/compiling-your-project.md
@@ -1,5 +1,5 @@
 To compile your project, run a classic *gradle build*. By default this creates a `debug` version of your code.
-Ex:
+Ex:  
 ```
 ./gradlew build
 ```
@@ -8,10 +8,20 @@ Ex:
 
 We have two targets: `debug` and `release`.  
 In order to build in release, you should add `release` parameter to your gradle build command.  
-Ex:
+Ex:  
 ```
 ./gradlew build -Prelease
 ```
 
 Using debug builds is recommended when developing. It adds some sanity checks that are cut off in `release`.  
 Release builds are recommended when retail.
+
+## Write debug code
+
+You can add code only for debug version of your project, by using `GodotJvmDefinitions`.  
+Ex:  
+```kotlin
+if (GodotJvmDefinitions.DEBUG) {
+    ...
+}
+```

--- a/docs/src/doc/user-guide/compiling-your-project.md
+++ b/docs/src/doc/user-guide/compiling-your-project.md
@@ -1,0 +1,17 @@
+To compile your project, run a classic *gradle build*. By default this creates a `debug` version of your code.
+Ex:
+```
+./gradlew build
+```
+
+## TARGETS
+
+We have two targets: `debug` and `release`.  
+In order to build in release, you should add `release` parameter to your gradle build command.  
+Ex:
+```
+./gradlew build -Prelease
+```
+
+Using debug builds is recommended when developing. It adds some sanity checks that are cut off in `release`.  
+Release builds are recommended when retail.

--- a/harness/tests/settings.gradle.kts
+++ b/harness/tests/settings.gradle.kts
@@ -8,7 +8,8 @@ includeBuild("../../kt/api-generator") {
 includeBuild("../../kt") {
     dependencySubstitution {
         substitute(module("com.utopia-rise:godot-gradle-plugin")).using(project(":godot-gradle-plugin"))
-        substitute(module("com.utopia-rise:godot-library")).using(project(":godot-library"))
+        substitute(module("com.utopia-rise:godot-library-debug")).using(project(":godot-library"))
+        substitute(module("com.utopia-rise:godot-library-release")).using(project(":godot-library"))
         substitute(module("com.utopia-rise:godot-kotlin-symbol-processor")).using(project(":godot-kotlin-symbol-processor"))
         substitute(module("com.utopia-rise:godot-entry-generator")).using(project(":godot-entry-generator"))
     }

--- a/kt/build-logic/convention/src/main/kotlin/publish/PublishToMavenCentralPlugin.kt
+++ b/kt/build-logic/convention/src/main/kotlin/publish/PublishToMavenCentralPlugin.kt
@@ -66,7 +66,8 @@ class PublishToMavenCentralPlugin : Plugin<Project> {
                     publicationContainer.all { publication ->
                         if (publication is MavenPublication) {
                             publication.groupId = "com.utopia-rise"
-                            publication.artifactId = project.name
+                            val artifactId = publication.artifactId
+                            publication.artifactId = if (artifactId.isNullOrEmpty()) project.name else artifactId
                             publication.version = project.version as String
 
                             publication.pom { mavenPom ->

--- a/kt/godot-library/build.gradle.kts
+++ b/kt/godot-library/build.gradle.kts
@@ -7,10 +7,7 @@ plugins {
     id("com.utopia-rise.godot-publish")
     id("com.utopia-rise.versioninfo")
     alias(libs.plugins.shadowJar)
-    id("com.utopia-rise.godot-dependencies")
-    id("com.github.johnrengelman.shadow")
-
-    id("com.utopia-rise.kotlin-preprocessors") version "0.1.4"
+    alias(libs.plugins.kotlinPreProcessors)
 }
 
 val isRelease = project.hasProperty("release")
@@ -81,15 +78,17 @@ tasks {
     }
 }
 
+val targetSuffix = if (isRelease) "release" else "debug"
+
 publishing {
     publications {
         @Suppress("UNUSED_VARIABLE")
         val godotLibraryPublication by creating(MavenPublication::class) {
             pom {
-                name.set(project.name)
+                name.set("${project.name}-$targetSuffix")
                 description.set("Contains godot api as kotlin classes and jvm cpp interaction code.")
             }
-            artifactId = "godot-library"
+            artifactId = "godot-library-$targetSuffix"
             description = "Contains godot api as kotlin classes and jvm cpp interaction code."
             artifact(tasks.jar)
             artifact(tasks.getByName("sourcesJar"))

--- a/kt/godot-library/build.gradle.kts
+++ b/kt/godot-library/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 val isRelease = project.hasProperty("release")
 
 kotlinDefinitions {
-    definitionsObjectPrefix.set("GodotJvm")
+    definitionsObjectName.set("GodotJvmBuildConfig")
 
     define("DEBUG", !isRelease)
 }

--- a/kt/godot-library/build.gradle.kts
+++ b/kt/godot-library/build.gradle.kts
@@ -7,6 +7,18 @@ plugins {
     id("com.utopia-rise.godot-publish")
     id("com.utopia-rise.versioninfo")
     alias(libs.plugins.shadowJar)
+    id("com.utopia-rise.godot-dependencies")
+    id("com.github.johnrengelman.shadow")
+
+    id("com.utopia-rise.kotlin-preprocessors") version "0.1.4"
+}
+
+val isRelease = project.hasProperty("release")
+
+kotlinDefinitions {
+    definitionsObjectPrefix.set("GodotJvm")
+
+    define("DEBUG", !isRelease)
 }
 
 apiGenerator {

--- a/kt/godot-library/src/main/kotlin/godot/core/AABB.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/AABB.kt
@@ -4,6 +4,7 @@ import godot.annotation.CoreTypeLocalCopy
 import godot.annotation.CoreTypeHelper
 import godot.util.CMP_EPSILON
 import godot.util.RealT
+import kotlincompile.definitions.GodotJvmDefinitions
 import kotlin.math.min
 
 
@@ -425,8 +426,10 @@ class AABB(
      * Returns `true` if the given ray intersects with this [AABB]. Ray length is infinite.
      */
     fun intersectsRay(from: Vector3, dir: Vector3): Boolean {
-        require(size.x >= 0 && size.y >= 0 && size.z >= 0) {
-            "AABB size is negative, this is not supported. Use AABB.abs() to get an AABB with a positive size."
+        if (GodotJvmDefinitions.DEBUG) {
+            require(size.x >= 0 && size.y >= 0 && size.z >= 0) {
+                "AABB size is negative, this is not supported. Use AABB.abs() to get an AABB with a positive size."
+            }
         }
 
         var c1 = Vector3()

--- a/kt/godot-library/src/main/kotlin/godot/core/AABB.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/AABB.kt
@@ -4,7 +4,7 @@ import godot.annotation.CoreTypeLocalCopy
 import godot.annotation.CoreTypeHelper
 import godot.util.CMP_EPSILON
 import godot.util.RealT
-import kotlincompile.definitions.GodotJvmDefinitions
+import kotlincompile.definitions.GodotJvmBuildConfig
 import kotlin.math.min
 
 
@@ -426,7 +426,7 @@ class AABB(
      * Returns `true` if the given ray intersects with this [AABB]. Ray length is infinite.
      */
     fun intersectsRay(from: Vector3, dir: Vector3): Boolean {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(size.x >= 0 && size.y >= 0 && size.z >= 0) {
                 "AABB size is negative, this is not supported. Use AABB.abs() to get an AABB with a positive size."
             }

--- a/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
@@ -7,6 +7,7 @@ import godot.util.CMP_EPSILON
 import godot.util.RealT
 import godot.util.isEqualApprox
 import godot.util.toRealT
+import kotlincompile.definitions.GodotJvmDefinitions
 import kotlin.math.*
 
 class Basis() : CoreType {
@@ -85,11 +86,13 @@ class Basis() : CoreType {
          * If [useModelFront] is true, the +Z axis (asset front) is treated as forward (implies +X is left) and points toward the [target] position. By default, the -Z axis (camera forward) is treated as forward (implies +X is right).
          */
         fun lookingAt(target: Vector3, up: Vector3 = Vector3(0, 1, 0), useModelFront: Boolean = false): Basis {
-            require(!target.isZeroApprox()) {
-                "The target vector can't be zero."
-            }
-            require(!up.isZeroApprox()) {
-                "The up vector can't be zero."
+            if (GodotJvmDefinitions.DEBUG) {
+                require(!target.isZeroApprox()) {
+                    "The target vector can't be zero."
+                }
+                require(!up.isZeroApprox()) {
+                    "The up vector can't be zero."
+                }
             }
             val vZ: Vector3 = if (!useModelFront) {
                 -target.normalized()
@@ -98,8 +101,10 @@ class Basis() : CoreType {
             }
             val vX: Vector3 = up.cross(vZ)
 
-            require(!vX.isZeroApprox()) {
-                "The target vector and up vector can't be parallel to each other."
+            if (GodotJvmDefinitions.DEBUG) {
+                require(!vX.isZeroApprox()) {
+                    "The target vector and up vector can't be parallel to each other."
+                }
             }
 
             vX.normalize()
@@ -535,8 +540,9 @@ class Basis() : CoreType {
 
         val det: RealT = this._x.x * co1 + this._x.y * co2 + this._x.z * co3
 
-
-        require(!isEqualApprox(det, 0.0)) { "Determinant is zero!" }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(!isEqualApprox(det, 0.0)) { "Determinant is zero!" }
+        }
 
         val s = 1.0 / det
         set(
@@ -547,7 +553,9 @@ class Basis() : CoreType {
     }
 
     fun getQuaternion(): Quaternion {
-        require(isRotation()) { "Basis must be normalized in order to be casted to a Quaternion. Use get_rotation_quat() or call orthonormalized() instead." }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(isRotation()) { "Basis must be normalized in order to be casted to a Quaternion. Use get_rotation_quat() or call orthonormalized() instead." }
+        }
         val trace = this._x.x + this._y.y + this._z.z
         val temp: Array<RealT>
 
@@ -618,7 +626,9 @@ class Basis() : CoreType {
     }
 
     internal fun orthonormalize() {
-        require(!isEqualApprox(determinant(), 0.0)) { "Determinant is zero!" }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(!isEqualApprox(determinant(), 0.0)) { "Determinant is zero!" }
+        }
 
         val x = getColumn(0)
         var y = getColumn(1)
@@ -721,7 +731,9 @@ class Basis() : CoreType {
      *
      */
     fun setOrthogonalIndex(index: Int) {
-        require(index < 24) { "Index must be less than 24!" }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(index < 24) { "Index must be less than 24!" }
+        }
         val ret = orthoBases[index]
         this._x = ret._x
         this._y = ret._y
@@ -732,7 +744,9 @@ class Basis() : CoreType {
      * Assuming that the matrix is a proper rotation matrix, slerp performs a spherical-linear interpolation with another rotation matrix.
      */
     fun slerp(b: Basis, t: RealT): Basis {
-        require(isRotation()) { "Basis is not a rotation!" }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(isRotation()) { "Basis is not a rotation!" }
+        }
 
         val from = Quaternion(this)
         val to = Quaternion(b)

--- a/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Basis.kt
@@ -7,7 +7,7 @@ import godot.util.CMP_EPSILON
 import godot.util.RealT
 import godot.util.isEqualApprox
 import godot.util.toRealT
-import kotlincompile.definitions.GodotJvmDefinitions
+import kotlincompile.definitions.GodotJvmBuildConfig
 import kotlin.math.*
 
 class Basis() : CoreType {
@@ -86,7 +86,7 @@ class Basis() : CoreType {
          * If [useModelFront] is true, the +Z axis (asset front) is treated as forward (implies +X is left) and points toward the [target] position. By default, the -Z axis (camera forward) is treated as forward (implies +X is right).
          */
         fun lookingAt(target: Vector3, up: Vector3 = Vector3(0, 1, 0), useModelFront: Boolean = false): Basis {
-            if (GodotJvmDefinitions.DEBUG) {
+            if (GodotJvmBuildConfig.DEBUG) {
                 require(!target.isZeroApprox()) {
                     "The target vector can't be zero."
                 }
@@ -101,7 +101,7 @@ class Basis() : CoreType {
             }
             val vX: Vector3 = up.cross(vZ)
 
-            if (GodotJvmDefinitions.DEBUG) {
+            if (GodotJvmBuildConfig.DEBUG) {
                 require(!vX.isZeroApprox()) {
                     "The target vector and up vector can't be parallel to each other."
                 }
@@ -540,7 +540,7 @@ class Basis() : CoreType {
 
         val det: RealT = this._x.x * co1 + this._x.y * co2 + this._x.z * co3
 
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(!isEqualApprox(det, 0.0)) { "Determinant is zero!" }
         }
 
@@ -553,7 +553,7 @@ class Basis() : CoreType {
     }
 
     fun getQuaternion(): Quaternion {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(isRotation()) { "Basis must be normalized in order to be casted to a Quaternion. Use get_rotation_quat() or call orthonormalized() instead." }
         }
         val trace = this._x.x + this._y.y + this._z.z
@@ -626,7 +626,7 @@ class Basis() : CoreType {
     }
 
     internal fun orthonormalize() {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(!isEqualApprox(determinant(), 0.0)) { "Determinant is zero!" }
         }
 
@@ -731,7 +731,7 @@ class Basis() : CoreType {
      *
      */
     fun setOrthogonalIndex(index: Int) {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(index < 24) { "Index must be less than 24!" }
         }
         val ret = orthoBases[index]
@@ -744,7 +744,7 @@ class Basis() : CoreType {
      * Assuming that the matrix is a proper rotation matrix, slerp performs a spherical-linear interpolation with another rotation matrix.
      */
     fun slerp(b: Basis, t: RealT): Basis {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(isRotation()) { "Basis is not a rotation!" }
         }
 

--- a/kt/godot-library/src/main/kotlin/godot/core/KtObject.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/KtObject.kt
@@ -6,7 +6,7 @@ import godot.core.memory.TransferContext
 import godot.util.VoidPtr
 import godot.util.nullObjectID
 import godot.util.nullptr
-import kotlincompile.definitions.GodotJvmDefinitions
+import kotlincompile.definitions.GodotJvmBuildConfig
 
 @Suppress("LeakingThis")
 abstract class KtObject {
@@ -27,7 +27,7 @@ abstract class KtObject {
 
     var rawPtr: VoidPtr = nullptr
         set(value) {
-            if (GodotJvmDefinitions.DEBUG) {
+            if (GodotJvmBuildConfig.DEBUG) {
                 require(field == nullptr) {
                     "rawPtr should only be set once!"
                 }
@@ -37,7 +37,7 @@ abstract class KtObject {
 
     var id: ObjectID = nullObjectID
         set(value) {
-            if (GodotJvmDefinitions.DEBUG) {
+            if (GodotJvmBuildConfig.DEBUG) {
                 require(field == nullObjectID) {
                     "id should only be set once!"
                 }

--- a/kt/godot-library/src/main/kotlin/godot/core/KtObject.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/KtObject.kt
@@ -6,6 +6,7 @@ import godot.core.memory.TransferContext
 import godot.util.VoidPtr
 import godot.util.nullObjectID
 import godot.util.nullptr
+import kotlincompile.definitions.GodotJvmDefinitions
 
 @Suppress("LeakingThis")
 abstract class KtObject {
@@ -26,16 +27,20 @@ abstract class KtObject {
 
     var rawPtr: VoidPtr = nullptr
         set(value) {
-            require(field == nullptr) {
-                "rawPtr should only be set once!"
+            if (GodotJvmDefinitions.DEBUG) {
+                require(field == nullptr) {
+                    "rawPtr should only be set once!"
+                }
             }
             field = value
         }
 
     var id: ObjectID = nullObjectID
         set(value) {
-            require(field == nullObjectID) {
-                "id should only be set once!"
+            if (GodotJvmDefinitions.DEBUG) {
+                require(field == nullObjectID) {
+                    "id should only be set once!"
+                }
             }
             field = value
         }

--- a/kt/godot-library/src/main/kotlin/godot/core/Quaternion.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Quaternion.kt
@@ -3,7 +3,7 @@ package godot.core
 import godot.EulerOrder
 import godot.util.*
 import kotlin.math.*
-import kotlincompile.definitions.GodotJvmDefinitions
+import kotlincompile.definitions.GodotJvmBuildConfig
 
 
 class Quaternion(
@@ -131,7 +131,7 @@ class Quaternion(
      * Z angle).
      */
     fun getEuler(order: EulerOrder = EulerOrder.EULER_ORDER_YXZ): Vector3 {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(isNormalized()) {
                 "The quaternion must be normalized."
             }
@@ -206,7 +206,7 @@ class Quaternion(
      * Sets the quaternion to a rotation which rotates around axis by the specified angle, in radians. The axis must be a normalized vector.
      */
     fun setAxisAndAngle(axis: Vector3, angle: RealT) {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(axis.isNormalized()) { "Axis must be normalized!" }
         }
 
@@ -295,7 +295,7 @@ class Quaternion(
      * amount [weight].
      */
     fun sphericalCubicInterpolate(b: Quaternion, preA: Quaternion, postB: Quaternion, weight: RealT): Quaternion {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(isNormalized()) {
                 "The start quaternion must be normalized."
             }
@@ -365,7 +365,7 @@ class Quaternion(
         p_pre_a_t: RealT,
         p_post_b_t: RealT
     ): Quaternion {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(isNormalized()) {
                 "The start quaternion must be normalized."
             }
@@ -427,7 +427,7 @@ class Quaternion(
     }
 
     internal fun xform(v: Vector3): Vector3 {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(isNormalized()) {
                 "The quaternion must be normalized."
             }

--- a/kt/godot-library/src/main/kotlin/godot/core/Quaternion.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Quaternion.kt
@@ -427,8 +427,10 @@ class Quaternion(
     }
 
     internal fun xform(v: Vector3): Vector3 {
-        require(isNormalized()) {
-            "The quaternion must be normalized."
+        if (GodotJvmDefinitions.DEBUG) {
+            require(isNormalized()) {
+                "The quaternion must be normalized."
+            }
         }
 
         val u = Vector3(x, y, z)

--- a/kt/godot-library/src/main/kotlin/godot/core/Quaternion.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Quaternion.kt
@@ -3,6 +3,7 @@ package godot.core
 import godot.EulerOrder
 import godot.util.*
 import kotlin.math.*
+import kotlincompile.definitions.GodotJvmDefinitions
 
 
 class Quaternion(
@@ -130,8 +131,10 @@ class Quaternion(
      * Z angle).
      */
     fun getEuler(order: EulerOrder = EulerOrder.EULER_ORDER_YXZ): Vector3 {
-        require(isNormalized()) {
-            "The quaternion must be normalized."
+        if (GodotJvmDefinitions.DEBUG) {
+            require(isNormalized()) {
+                "The quaternion must be normalized."
+            }
         }
         return Basis(this).getEuler(order)
     }
@@ -203,7 +206,9 @@ class Quaternion(
      * Sets the quaternion to a rotation which rotates around axis by the specified angle, in radians. The axis must be a normalized vector.
      */
     fun setAxisAndAngle(axis: Vector3, angle: RealT) {
-        require(axis.isNormalized()) { "Axis must be normalized!" }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(axis.isNormalized()) { "Axis must be normalized!" }
+        }
 
         val d = axis.length()
         if (isEqualApprox(d, 0.0)) {
@@ -290,11 +295,13 @@ class Quaternion(
      * amount [weight].
      */
     fun sphericalCubicInterpolate(b: Quaternion, preA: Quaternion, postB: Quaternion, weight: RealT): Quaternion {
-        require(isNormalized()) {
-            "The start quaternion must be normalized."
-        }
-        require(b.isNormalized()) {
-            "The end quaternion must be normalized."
+        if (GodotJvmDefinitions.DEBUG) {
+            require(isNormalized()) {
+                "The start quaternion must be normalized."
+            }
+            require(b.isNormalized()) {
+                "The end quaternion must be normalized."
+            }
         }
 
         var fromQ = this
@@ -358,11 +365,13 @@ class Quaternion(
         p_pre_a_t: RealT,
         p_post_b_t: RealT
     ): Quaternion {
-        require(isNormalized()) {
-            "The start quaternion must be normalized."
-        }
-        require(p_b.isNormalized()) {
-            "The end quaternion must be normalized."
+        if (GodotJvmDefinitions.DEBUG) {
+            require(isNormalized()) {
+                "The start quaternion must be normalized."
+            }
+            require(p_b.isNormalized()) {
+                "The end quaternion must be normalized."
+            }
         }
 
         var from_q = this

--- a/kt/godot-library/src/main/kotlin/godot/core/Transform2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Transform2D.kt
@@ -5,7 +5,7 @@ import godot.annotation.CoreTypeHelper
 import godot.util.RealT
 import godot.util.isEqualApprox
 import godot.util.toRealT
-import kotlincompile.definitions.GodotJvmDefinitions
+import kotlincompile.definitions.GodotJvmBuildConfig
 import kotlin.math.acos
 import kotlin.math.atan2
 import kotlin.math.cos
@@ -120,7 +120,7 @@ class Transform2D(
      */
     internal fun affineInvert() {
         val det = basisDeterminant()
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(!isEqualApprox(det, 0.0)) { "Determinant is 0!" }
         }
         val idet = -1.0 / det

--- a/kt/godot-library/src/main/kotlin/godot/core/Transform2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Transform2D.kt
@@ -5,6 +5,7 @@ import godot.annotation.CoreTypeHelper
 import godot.util.RealT
 import godot.util.isEqualApprox
 import godot.util.toRealT
+import kotlincompile.definitions.GodotJvmDefinitions
 import kotlin.math.acos
 import kotlin.math.atan2
 import kotlin.math.cos
@@ -119,7 +120,9 @@ class Transform2D(
      */
     internal fun affineInvert() {
         val det = basisDeterminant()
-        require(!isEqualApprox(det, 0.0)) { "Determinant is 0!" }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(!isEqualApprox(det, 0.0)) { "Determinant is 0!" }
+        }
         val idet = -1.0 / det
         val copy = _x.x
         _x.x = _y.y

--- a/kt/godot-library/src/main/kotlin/godot/core/Transform3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Transform3D.kt
@@ -3,6 +3,7 @@ package godot.core
 import godot.annotation.CoreTypeLocalCopy
 import godot.annotation.CoreTypeHelper
 import godot.util.RealT
+import kotlincompile.definitions.GodotJvmDefinitions
 
 class Transform3D(
     p_basis: Basis,
@@ -162,8 +163,10 @@ class Transform3D(
     }
 
     internal fun setLookAt(eye: Vector3, target: Vector3, up: Vector3, useModelFront: Boolean) {
-        require(!eye.isEqualApprox(target)) {
-            "The eye and target vectors can't be equal."
+        if (GodotJvmDefinitions.DEBUG) {
+            require(!eye.isEqualApprox(target)) {
+                "The eye and target vectors can't be equal."
+            }
         }
         _basis = Basis.lookingAt(target - eye, up, useModelFront);
         _origin = Vector3(eye)

--- a/kt/godot-library/src/main/kotlin/godot/core/Transform3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Transform3D.kt
@@ -3,7 +3,7 @@ package godot.core
 import godot.annotation.CoreTypeLocalCopy
 import godot.annotation.CoreTypeHelper
 import godot.util.RealT
-import kotlincompile.definitions.GodotJvmDefinitions
+import kotlincompile.definitions.GodotJvmBuildConfig
 
 class Transform3D(
     p_basis: Basis,
@@ -163,7 +163,7 @@ class Transform3D(
     }
 
     internal fun setLookAt(eye: Vector3, target: Vector3, up: Vector3, useModelFront: Boolean) {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(!eye.isEqualApprox(target)) {
                 "The eye and target vectors can't be equal."
             }

--- a/kt/godot-library/src/main/kotlin/godot/core/Vector2.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Vector2.kt
@@ -1,6 +1,7 @@
 package godot.core
 
 import godot.util.*
+import kotlincompile.definitions.GodotJvmDefinitions
 import kotlin.math.*
 
 @Suppress("MemberVisibilityCanBePrivate")
@@ -428,7 +429,9 @@ class Vector2(
      * Note: Both vectors must be normalized.
      */
     fun slerp(b: Vector2, t: RealT): Vector2 {
-        require(this.isNormalized() && b.isNormalized()) { "Both this and b vector must be normalized!" }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(this.isNormalized() && b.isNormalized()) { "Both this and b vector must be normalized!" }
+        }
         val theta: RealT = angleTo(b)
         return rotated((theta * t))
     }

--- a/kt/godot-library/src/main/kotlin/godot/core/Vector2.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Vector2.kt
@@ -1,7 +1,7 @@
 package godot.core
 
 import godot.util.*
-import kotlincompile.definitions.GodotJvmDefinitions
+import kotlincompile.definitions.GodotJvmBuildConfig
 import kotlin.math.*
 
 @Suppress("MemberVisibilityCanBePrivate")
@@ -429,7 +429,7 @@ class Vector2(
      * Note: Both vectors must be normalized.
      */
     fun slerp(b: Vector2, t: RealT): Vector2 {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(this.isNormalized() && b.isNormalized()) { "Both this and b vector must be normalized!" }
         }
         val theta: RealT = angleTo(b)

--- a/kt/godot-library/src/main/kotlin/godot/core/Vector3.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Vector3.kt
@@ -1,6 +1,7 @@
 package godot.core
 
 import godot.util.*
+import kotlincompile.definitions.GodotJvmDefinitions
 import kotlin.math.*
 
 
@@ -472,7 +473,9 @@ class Vector3(
      * Rotates the vector around a given axis by phi radians. The axis must be a normalized vector.
      */
     fun rotated(axis: Vector3, phi: RealT): Vector3 {
-        require(axis.isNormalized()) { "Axis not normalized!" }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(axis.isNormalized()) { "Axis not normalized!" }
+        }
         val v = Vector3(this)
         v.rotate(axis, phi)
         return v
@@ -517,7 +520,9 @@ class Vector3(
      * Note: Both vectors must be normalized.
      */
     fun slerp(b: Vector3, t: RealT): Vector3 {
-        require(this.isNormalized() && b.isNormalized()) { "Both this and b vectors must be normalized!" }
+        if (GodotJvmDefinitions.DEBUG) {
+            require(this.isNormalized() && b.isNormalized()) { "Both this and b vectors must be normalized!" }
+        }
         val theta: RealT = angleTo(b)
         return rotated(cross(b).normalized(), theta * t)
     }

--- a/kt/godot-library/src/main/kotlin/godot/core/Vector3.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Vector3.kt
@@ -463,8 +463,10 @@ class Vector3(
      * Returns the vector reflected from a plane defined by the given normal.
      */
     fun reflect(normal: Vector3): Vector3 {
-        require(normal.isNormalized()){
-            "The normal Vector3 must be normalized. But got $normal"
+        if (GodotJvmDefinitions.DEBUG) {
+            require(normal.isNormalized()){
+                "The normal Vector3 must be normalized. But got $normal"
+            }
         }
         return 2.0 * normal * this.dot(normal) - this
     }

--- a/kt/godot-library/src/main/kotlin/godot/core/Vector3.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Vector3.kt
@@ -1,7 +1,7 @@
 package godot.core
 
 import godot.util.*
-import kotlincompile.definitions.GodotJvmDefinitions
+import kotlincompile.definitions.GodotJvmBuildConfig
 import kotlin.math.*
 
 
@@ -463,7 +463,7 @@ class Vector3(
      * Returns the vector reflected from a plane defined by the given normal.
      */
     fun reflect(normal: Vector3): Vector3 {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(normal.isNormalized()){
                 "The normal Vector3 must be normalized. But got $normal"
             }
@@ -475,7 +475,7 @@ class Vector3(
      * Rotates the vector around a given axis by phi radians. The axis must be a normalized vector.
      */
     fun rotated(axis: Vector3, phi: RealT): Vector3 {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(axis.isNormalized()) { "Axis not normalized!" }
         }
         val v = Vector3(this)
@@ -522,7 +522,7 @@ class Vector3(
      * Note: Both vectors must be normalized.
      */
     fun slerp(b: Vector3, t: RealT): Vector3 {
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(this.isNormalized() && b.isNormalized()) { "Both this and b vectors must be normalized!" }
         }
         val theta: RealT = angleTo(b)

--- a/kt/godot-library/src/main/kotlin/godot/core/memory/TransferContext.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/memory/TransferContext.kt
@@ -7,6 +7,7 @@ import godot.core.VariantType
 import godot.tools.common.constants.Constraints
 import godot.util.VoidPtr
 import godot.util.threadLocalLazy
+import kotlincompile.definitions.GodotJvmDefinitions
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -40,8 +41,10 @@ internal object TransferContext {
     fun readSingleArgument(variantType: VariantType, isNullable: Boolean = false): Any? {
         buffer.rewind()
         val argsSize = buffer.int
-        require(argsSize == 1) {
-            "Expecting 1 parameter, but got $argsSize instead."
+        if (GodotJvmDefinitions.DEBUG) {
+            require(argsSize == 1) {
+                "Expecting 1 parameter, but got $argsSize instead."
+            }
         }
         return variantType.toKotlin(buffer, isNullable)
     }
@@ -50,8 +53,10 @@ internal object TransferContext {
         buffer.rewind()
         val argsSize = buffer.int
         val argumentCount = variantTypes.size
-        require(argsSize == argumentCount) {
-            "Expecting $argumentCount parameter(s), but got $argsSize instead."
+        if (GodotJvmDefinitions.DEBUG) {
+            require(argsSize == argumentCount) {
+                "Expecting $argumentCount parameter(s), but got $argsSize instead."
+            }
         }
 
         // Assume that variantTypes and areNullable have the same size and that returnArray is big enough

--- a/kt/godot-library/src/main/kotlin/godot/core/memory/TransferContext.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/memory/TransferContext.kt
@@ -7,7 +7,7 @@ import godot.core.VariantType
 import godot.tools.common.constants.Constraints
 import godot.util.VoidPtr
 import godot.util.threadLocalLazy
-import kotlincompile.definitions.GodotJvmDefinitions
+import kotlincompile.definitions.GodotJvmBuildConfig
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
@@ -41,7 +41,7 @@ internal object TransferContext {
     fun readSingleArgument(variantType: VariantType, isNullable: Boolean = false): Any? {
         buffer.rewind()
         val argsSize = buffer.int
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(argsSize == 1) {
                 "Expecting 1 parameter, but got $argsSize instead."
             }
@@ -53,7 +53,7 @@ internal object TransferContext {
         buffer.rewind()
         val argsSize = buffer.int
         val argumentCount = variantTypes.size
-        if (GodotJvmDefinitions.DEBUG) {
+        if (GodotJvmBuildConfig.DEBUG) {
             require(argsSize == argumentCount) {
                 "Expecting $argumentCount parameter(s), but got $argsSize instead."
             }

--- a/kt/gradle/libs.versions.toml
+++ b/kt/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ gradlePublish = "1.2.1"
 changelog = "2.1.2"
 gradleIntelliJPlugin = "1.15.0"
 ideaSync = "1.1.7" # https://plugins.gradle.org/plugin/org.jetbrains.gradle.plugin.idea-ext
-kotlinPreProcessors = "0.1.4"
+kotlinPreProcessors = "0.2.0"
 
 [libraries]
 shadowJar = { module = "com.github.johnrengelman:shadow", version.ref = "shadowJar" }

--- a/kt/gradle/libs.versions.toml
+++ b/kt/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ gradlePublish = "1.2.1"
 changelog = "2.1.2"
 gradleIntelliJPlugin = "1.15.0"
 ideaSync = "1.1.7" # https://plugins.gradle.org/plugin/org.jetbrains.gradle.plugin.idea-ext
+kotlinPreProcessors = "0.1.4"
 
 [libraries]
 shadowJar = { module = "com.github.johnrengelman:shadow", version.ref = "shadowJar" }
@@ -37,3 +38,4 @@ java = { id = "java" }
 grgit = { id = "org.ajoberstar.grgit", version.ref = "grgit" }
 shadowJar = { id = "com.github.johnrengelman.shadow", version.ref = "shadowJar" }
 gradlePublish = { id = "com.gradle.plugin-publish", version.ref = "gradlePublish" }
+kotlinPreProcessors = { id = "com.utopia-rise.kotlin-preprocessors", version.ref = "kotlinPreProcessors" }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/projectExtensions.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/projectExtensions.kt
@@ -30,3 +30,9 @@ val Project.ideaExtension: IdeaModel
     ) {
         "idea extension not found"
     }
+
+val Project.isRelease: Boolean
+    get() = hasProperty("release")
+
+val Project.godotLibraryArtifactName: String
+    get() = "godot-library-${if (isRelease) "release" else "debug"}"

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/setupConfigurationsAndCompilations.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/setupConfigurationsAndCompilations.kt
@@ -18,7 +18,7 @@ fun Project.setupConfigurationsAndCompilations() {
     //add our dependencies to the main compilation -> convenience for the user
     kotlinJvmExtension.target.compilations.getByName("main").apply {
         dependencies {
-            compileOnly("com.utopia-rise:godot-library:${GodotBuildProperties.assembledGodotKotlinJvmVersion}")
+            compileOnly("com.utopia-rise:$godotLibraryArtifactName:${GodotBuildProperties.assembledGodotKotlinJvmVersion}")
             compileOnly("com.utopia-rise:godot-kotlin-symbol-processor:${GodotBuildProperties.assembledGodotKotlinJvmVersion}")
         }
         dependencies.add(
@@ -32,7 +32,7 @@ fun Project.setupConfigurationsAndCompilations() {
     val bootstrapConfiguration = configurations.create("bootstrap") {
         with(it.dependencies) {
             add(dependencies.create("org.jetbrains.kotlin:kotlin-stdlib:${kotlinJvmExtension.coreLibrariesVersion}"))
-            add(dependencies.create("com.utopia-rise:godot-library:${GodotBuildProperties.assembledGodotKotlinJvmVersion}"))
+            add(dependencies.create("com.utopia-rise:$godotLibraryArtifactName:${GodotBuildProperties.assembledGodotKotlinJvmVersion}"))
         }
     }
 }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/packageMainJar.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/packageMainJar.kt
@@ -1,6 +1,7 @@
 package godot.gradle.tasks
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import godot.gradle.projectExt.godotLibraryArtifactName
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.TaskProvider
@@ -24,7 +25,7 @@ fun Project.packageMainJarTask(
 
             dependencies {
                 it.exclude(it.dependency("org.jetbrains.kotlin:kotlin-stdlib.*"))
-                it.exclude(it.dependency("com.utopia-rise:godot-library:.*"))
+                it.exclude(it.dependency("com.utopia-rise:$godotLibraryArtifactName:.*"))
             }
 
             dependsOn(


### PR DESCRIPTION
This makes use of new [kotlin-preprocessors](https://github.com/utopia-rise/kotlin-preprocessors) gradle plugin.  
This creates a `debug` and `release` version of `godot-library`, which is now published under `godot-library-debug` and `godot-library-release`. Add `-Prelease` when building `godot-library` to build `release` version, default is `debug`.  
Godot Kotlin gradle plugins now check presence of `release` parameter. If it is present, it will fetch `godot-library-release`, otherwise it will fetch `godot-library-debug`.  

This does not build when exporting, this should be done in another PR.