### PR TITLE
fix(cpp): implement ScriptLanguage::thread_enter and ScriptLanguage::thread_exit to attach and detach threads to JVM

### DIFF
--- a/harness/tests/test/unit/test_multi_thread.gd
+++ b/harness/tests/test/unit/test_multi_thread.gd
@@ -1,0 +1,24 @@
+extends "res://addons/gut/test.gd"
+
+
+var results := Array()
+var mutex := Mutex.new()
+
+func test_should_do_multi_threading():
+	var threads := Array()
+	for i in range(0, 3):
+		var thread = Thread.new()
+		thread.start(_thread_assert)
+		threads.append(thread)
+	for thread in threads:
+		thread.wait_to_finish()
+	var expected_aabb = AABB(Vector3(1, 1, 1), Vector3(2, 2, 2))
+	for result in results:
+		assert_eq(result, expected_aabb, "Should get same aabb")
+
+func _thread_assert():
+	var instance = CoreTypesIdentityTest.new()
+	mutex.lock()
+	results.append(instance.aabb)
+	mutex.unlock()
+	instance.free()

--- a/src/jni/platforms/jvm_default.cpp
+++ b/src/jni/platforms/jvm_default.cpp
@@ -9,6 +9,8 @@
 #endif
 
 #include "../jvm_loader.h"
+#include "jni/jvm.h"
+
 
 namespace jni {
     JavaVM* Jvm::vm = nullptr;
@@ -75,11 +77,8 @@ namespace jni {
 
     Env Jvm::attach() {
         JNIEnv* r_env;
-        auto result = vm->GetEnv((void**) &r_env, version);
-        if (result == JNI_EDETACHED) {
-            result = vm->AttachCurrentThread((void**) &r_env, nullptr);
-            JVM_CRASH_COND_MSG(result != JNI_OK, "Failed to attach vm to current thread!");
-        }
+        auto result = vm->AttachCurrentThread((void**) &r_env, nullptr);
+        JVM_CRASH_COND_MSG(result != JNI_OK, "Failed to attach vm to current thread!");
         Jvm::env = new Env(r_env);
         return Env(r_env);
     }

--- a/src/kotlin_language.cpp
+++ b/src/kotlin_language.cpp
@@ -277,11 +277,11 @@ void KotlinLanguage::remove_named_global_constant(const StringName& p_name) {
 }
 
 void KotlinLanguage::thread_enter() {
-    ScriptLanguage::thread_enter();
+    jni::Jvm::attach();
 }
 
 void KotlinLanguage::thread_exit() {
-    ScriptLanguage::thread_exit();
+    jni::Jvm::detach();
 }
 
 String KotlinLanguage::debug_get_error() const {


### PR DESCRIPTION
This implements `ScriptLanguage::thread_enter` and `ScriptLanguage::thread_exit` in `KotlinLanguage` to attach native threads to JVM according to their lifecycle.  
This needs https://github.com/godotengine/godot/pull/82578