### PR TITLE
Rewind() called early in TransferContext

### DIFF
--- a/kt/godot-library/src/main/kotlin/godot/core/Constructors.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Constructors.kt
@@ -17,14 +17,7 @@ abstract class KtConstructor<T : KtObject>(
     abstract operator fun invoke(): T
 
     fun construct(rawPtr: VoidPtr, instanceId: Long) = KtObject.instantiateWith(rawPtr, instanceId) {
-        val argsSize = TransferContext.buffer.int
-        require(argsSize == parameterCount) {
-            "Expecting $parameterCount parameter(s) for constructor, but got $argsSize instead."
-        }
-        for (i in 0 until parameterCount) {
-            paramsArray[i] = TransferContext.readSingleArgument(parameterTypes[i], parameterNullables[i])
-        }
-        TransferContext.buffer.rewind()
+        TransferContext.readArguments(parameterTypes, parameterNullables, paramsArray)
         val instance = invoke()
         resetParamsArray()
         instance

--- a/kt/godot-library/src/main/kotlin/godot/core/KtObject.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/KtObject.kt
@@ -79,19 +79,12 @@ abstract class KtObject {
 
     internal inline fun callConstructor(classIndex: Int, scriptIndex: Int): Unit {
         TransferContext.createNativeObject(classIndex, this, scriptIndex)
-        readPtrAndIdFromBuffer()
+        TransferContext.initializeKtObject(this)
     }
 
     internal inline fun getSingleton(classIndex: Int) {
         TransferContext.getSingleton(classIndex)
-        readPtrAndIdFromBuffer()
-    }
-
-    private inline fun readPtrAndIdFromBuffer() {
-        val buffer = TransferContext.buffer
-        rawPtr = buffer.long
-        id = ObjectID(buffer.long)
-        buffer.rewind()
+        TransferContext.initializeKtObject(this)
     }
 
     open fun _onDestroy() = Unit

--- a/kt/godot-library/src/main/kotlin/godot/core/Properties.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Properties.kt
@@ -34,11 +34,8 @@ open class KtProperty<T : KtObject, P : Any?>(
     }
 
     protected fun <P> extractSetterArgument(): P {
-        val argsSize = TransferContext.buffer.int
-        require(argsSize == 1) { "Setter should be called with only one argument." }
         //TODO: manage nullable argument of enum setter (only for objects)
         val arg = TransferContext.readSingleArgument(variantType)
-        TransferContext.buffer.rewind()
         @Suppress("UNCHECKED_CAST")
         return arg as P
     }

--- a/kt/godot-library/src/main/kotlin/godot/core/callable/KtCallable.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/callable/KtCallable.kt
@@ -12,24 +12,15 @@ abstract class KtCallable<T : KtObject, R : Any?>(
     val variantType: VariantType,
     vararg parameterTypes: Pair<VariantType, Boolean>
 ) {
-    private val types: List<VariantType> = parameterTypes.map { it.first }
-    private val isNullables: List<Boolean> = parameterTypes.map { it.second }
+    private val types: Array<VariantType> = parameterTypes.map { it.first }.toTypedArray()
+    private val isNullables: Array<Boolean> = parameterTypes.map { it.second }.toTypedArray()
 
     fun invoke(instance: T) {
-        val argsSize = TransferContext.buffer.int
-        require(argsSize == parameterCount) { "Expecting $parameterCount parameter(s) for function $name, but got $argsSize instead." }
-        readArguments(argsSize)
+        TransferContext.readArguments(types, isNullables, paramsArray)
         val ret = invokeKt(instance)
         resetParamsArray()
 
         TransferContext.writeReturnValue(ret, variantType)
-    }
-
-    private fun readArguments(argsSize: Int) {
-        for (i in 0 until argsSize) {
-            paramsArray[i] = TransferContext.readSingleArgument(types[i], isNullables[i])
-        }
-        TransferContext.buffer.rewind()
     }
 
     companion object {

--- a/kt/godot-library/src/main/kotlin/godot/core/memory/TransferContext.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/memory/TransferContext.kt
@@ -67,8 +67,7 @@ internal object TransferContext {
 
     fun readReturnValue(type: VariantType, isNullable: Boolean = false): Any? {
         buffer.rewind()
-        val ret = type.toKotlin(buffer, isNullable)
-        return ret
+        return type.toKotlin(buffer, isNullable)
     }
 
     fun callMethod(ptr: VoidPtr, methodIndex: Int, expectedReturnType: VariantType) {

--- a/src/memory/transfer_context.cpp
+++ b/src/memory/transfer_context.cpp
@@ -112,7 +112,6 @@ void TransferContext::icall(JNIEnv* rawEnv, jobject instance, jlong j_ptr, jint 
     if (unlikely(stack_offset + args_size > MAX_STACK_SIZE)) {
         Variant args[MAX_FUNCTION_ARG_COUNT];
         read_args_to_array(buffer, args, args_size);
-        buffer->rewind();
 
         const Variant* args_ptr[MAX_FUNCTION_ARG_COUNT];
         for (uint32_t i = 0; i < args_size; i++) {
@@ -120,11 +119,13 @@ void TransferContext::icall(JNIEnv* rawEnv, jobject instance, jlong j_ptr, jint 
         }
 
         const Variant& ret_value {methodBind->call(ptr, args_ptr, args_size, r_error)};
+
+        buffer->rewind();
         write_return_value(buffer, ret_value);
     } else {
         Variant* args {variant_args + stack_offset};
         read_args_to_array(buffer, args, args_size);
-        buffer->rewind();
+
 
         const Variant** args_ptr {variant_args_ptr + stack_offset};
 
@@ -132,6 +133,7 @@ void TransferContext::icall(JNIEnv* rawEnv, jobject instance, jlong j_ptr, jint 
         const Variant& ret_value {methodBind->call(ptr, args_ptr, args_size, r_error)};
         stack_offset -= args_size;
 
+        buffer->rewind();
         write_return_value(buffer, ret_value);
     }
 

--- a/src/memory/transfer_context.cpp
+++ b/src/memory/transfer_context.cpp
@@ -77,7 +77,7 @@ uint32_t TransferContext::read_args(jni::Env& p_env, Variant* args) {
 }
 
 void TransferContext::write_return_value(jni::Env& p_env, Variant& variant) {
-    write_return_value(get_and_rewind_buffer(p_env), variant);
+    ktvariant::send_variant_to_buffer(variant, get_and_rewind_buffer(p_env));
 }
 
 void TransferContext::icall(JNIEnv* rawEnv, jobject instance, jlong j_ptr, jint p_method_index, jint expectedReturnType) {
@@ -121,7 +121,7 @@ void TransferContext::icall(JNIEnv* rawEnv, jobject instance, jlong j_ptr, jint 
         const Variant& ret_value {methodBind->call(ptr, args_ptr, args_size, r_error)};
 
         buffer->rewind();
-        write_return_value(buffer, ret_value);
+        ktvariant::send_variant_to_buffer(ret_value, buffer);
     } else {
         Variant* args {variant_args + stack_offset};
         read_args_to_array(buffer, args, args_size);
@@ -134,7 +134,7 @@ void TransferContext::icall(JNIEnv* rawEnv, jobject instance, jlong j_ptr, jint 
         stack_offset -= args_size;
 
         buffer->rewind();
-        write_return_value(buffer, ret_value);
+        ktvariant::send_variant_to_buffer(ret_value, buffer);
     }
 
 #ifdef DEBUG_ENABLED

--- a/src/memory/transfer_context.h
+++ b/src/memory/transfer_context.h
@@ -48,10 +48,6 @@ private:
         }
     }
 
-    _FORCE_INLINE_ static void write_return_value(SharedBuffer* buffer, const Variant& r_ret) {
-        ktvariant::send_variant_to_buffer(r_ret, buffer);
-    }
-
     // clang-format off
     DECLARE_JNI_METHODS(
             JNI_METHOD(GET_BUFFER, "getBuffer", "()Ljava/nio/ByteBuffer;")

--- a/src/memory/transfer_context.h
+++ b/src/memory/transfer_context.h
@@ -46,13 +46,10 @@ private:
         for (uint32_t i = 0; i < args_size; ++i) {
             ktvariant::get_variant_from_buffer(buffer, p_args[i]);
         }
-
-        buffer->rewind();
     }
 
     _FORCE_INLINE_ static void write_return_value(SharedBuffer* buffer, const Variant& r_ret) {
         ktvariant::send_variant_to_buffer(r_ret, buffer);
-        buffer->rewind();
     }
 
     // clang-format off

--- a/src/memory/transfer_context.h
+++ b/src/memory/transfer_context.h
@@ -34,7 +34,7 @@ public:
     static void free_object(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr);
 
 private:
-    SharedBuffer* get_buffer(jni::Env& p_env);
+    SharedBuffer* get_and_rewind_buffer(jni::Env& p_env);
 
     _FORCE_INLINE_ static uint32_t read_args_size(SharedBuffer* buffer) {
         uint32_t args_size {decode_uint32(buffer->get_cursor())};


### PR DESCRIPTION
Implement #509 

C++:
The idea is simple. Instead of having to call `rewind()` after any operation on the buffer, we simply rewind it as part of the `get_buffer()` method. (The buffer is stored directly inside that method, so it's the only way to get it).
The only manual `rewind()` left is the one in `icall()` as I need to reset it to write the return value.

Kotlin:
I decided to made `TransferContext.buffer` private (doesn't change its visibility from C++ through JNI). I don't think it should be used directly outside TransferContext, so I did a small rework of its methods.
The goal was to remove any manual call to `rewind()` in the rest of the code. Rewinding should be the responsibility of TransferContext alone.