### PR TITLE
Increase MAX_FUNCTION_ARG_COUNT to 16.

### DIFF
--- a/docs/src/doc/contribution/knowledge-base/shared-buffer.md
+++ b/docs/src/doc/contribution/knowledge-base/shared-buffer.md
@@ -7,7 +7,7 @@ The classical way of making the JVM and C++ code interact with each other is to 
 The only data written in that buffer are the usual Godot types: primitives, strings, coreTypes, and objects. We don't need a generic way of serializing data like protobuff. We tried that solution at first, but it was too slow for an interprocess job. Writing data to the buffer is quite simple in C++, we just use the Marshalls utility of the Godot Engine. On the Kotlin side, we just reimplement them from scratch.
 
 ## Memory
-To avoid unnecessary locks, we create one buffer for each thread that works with both C++ and the JVM. That way, one thread doesn't need to wait for another to finish its job with the buffer. The buffer currently has a size of 4 KB by default. The reason for that is that we allow strings up to 512 bytes in size and only 8 parameters for a registered Kotlin function.
+To avoid unnecessary locks, we create one buffer for each thread that works with both C++ and the JVM. That way, one thread doesn't need to wait for another to finish its job with the buffer. The buffer currently has a size of 8 KB by default. The reason for that is that we allow strings up to 512 bytes in size and up to 16 parameters for a registered Kotlin function.
 
 ## String
 String is a special case because it has a dynamic size so they can potentially have any size. We have set a maximum size allowed in the buffer. If we go above it, it switches to a regular JNI call. When it is done that way, the string is stored in a queue so we can retrieve the strings from it instead of reading from the buffer. In most cases, you would rarely reach that maximum size in a video game. Other dynamic types like `Array` and `Dictionary` are not an issue as only their pointers is sent to the JVM.

--- a/harness/tests/src/main/kotlin/godot/tests/args/FunctionArgSizeTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/args/FunctionArgSizeTest.kt
@@ -143,4 +143,260 @@ class FunctionArgSizeTest : Node() {
             p8,
         )
     }
+
+    @RegisterFunction
+    fun arg9(
+        p1: String,
+        p2: String,
+        p3: String,
+        p4: String,
+        p5: String,
+        p6: String,
+        p7: String,
+        p8: String,
+        p9: String
+    ): VariantArray<Any> {
+        return variantArrayOf(
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+            p8,
+            p9
+        )
+    }
+
+    @RegisterFunction
+    fun arg10(
+        p1: String,
+        p2: String,
+        p3: String,
+        p4: String,
+        p5: String,
+        p6: String,
+        p7: String,
+        p8: String,
+        p9: String,
+        p10: String
+    ): VariantArray<Any> {
+        return variantArrayOf(
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+            p8,
+            p9,
+            p10
+        )
+    }
+
+    @RegisterFunction
+    fun arg11(
+        p1: String,
+        p2: String,
+        p3: String,
+        p4: String,
+        p5: String,
+        p6: String,
+        p7: String,
+        p8: String,
+        p9: String,
+        p10: String,
+        p11: String
+    ): VariantArray<Any> {
+        return variantArrayOf(
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+            p8,
+            p9,
+            p10,
+            p11
+        )
+    }
+
+    @RegisterFunction
+    fun arg12(
+        p1: String,
+        p2: String,
+        p3: String,
+        p4: String,
+        p5: String,
+        p6: String,
+        p7: String,
+        p8: String,
+        p9: String,
+        p10: String,
+        p11: String,
+        p12: String
+    ): VariantArray<Any> {
+        return variantArrayOf(
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+            p8,
+            p9,
+            p10,
+            p11,
+            p12
+        )
+    }
+
+    @RegisterFunction
+    fun arg13(
+        p1: String,
+        p2: String,
+        p3: String,
+        p4: String,
+        p5: String,
+        p6: String,
+        p7: String,
+        p8: String,
+        p9: String,
+        p10: String,
+        p11: String,
+        p12: String,
+        p13: String
+    ): VariantArray<Any> {
+        return variantArrayOf(
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+            p8,
+            p9,
+            p10,
+            p11,
+            p12,
+            p13
+        )
+    }
+
+    @RegisterFunction
+    fun arg14(
+        p1: String,
+        p2: String,
+        p3: String,
+        p4: String,
+        p5: String,
+        p6: String,
+        p7: String,
+        p8: String,
+        p9: String,
+        p10: String,
+        p11: String,
+        p12: String,
+        p13: String,
+        p14: String
+    ): VariantArray<Any> {
+        return variantArrayOf(
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+            p8,
+            p9,
+            p10,
+            p11,
+            p12,
+            p13,
+            p14
+        )
+    }
+
+    @RegisterFunction
+    fun arg15(
+        p1: String,
+        p2: String,
+        p3: String,
+        p4: String,
+        p5: String,
+        p6: String,
+        p7: String,
+        p8: String,
+        p9: String,
+        p10: String,
+        p11: String,
+        p12: String,
+        p13: String,
+        p14: String,
+        p15: String
+    ): VariantArray<Any> {
+        return variantArrayOf(
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+            p8,
+            p9,
+            p10,
+            p11,
+            p12,
+            p13,
+            p14,
+            p15
+        )
+    }
+
+    @RegisterFunction
+    fun arg16(
+        p1: String,
+        p2: String,
+        p3: String,
+        p4: String,
+        p5: String,
+        p6: String,
+        p7: String,
+        p8: String,
+        p9: String,
+        p10: String,
+        p11: String,
+        p12: String,
+        p13: String,
+        p14: String,
+        p15: String,
+        p16: String
+    ): VariantArray<Any> {
+        return variantArrayOf(
+            p1,
+            p2,
+            p3,
+            p4,
+            p5,
+            p6,
+            p7,
+            p8,
+            p9,
+            p10,
+            p11,
+            p12,
+            p13,
+            p14,
+            p15,
+            p16
+        )
+    }
 }

--- a/harness/tests/test/unit/test_function_args.gd
+++ b/harness/tests/test/unit/test_function_args.gd
@@ -9,6 +9,14 @@ var test_data = [
 	"arg6",
 	"arg7",
 	"arg8",
+	"arg9",
+	"arg10",
+	"arg11",
+	"arg12",
+	"arg13",
+	"arg14",
+	"arg15",
+	"arg16",
 ]
 
 func test_function_arg_size():

--- a/kt/api-generator/src/main/kotlin/godot/codegen/exceptions/TooManyArgument.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/exceptions/TooManyArgument.kt
@@ -1,0 +1,11 @@
+package godot.codegen.exceptions
+
+import godot.codegen.models.enriched.EnrichedMethod
+import godot.codegen.models.enriched.EnrichedSignal
+import godot.tools.common.constants.Constraints
+
+class TooManyMethodArgument(method: EnrichedMethod) :
+    Exception("${method.name} has ${method.arguments.size} arguments but the maximum number is ${Constraints.MAX_FUNCTION_ARG_COUNT}")
+
+class TooManySignalArgument(signal: EnrichedSignal) :
+    Exception("${signal.name} has ${signal.arguments.size} arguments but the maximum number is ${Constraints.MAX_SIGNAL_ARG_COUNT}")

--- a/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedMethod.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedMethod.kt
@@ -1,12 +1,12 @@
 package godot.codegen.models.enriched
 
-import com.squareup.kotlinpoet.ANY
-import godot.codegen.extensions.getTypeClassName
+import godot.codegen.exceptions.TooManyMethodArgument
 import godot.codegen.extensions.isObjectSubClass
 import godot.codegen.models.Argument
 import godot.codegen.models.Method
 import godot.codegen.traits.CallableTrait
 import godot.codegen.workarounds.sanitizeApiType
+import godot.tools.common.constants.Constraints
 import godot.tools.common.constants.GodotTypes
 import godot.tools.common.extensions.convertToCamelCase
 import java.util.*
@@ -22,7 +22,11 @@ class EnrichedMethod(val internal: Method, engineClassIndexName: String) : Calla
         if (internal.isVirtual && !kotlinName.startsWith("_")) {
             kotlinName = "_$kotlinName"
         }
+
         name = kotlinName
+        if (arguments.size > Constraints.MAX_FUNCTION_ARG_COUNT) {
+            throw TooManyMethodArgument(this)
+        }
     }
 
     var isGetterOrSetter = false

--- a/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedSignal.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedSignal.kt
@@ -1,14 +1,22 @@
 package godot.codegen.models.enriched
 
+import godot.codegen.exceptions.TooManySignalArgument
 import godot.tools.common.extensions.convertToCamelCase
 import godot.tools.common.extensions.escapeKotlinReservedNames
 import godot.codegen.models.Signal
 import godot.codegen.traits.TypedTrait
+import godot.tools.common.constants.Constraints
 
 class EnrichedSignal(val internal: Signal) : TypedTrait {
     val name = internal.name.convertToCamelCase().escapeKotlinReservedNames()
     val arguments = internal.arguments?.toEnriched() ?: listOf()
     override val type = "Signal${arguments.size}"
+
+    init{
+        if (arguments.size > Constraints.MAX_SIGNAL_ARG_COUNT) {
+            throw TooManySignalArgument(this)
+        }
+    }
 }
 
 fun List<Signal>.toEnriched() = map { EnrichedSignal(it) }

--- a/kt/godot-library/src/main/kotlin/godot/core/Functions.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/Functions.kt
@@ -296,3 +296,283 @@ class KtFunction8<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 :
         paramsArray[7] as P7,
     )
 }
+
+class KtFunction9<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, R : Any?>(
+    functionInfo: KtFunctionInfo,
+    private val function: (T, P0, P1, P2, P3, P4, P5, P6, P7, P8) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>
+) : KtFunction<T, R>(functionInfo, 9, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type) {
+    override fun invokeKt(instance: T): R = function(
+        instance,
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8
+    )
+}
+
+class KtFunction10<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, R : Any?>(
+    functionInfo: KtFunctionInfo,
+    private val function: (T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>
+) : KtFunction<T, R>(functionInfo, 10, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type) {
+    override fun invokeKt(instance: T): R = function(
+        instance,
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9
+    )
+}
+
+class KtFunction11<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, R : Any?>(
+    functionInfo: KtFunctionInfo,
+    private val function: (T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>
+) : KtFunction<T, R>(functionInfo, 11, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type) {
+    override fun invokeKt(instance: T): R = function(
+        instance,
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10
+    )
+}
+
+class KtFunction12<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, R : Any?>(
+    functionInfo: KtFunctionInfo,
+    private val function: (T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>
+) : KtFunction<T, R>(functionInfo, 12, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type) {
+    override fun invokeKt(instance: T): R = function(
+        instance,
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11
+    )
+}
+
+class KtFunction13<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, P12 : Any?, R : Any?>(
+    functionInfo: KtFunctionInfo,
+    private val function: (T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>,
+    p12Type: Pair<VariantType, Boolean>
+) : KtFunction<T, R>(functionInfo, 13, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type, p12Type) {
+    override fun invokeKt(instance: T): R = function(
+        instance,
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11,
+        paramsArray[12] as P12
+    )
+}
+
+class KtFunction14<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, P12 : Any?, P13 : Any?, R : Any?>(
+    functionInfo: KtFunctionInfo,
+    private val function: (T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>,
+    p12Type: Pair<VariantType, Boolean>,
+    p13Type: Pair<VariantType, Boolean>
+) : KtFunction<T, R>(functionInfo, 14, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type, p12Type, p13Type) {
+    override fun invokeKt(instance: T): R = function(
+        instance,
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11,
+        paramsArray[12] as P12,
+        paramsArray[13] as P13
+    )
+}
+
+class KtFunction15<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, P12 : Any?, P13 : Any?, P14 : Any?, R : Any?>(
+    functionInfo: KtFunctionInfo,
+    private val function: (T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>,
+    p12Type: Pair<VariantType, Boolean>,
+    p13Type: Pair<VariantType, Boolean>,
+    p14Type: Pair<VariantType, Boolean>
+) : KtFunction<T, R>(functionInfo, 15, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type, p12Type, p13Type, p14Type) {
+    override fun invokeKt(instance: T): R = function(
+        instance,
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11,
+        paramsArray[12] as P12,
+        paramsArray[13] as P13,
+        paramsArray[14] as P14
+    )
+}
+
+class KtFunction16<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, P12 : Any?, P13 : Any?, P14 : Any?, P15 : Any?, R : Any?>(
+    functionInfo: KtFunctionInfo,
+    private val function: (T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>,
+    p12Type: Pair<VariantType, Boolean>,
+    p13Type: Pair<VariantType, Boolean>,
+    p14Type: Pair<VariantType, Boolean>,
+    p15Type: Pair<VariantType, Boolean>
+) : KtFunction<T, R>(functionInfo, 16, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type, p12Type, p13Type, p14Type, p15Type) {
+    override fun invokeKt(instance: T): R = function(
+        instance,
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11,
+        paramsArray[12] as P12,
+        paramsArray[13] as P13,
+        paramsArray[14] as P14,
+        paramsArray[15] as P15
+    )
+}

--- a/kt/godot-library/src/main/kotlin/godot/core/callable/KtCallables.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/callable/KtCallables.kt
@@ -176,4 +176,268 @@ class TargetedCall8<
     )
 }
 
+class TargetedCall9<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, R : Any?>(
+    private val function: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>
+) : KtCallable<T, R>(this.toString(), 9, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type) {
+    override fun invokeKt(instance: T): R = instance.function(
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8
+    )
+}
+
+class TargetedCall10<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, R : Any?>(
+    private val function: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>
+) : KtCallable<T, R>(this.toString(), 10, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type) {
+    override fun invokeKt(instance: T): R = instance.function(
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9
+    )
+}
+
+class TargetedCall11<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, R : Any?>(
+    private val function: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>
+) : KtCallable<T, R>(this.toString(), 11, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type) {
+    override fun invokeKt(instance: T): R = instance.function(
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10
+    )
+}
+
+class TargetedCall12<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, R : Any?>(
+    private val function: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>
+) : KtCallable<T, R>(this.toString(), 12, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type) {
+    override fun invokeKt(instance: T): R = instance.function(
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11
+    )
+}
+
+class TargetedCall13<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, P12 : Any?, R : Any?>(
+    private val function: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>,
+    p12Type: Pair<VariantType, Boolean>
+) : KtCallable<T, R>(this.toString(), 13, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type, p12Type) {
+    override fun invokeKt(instance: T): R = instance.function(
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11,
+        paramsArray[12] as P12
+    )
+}
+
+class TargetedCall14<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, P12 : Any?, P13 : Any?, R : Any?>(
+    private val function: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>,
+    p12Type: Pair<VariantType, Boolean>,
+    p13Type: Pair<VariantType, Boolean>
+) : KtCallable<T, R>(this.toString(), 14, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type, p12Type, p13Type) {
+    override fun invokeKt(instance: T): R = instance.function(
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11,
+        paramsArray[12] as P12,
+        paramsArray[13] as P13
+    )
+}
+
+class TargetedCall15<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, P12 : Any?, P13 : Any?, P14 : Any?, R : Any?>(
+    private val function: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>,
+    p12Type: Pair<VariantType, Boolean>,
+    p13Type: Pair<VariantType, Boolean>,
+    p14Type: Pair<VariantType, Boolean>
+) : KtCallable<T, R>(this.toString(), 15, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type, p12Type, p13Type, p14Type) {
+    override fun invokeKt(instance: T): R = instance.function(
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11,
+        paramsArray[12] as P12,
+        paramsArray[13] as P13,
+        paramsArray[14] as P14
+    )
+}
+
+class TargetedCall16<T : KtObject, P0 : Any?, P1 : Any?, P2 : Any?, P3 : Any?, P4 : Any?, P5 : Any?, P6 : Any?, P7 : Any?, P8 : Any?, P9 : Any?, P10 : Any?, P11 : Any?, P12 : Any?, P13 : Any?, P14 : Any?, P15 : Any?, R : Any?>(
+    private val function: T.(P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15) -> R,
+    variantType: VariantType,
+    p0Type: Pair<VariantType, Boolean>,
+    p1Type: Pair<VariantType, Boolean>,
+    p2Type: Pair<VariantType, Boolean>,
+    p3Type: Pair<VariantType, Boolean>,
+    p4Type: Pair<VariantType, Boolean>,
+    p5Type: Pair<VariantType, Boolean>,
+    p6Type: Pair<VariantType, Boolean>,
+    p7Type: Pair<VariantType, Boolean>,
+    p8Type: Pair<VariantType, Boolean>,
+    p9Type: Pair<VariantType, Boolean>,
+    p10Type: Pair<VariantType, Boolean>,
+    p11Type: Pair<VariantType, Boolean>,
+    p12Type: Pair<VariantType, Boolean>,
+    p13Type: Pair<VariantType, Boolean>,
+    p14Type: Pair<VariantType, Boolean>,
+    p15Type: Pair<VariantType, Boolean>
+) : KtCallable<T, R>(this.toString(), 16, variantType, p0Type, p1Type, p2Type, p3Type, p4Type, p5Type, p6Type, p7Type, p8Type, p9Type, p10Type, p11Type, p12Type, p13Type, p14Type, p15Type) {
+    override fun invokeKt(instance: T): R = instance.function(
+        paramsArray[0] as P0,
+        paramsArray[1] as P1,
+        paramsArray[2] as P2,
+        paramsArray[3] as P3,
+        paramsArray[4] as P4,
+        paramsArray[5] as P5,
+        paramsArray[6] as P6,
+        paramsArray[7] as P7,
+        paramsArray[8] as P8,
+        paramsArray[9] as P9,
+        paramsArray[10] as P10,
+        paramsArray[11] as P11,
+        paramsArray[12] as P12,
+        paramsArray[13] as P13,
+        paramsArray[14] as P14,
+        paramsArray[15] as P15
+    )
+}
+
 

--- a/kt/godot-library/src/main/kotlin/godot/registration/Registration.kt
+++ b/kt/godot-library/src/main/kotlin/godot/registration/Registration.kt
@@ -14,6 +14,14 @@ import godot.core.KtFunction5
 import godot.core.KtFunction6
 import godot.core.KtFunction7
 import godot.core.KtFunction8
+import godot.core.KtFunction9
+import godot.core.KtFunction10
+import godot.core.KtFunction11
+import godot.core.KtFunction12
+import godot.core.KtFunction13
+import godot.core.KtFunction14
+import godot.core.KtFunction15
+import godot.core.KtFunction16
 import godot.core.KtFunctionInfo
 import godot.core.KtObject
 import godot.core.KtProperty
@@ -37,6 +45,14 @@ import kotlin.reflect.KFunction6
 import kotlin.reflect.KFunction7
 import kotlin.reflect.KFunction8
 import kotlin.reflect.KFunction9
+import kotlin.reflect.KFunction10
+import kotlin.reflect.KFunction11
+import kotlin.reflect.KFunction12
+import kotlin.reflect.KFunction13
+import kotlin.reflect.KFunction14
+import kotlin.reflect.KFunction15
+import kotlin.reflect.KFunction16
+import kotlin.reflect.KFunction17
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KProperty
 
@@ -564,6 +580,574 @@ class ClassBuilderDsl<T : KtObject>(
                 p5Type = p5Type,
                 p6Type = p6Type,
                 p7Type = p7Type,
+            )
+        )
+    }
+
+    fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, R : Any?> function(
+        func: KFunction10<T, P0, P1, P2, P3, P4, P5, P6, P7, P8, R>,
+        variantType: VariantType,
+        p0Type: Pair<VariantType, Boolean>,
+        p1Type: Pair<VariantType, Boolean>,
+        p2Type: Pair<VariantType, Boolean>,
+        p3Type: Pair<VariantType, Boolean>,
+        p4Type: Pair<VariantType, Boolean>,
+        p5Type: Pair<VariantType, Boolean>,
+        p6Type: Pair<VariantType, Boolean>,
+        p7Type: Pair<VariantType, Boolean>,
+        p8Type: Pair<VariantType, Boolean>,
+        p0: KtFunctionArgument,
+        p1: KtFunctionArgument,
+        p2: KtFunctionArgument,
+        p3: KtFunctionArgument,
+        p4: KtFunctionArgument,
+        p5: KtFunctionArgument,
+        p6: KtFunctionArgument,
+        p7: KtFunctionArgument,
+        p8: KtFunctionArgument,
+        returnType: KtFunctionArgument,
+        rpcConfig: KtRpcConfig
+    ) {
+        appendFunction(
+            KtFunction9(
+                functionInfo = KtFunctionInfo(
+                    name = func.name.camelToSnakeCase(),
+                    _arguments = listOf(
+                        p0.toKtPropertyInfo(),
+                        p1.toKtPropertyInfo(),
+                        p2.toKtPropertyInfo(),
+                        p3.toKtPropertyInfo(),
+                        p4.toKtPropertyInfo(),
+                        p5.toKtPropertyInfo(),
+                        p6.toKtPropertyInfo(),
+                        p7.toKtPropertyInfo(),
+                        p8.toKtPropertyInfo()
+                    ),
+                    returnVal = returnType.toKtPropertyInfo(),
+                    rpcConfig = rpcConfig
+                ),
+                function = func,
+                variantType = variantType,
+                p0Type = p0Type,
+                p1Type = p1Type,
+                p2Type = p2Type,
+                p3Type = p3Type,
+                p4Type = p4Type,
+                p5Type = p5Type,
+                p6Type = p6Type,
+                p7Type = p7Type,
+                p8Type = p8Type
+            )
+        )
+    }
+
+    fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, R : Any?> function(
+        func: KFunction11<T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, R>,
+        variantType: VariantType,
+        p0Type: Pair<VariantType, Boolean>,
+        p1Type: Pair<VariantType, Boolean>,
+        p2Type: Pair<VariantType, Boolean>,
+        p3Type: Pair<VariantType, Boolean>,
+        p4Type: Pair<VariantType, Boolean>,
+        p5Type: Pair<VariantType, Boolean>,
+        p6Type: Pair<VariantType, Boolean>,
+        p7Type: Pair<VariantType, Boolean>,
+        p8Type: Pair<VariantType, Boolean>,
+        p9Type: Pair<VariantType, Boolean>,
+        p0: KtFunctionArgument,
+        p1: KtFunctionArgument,
+        p2: KtFunctionArgument,
+        p3: KtFunctionArgument,
+        p4: KtFunctionArgument,
+        p5: KtFunctionArgument,
+        p6: KtFunctionArgument,
+        p7: KtFunctionArgument,
+        p8: KtFunctionArgument,
+        p9: KtFunctionArgument,
+        returnType: KtFunctionArgument,
+        rpcConfig: KtRpcConfig
+    ) {
+        appendFunction(
+            KtFunction10(
+                functionInfo = KtFunctionInfo(
+                    name = func.name.camelToSnakeCase(),
+                    _arguments = listOf(
+                        p0.toKtPropertyInfo(),
+                        p1.toKtPropertyInfo(),
+                        p2.toKtPropertyInfo(),
+                        p3.toKtPropertyInfo(),
+                        p4.toKtPropertyInfo(),
+                        p5.toKtPropertyInfo(),
+                        p6.toKtPropertyInfo(),
+                        p7.toKtPropertyInfo(),
+                        p8.toKtPropertyInfo(),
+                        p9.toKtPropertyInfo()
+                    ),
+                    returnVal = returnType.toKtPropertyInfo(),
+                    rpcConfig = rpcConfig
+                ),
+                function = func,
+                variantType = variantType,
+                p0Type = p0Type,
+                p1Type = p1Type,
+                p2Type = p2Type,
+                p3Type = p3Type,
+                p4Type = p4Type,
+                p5Type = p5Type,
+                p6Type = p6Type,
+                p7Type = p7Type,
+                p8Type = p8Type,
+                p9Type = p9Type
+            )
+        )
+    }
+
+    fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R : Any?> function(
+        func: KFunction12<T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, R>,
+        variantType: VariantType,
+        p0Type: Pair<VariantType, Boolean>,
+        p1Type: Pair<VariantType, Boolean>,
+        p2Type: Pair<VariantType, Boolean>,
+        p3Type: Pair<VariantType, Boolean>,
+        p4Type: Pair<VariantType, Boolean>,
+        p5Type: Pair<VariantType, Boolean>,
+        p6Type: Pair<VariantType, Boolean>,
+        p7Type: Pair<VariantType, Boolean>,
+        p8Type: Pair<VariantType, Boolean>,
+        p9Type: Pair<VariantType, Boolean>,
+        p10Type: Pair<VariantType, Boolean>,
+        p0: KtFunctionArgument,
+        p1: KtFunctionArgument,
+        p2: KtFunctionArgument,
+        p3: KtFunctionArgument,
+        p4: KtFunctionArgument,
+        p5: KtFunctionArgument,
+        p6: KtFunctionArgument,
+        p7: KtFunctionArgument,
+        p8: KtFunctionArgument,
+        p9: KtFunctionArgument,
+        p10: KtFunctionArgument,
+        returnType: KtFunctionArgument,
+        rpcConfig: KtRpcConfig
+    ) {
+        appendFunction(
+            KtFunction11(
+                functionInfo = KtFunctionInfo(
+                    name = func.name.camelToSnakeCase(),
+                    _arguments = listOf(
+                        p0.toKtPropertyInfo(),
+                        p1.toKtPropertyInfo(),
+                        p2.toKtPropertyInfo(),
+                        p3.toKtPropertyInfo(),
+                        p4.toKtPropertyInfo(),
+                        p5.toKtPropertyInfo(),
+                        p6.toKtPropertyInfo(),
+                        p7.toKtPropertyInfo(),
+                        p8.toKtPropertyInfo(),
+                        p9.toKtPropertyInfo(),
+                        p10.toKtPropertyInfo()
+                    ),
+                    returnVal = returnType.toKtPropertyInfo(),
+                    rpcConfig = rpcConfig
+                ),
+                function = func,
+                variantType = variantType,
+                p0Type = p0Type,
+                p1Type = p1Type,
+                p2Type = p2Type,
+                p3Type = p3Type,
+                p4Type = p4Type,
+                p5Type = p5Type,
+                p6Type = p6Type,
+                p7Type = p7Type,
+                p8Type = p8Type,
+                p9Type = p9Type,
+                p10Type = p10Type
+            )
+        )
+    }
+
+    fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R : Any?> function(
+        func: KFunction13<T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, R>,
+        variantType: VariantType,
+        p0Type: Pair<VariantType, Boolean>,
+        p1Type: Pair<VariantType, Boolean>,
+        p2Type: Pair<VariantType, Boolean>,
+        p3Type: Pair<VariantType, Boolean>,
+        p4Type: Pair<VariantType, Boolean>,
+        p5Type: Pair<VariantType, Boolean>,
+        p6Type: Pair<VariantType, Boolean>,
+        p7Type: Pair<VariantType, Boolean>,
+        p8Type: Pair<VariantType, Boolean>,
+        p9Type: Pair<VariantType, Boolean>,
+        p10Type: Pair<VariantType, Boolean>,
+        p11Type: Pair<VariantType, Boolean>,
+        p0: KtFunctionArgument,
+        p1: KtFunctionArgument,
+        p2: KtFunctionArgument,
+        p3: KtFunctionArgument,
+        p4: KtFunctionArgument,
+        p5: KtFunctionArgument,
+        p6: KtFunctionArgument,
+        p7: KtFunctionArgument,
+        p8: KtFunctionArgument,
+        p9: KtFunctionArgument,
+        p10: KtFunctionArgument,
+        p11: KtFunctionArgument,
+        returnType: KtFunctionArgument,
+        rpcConfig: KtRpcConfig
+    ) {
+        appendFunction(
+            KtFunction12(
+                functionInfo = KtFunctionInfo(
+                    name = func.name.camelToSnakeCase(),
+                    _arguments = listOf(
+                        p0.toKtPropertyInfo(),
+                        p1.toKtPropertyInfo(),
+                        p2.toKtPropertyInfo(),
+                        p3.toKtPropertyInfo(),
+                        p4.toKtPropertyInfo(),
+                        p5.toKtPropertyInfo(),
+                        p6.toKtPropertyInfo(),
+                        p7.toKtPropertyInfo(),
+                        p8.toKtPropertyInfo(),
+                        p9.toKtPropertyInfo(),
+                        p10.toKtPropertyInfo(),
+                        p11.toKtPropertyInfo()
+                    ),
+                    returnVal = returnType.toKtPropertyInfo(),
+                    rpcConfig = rpcConfig
+                ),
+                function = func,
+                variantType = variantType,
+                p0Type = p0Type,
+                p1Type = p1Type,
+                p2Type = p2Type,
+                p3Type = p3Type,
+                p4Type = p4Type,
+                p5Type = p5Type,
+                p6Type = p6Type,
+                p7Type = p7Type,
+                p8Type = p8Type,
+                p9Type = p9Type,
+                p10Type = p10Type,
+                p11Type = p11Type
+            )
+        )
+    }
+
+    fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R : Any?> function(
+        func: KFunction14<T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, R>,
+        variantType: VariantType,
+        p0Type: Pair<VariantType, Boolean>,
+        p1Type: Pair<VariantType, Boolean>,
+        p2Type: Pair<VariantType, Boolean>,
+        p3Type: Pair<VariantType, Boolean>,
+        p4Type: Pair<VariantType, Boolean>,
+        p5Type: Pair<VariantType, Boolean>,
+        p6Type: Pair<VariantType, Boolean>,
+        p7Type: Pair<VariantType, Boolean>,
+        p8Type: Pair<VariantType, Boolean>,
+        p9Type: Pair<VariantType, Boolean>,
+        p10Type: Pair<VariantType, Boolean>,
+        p11Type: Pair<VariantType, Boolean>,
+        p12Type: Pair<VariantType, Boolean>,
+        p0: KtFunctionArgument,
+        p1: KtFunctionArgument,
+        p2: KtFunctionArgument,
+        p3: KtFunctionArgument,
+        p4: KtFunctionArgument,
+        p5: KtFunctionArgument,
+        p6: KtFunctionArgument,
+        p7: KtFunctionArgument,
+        p8: KtFunctionArgument,
+        p9: KtFunctionArgument,
+        p10: KtFunctionArgument,
+        p11: KtFunctionArgument,
+        p12: KtFunctionArgument,
+        returnType: KtFunctionArgument,
+        rpcConfig: KtRpcConfig
+    ) {
+        appendFunction(
+            KtFunction13(
+                functionInfo = KtFunctionInfo(
+                    name = func.name.camelToSnakeCase(),
+                    _arguments = listOf(
+                        p0.toKtPropertyInfo(),
+                        p1.toKtPropertyInfo(),
+                        p2.toKtPropertyInfo(),
+                        p3.toKtPropertyInfo(),
+                        p4.toKtPropertyInfo(),
+                        p5.toKtPropertyInfo(),
+                        p6.toKtPropertyInfo(),
+                        p7.toKtPropertyInfo(),
+                        p8.toKtPropertyInfo(),
+                        p9.toKtPropertyInfo(),
+                        p10.toKtPropertyInfo(),
+                        p11.toKtPropertyInfo(),
+                        p12.toKtPropertyInfo()
+                    ),
+                    returnVal = returnType.toKtPropertyInfo(),
+                    rpcConfig = rpcConfig
+                ),
+                function = func,
+                variantType = variantType,
+                p0Type = p0Type,
+                p1Type = p1Type,
+                p2Type = p2Type,
+                p3Type = p3Type,
+                p4Type = p4Type,
+                p5Type = p5Type,
+                p6Type = p6Type,
+                p7Type = p7Type,
+                p8Type = p8Type,
+                p9Type = p9Type,
+                p10Type = p10Type,
+                p11Type = p11Type,
+                p12Type = p12Type
+            )
+        )
+    }
+
+    fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R : Any?> function(
+        func: KFunction15<T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, R>,
+        variantType: VariantType,
+        p0Type: Pair<VariantType, Boolean>,
+        p1Type: Pair<VariantType, Boolean>,
+        p2Type: Pair<VariantType, Boolean>,
+        p3Type: Pair<VariantType, Boolean>,
+        p4Type: Pair<VariantType, Boolean>,
+        p5Type: Pair<VariantType, Boolean>,
+        p6Type: Pair<VariantType, Boolean>,
+        p7Type: Pair<VariantType, Boolean>,
+        p8Type: Pair<VariantType, Boolean>,
+        p9Type: Pair<VariantType, Boolean>,
+        p10Type: Pair<VariantType, Boolean>,
+        p11Type: Pair<VariantType, Boolean>,
+        p12Type: Pair<VariantType, Boolean>,
+        p13Type: Pair<VariantType, Boolean>,
+        p0: KtFunctionArgument,
+        p1: KtFunctionArgument,
+        p2: KtFunctionArgument,
+        p3: KtFunctionArgument,
+        p4: KtFunctionArgument,
+        p5: KtFunctionArgument,
+        p6: KtFunctionArgument,
+        p7: KtFunctionArgument,
+        p8: KtFunctionArgument,
+        p9: KtFunctionArgument,
+        p10: KtFunctionArgument,
+        p11: KtFunctionArgument,
+        p12: KtFunctionArgument,
+        p13: KtFunctionArgument,
+        returnType: KtFunctionArgument,
+        rpcConfig: KtRpcConfig
+    ) {
+        appendFunction(
+            KtFunction14(
+                functionInfo = KtFunctionInfo(
+                    name = func.name.camelToSnakeCase(),
+                    _arguments = listOf(
+                        p0.toKtPropertyInfo(),
+                        p1.toKtPropertyInfo(),
+                        p2.toKtPropertyInfo(),
+                        p3.toKtPropertyInfo(),
+                        p4.toKtPropertyInfo(),
+                        p5.toKtPropertyInfo(),
+                        p6.toKtPropertyInfo(),
+                        p7.toKtPropertyInfo(),
+                        p8.toKtPropertyInfo(),
+                        p9.toKtPropertyInfo(),
+                        p10.toKtPropertyInfo(),
+                        p11.toKtPropertyInfo(),
+                        p12.toKtPropertyInfo(),
+                        p13.toKtPropertyInfo()
+                    ),
+                    returnVal = returnType.toKtPropertyInfo(),
+                    rpcConfig = rpcConfig
+                ),
+                function = func,
+                variantType = variantType,
+                p0Type = p0Type,
+                p1Type = p1Type,
+                p2Type = p2Type,
+                p3Type = p3Type,
+                p4Type = p4Type,
+                p5Type = p5Type,
+                p6Type = p6Type,
+                p7Type = p7Type,
+                p8Type = p8Type,
+                p9Type = p9Type,
+                p10Type = p10Type,
+                p11Type = p11Type,
+                p12Type = p12Type,
+                p13Type = p13Type
+            )
+        )
+    }
+
+    fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R : Any?> function(
+        func: KFunction16<T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, R>,
+        variantType: VariantType,
+        p0Type: Pair<VariantType, Boolean>,
+        p1Type: Pair<VariantType, Boolean>,
+        p2Type: Pair<VariantType, Boolean>,
+        p3Type: Pair<VariantType, Boolean>,
+        p4Type: Pair<VariantType, Boolean>,
+        p5Type: Pair<VariantType, Boolean>,
+        p6Type: Pair<VariantType, Boolean>,
+        p7Type: Pair<VariantType, Boolean>,
+        p8Type: Pair<VariantType, Boolean>,
+        p9Type: Pair<VariantType, Boolean>,
+        p10Type: Pair<VariantType, Boolean>,
+        p11Type: Pair<VariantType, Boolean>,
+        p12Type: Pair<VariantType, Boolean>,
+        p13Type: Pair<VariantType, Boolean>,
+        p14Type: Pair<VariantType, Boolean>,
+        p0: KtFunctionArgument,
+        p1: KtFunctionArgument,
+        p2: KtFunctionArgument,
+        p3: KtFunctionArgument,
+        p4: KtFunctionArgument,
+        p5: KtFunctionArgument,
+        p6: KtFunctionArgument,
+        p7: KtFunctionArgument,
+        p8: KtFunctionArgument,
+        p9: KtFunctionArgument,
+        p10: KtFunctionArgument,
+        p11: KtFunctionArgument,
+        p12: KtFunctionArgument,
+        p13: KtFunctionArgument,
+        p14: KtFunctionArgument,
+        returnType: KtFunctionArgument,
+        rpcConfig: KtRpcConfig
+    ) {
+        appendFunction(
+            KtFunction15(
+                functionInfo = KtFunctionInfo(
+                    name = func.name.camelToSnakeCase(),
+                    _arguments = listOf(
+                        p0.toKtPropertyInfo(),
+                        p1.toKtPropertyInfo(),
+                        p2.toKtPropertyInfo(),
+                        p3.toKtPropertyInfo(),
+                        p4.toKtPropertyInfo(),
+                        p5.toKtPropertyInfo(),
+                        p6.toKtPropertyInfo(),
+                        p7.toKtPropertyInfo(),
+                        p8.toKtPropertyInfo(),
+                        p9.toKtPropertyInfo(),
+                        p10.toKtPropertyInfo(),
+                        p11.toKtPropertyInfo(),
+                        p12.toKtPropertyInfo(),
+                        p13.toKtPropertyInfo(),
+                        p14.toKtPropertyInfo()
+                    ),
+                    returnVal = returnType.toKtPropertyInfo(),
+                    rpcConfig = rpcConfig
+                ),
+                function = func,
+                variantType = variantType,
+                p0Type = p0Type,
+                p1Type = p1Type,
+                p2Type = p2Type,
+                p3Type = p3Type,
+                p4Type = p4Type,
+                p5Type = p5Type,
+                p6Type = p6Type,
+                p7Type = p7Type,
+                p8Type = p8Type,
+                p9Type = p9Type,
+                p10Type = p10Type,
+                p11Type = p11Type,
+                p12Type = p12Type,
+                p13Type = p13Type,
+                p14Type = p14Type
+            )
+        )
+    }
+
+    fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R : Any?> function(
+        func: KFunction17<T, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15, R>,
+        variantType: VariantType,
+        p0Type: Pair<VariantType, Boolean>,
+        p1Type: Pair<VariantType, Boolean>,
+        p2Type: Pair<VariantType, Boolean>,
+        p3Type: Pair<VariantType, Boolean>,
+        p4Type: Pair<VariantType, Boolean>,
+        p5Type: Pair<VariantType, Boolean>,
+        p6Type: Pair<VariantType, Boolean>,
+        p7Type: Pair<VariantType, Boolean>,
+        p8Type: Pair<VariantType, Boolean>,
+        p9Type: Pair<VariantType, Boolean>,
+        p10Type: Pair<VariantType, Boolean>,
+        p11Type: Pair<VariantType, Boolean>,
+        p12Type: Pair<VariantType, Boolean>,
+        p13Type: Pair<VariantType, Boolean>,
+        p14Type: Pair<VariantType, Boolean>,
+        p15Type: Pair<VariantType, Boolean>,
+        p0: KtFunctionArgument,
+        p1: KtFunctionArgument,
+        p2: KtFunctionArgument,
+        p3: KtFunctionArgument,
+        p4: KtFunctionArgument,
+        p5: KtFunctionArgument,
+        p6: KtFunctionArgument,
+        p7: KtFunctionArgument,
+        p8: KtFunctionArgument,
+        p9: KtFunctionArgument,
+        p10: KtFunctionArgument,
+        p11: KtFunctionArgument,
+        p12: KtFunctionArgument,
+        p13: KtFunctionArgument,
+        p14: KtFunctionArgument,
+        p15: KtFunctionArgument,
+        returnType: KtFunctionArgument,
+        rpcConfig: KtRpcConfig
+    ) {
+        appendFunction(
+            KtFunction16(
+                functionInfo = KtFunctionInfo(
+                    name = func.name.camelToSnakeCase(),
+                    _arguments = listOf(
+                        p0.toKtPropertyInfo(),
+                        p1.toKtPropertyInfo(),
+                        p2.toKtPropertyInfo(),
+                        p3.toKtPropertyInfo(),
+                        p4.toKtPropertyInfo(),
+                        p5.toKtPropertyInfo(),
+                        p6.toKtPropertyInfo(),
+                        p7.toKtPropertyInfo(),
+                        p8.toKtPropertyInfo(),
+                        p9.toKtPropertyInfo(),
+                        p10.toKtPropertyInfo(),
+                        p11.toKtPropertyInfo(),
+                        p12.toKtPropertyInfo(),
+                        p13.toKtPropertyInfo(),
+                        p14.toKtPropertyInfo(),
+                        p15.toKtPropertyInfo()
+                    ),
+                    returnVal = returnType.toKtPropertyInfo(),
+                    rpcConfig = rpcConfig
+                ),
+                function = func,
+                variantType = variantType,
+                p0Type = p0Type,
+                p1Type = p1Type,
+                p2Type = p2Type,
+                p3Type = p3Type,
+                p4Type = p4Type,
+                p5Type = p5Type,
+                p6Type = p6Type,
+                p7Type = p7Type,
+                p8Type = p8Type,
+                p9Type = p9Type,
+                p10Type = p10Type,
+                p11Type = p11Type,
+                p12Type = p12Type,
+                p13Type = p13Type,
+                p14Type = p14Type,
+                p15Type = p15Type
             )
         )
     }

--- a/kt/tools-common/src/main/kotlin/godot/tools/common/constants/Constraints.kt
+++ b/kt/tools-common/src/main/kotlin/godot/tools/common/constants/Constraints.kt
@@ -1,7 +1,9 @@
 package godot.tools.common.constants
 
 // when changed; also update constraints.h!
+// Since Godot 4, an unlimited amount of parameters is supported. Limits should be increased when appropriate.
 object Constraints {
     const val MAX_CONSTRUCTOR_ARG_COUNT = 8
-    const val MAX_FUNCTION_ARG_COUNT = 8 // https://github.com/godotengine/godot/pull/54188
+    const val MAX_FUNCTION_ARG_COUNT = 16
+    const val MAX_SIGNAL_ARG_COUNT = 8
 }

--- a/src/constraints.h
+++ b/src/constraints.h
@@ -9,6 +9,6 @@
 static constexpr const int MAX_CONSTRUCTOR_ARG_COUNT {8};
 
 // when changed, also update godot.tools.common.constants.Constraints.MAX_FUNCTION_ARG_COUNT!
-static constexpr const int MAX_FUNCTION_ARG_COUNT {8};
+static constexpr const int MAX_FUNCTION_ARG_COUNT {16};
 
 #endif //GODOT_JVM_CONSTRAINTS_H


### PR DESCRIPTION
Some API methods couldn't be called because they exceeded the maximal amount of arguments we support.
I added a sanity check in the api generator to detect when such cases happen.
The theorical maximal number of arguments in Godot in unlimited since version 4.
The practical maximal number to date in 4.1.2 is 14 arguments.
I increased the limit to 16, to keep it a power of 2 and give us a bit of leeway.