### PR TITLE
fix(docs): warning formatting and gradle snippet for ios documentation

### DIFF
--- a/docs/src/doc/index.md
+++ b/docs/src/doc/index.md
@@ -19,7 +19,7 @@ The items in this list are explicitly mentioned here as these will be implemente
 - Each registered constructor must have a unique number of arguments, constructor overloading is not yet supported
 - No tool mode (you can set it already in the `@RegisterClass` annotation but it has no effect yet)
 - No plugin support, you cannot use Godot Kotlin/JVM to write plugins and addons yet
-- Only desktop OS (Linux, MacOS, Windows) and Android are supported for now
+- We support desktop OS (Linux, MacOS, Windows), Android and iOS.
 
 ### Bug reporting and Questions
 If you find bugs, please report an [issue on github](https://github.com/utopia-rise/godot-kotlin-jvm/issues) - but check for duplicates first. If you have questions or need help, you can ask on [discord](https://discord.gg/zpb5Ru7v9x) in the channels `questions` and `help` respectively. If you don't have discord or don't want to use it, make a issue on github.

--- a/docs/src/doc/user-guide/exporting.md
+++ b/docs/src/doc/user-guide/exporting.md
@@ -101,10 +101,11 @@ On desktop platform default export is inferred by the `godot_kotin_configuration
 Additionally, to the regular GraalVM configuration mentioned above, add the following in `build.gradle.kts`:  
 ```kotlin
 godot {
+    isGraalNativeImageExportEnabled.set(true)
+    graalVmDirectory.set(File("Path to your graalVM install")) // or setup GRAALVM_HOME environment variable.
     isIOSExportEnabled.set(true)
 }
 ```
 
 !!! warning
-    With this export you don't have a choice regarding JVM embedding in the app. Godot kotlin's gradle plugin will
-automatically download a iOS static JDK libraries and pack it with your code for iOS.
+    With this export you don't have a choice regarding JVM embedding in the app. Godot kotlin's gradle plugin will automatically download a iOS static JDK libraries and pack it with your code for iOS.

--- a/docs/src/doc/user-guide/supported-platforms.md
+++ b/docs/src/doc/user-guide/supported-platforms.md
@@ -4,5 +4,4 @@ While Kotlin and Godot supports a wide range of platforms, this module for the m
 - Linux X64
 - MacOS X64
 - Android (arm64v8)
-
-iOS will be supported at a later date.
+- iOS (arm64v8)


### PR DESCRIPTION
Little fixes on doc concerning iOS support.