### PR TITLE
Update BunnyMark to Godot Kotlin 4

### DIFF
--- a/harness/bunnymark/Benchmarker.gd
+++ b/harness/bunnymark/Benchmarker.gd
@@ -1,25 +1,29 @@
 extends Control
 
-var fps_update_interval = 1.0
-var elapsed_time = 0.0
-var fps_label = null
-var benchmark_container = null
-var benchmark_node = null
-var output_path = "user://benchmark_results.json"
-var arg_bench = "--bench="
-var arg_lang = "--lang="
+var fps_update_interval := 1.0
+var elapsed_time := 0.0
+var fps_label: Label = null
+var benchmark_container: Node2D = null
+var benchmark_node: Node2D = null
+var output_path := "user://benchmark_results.json"
+var arg_bench := "--bench="
+var arg_lang := "--lang="
 
 # bunnymark
-var bunnymark_target = 60.0
-var bunnymark_target_error = 0.5
-var benchmark_is_bunnymark = false
-var bunnymark_update_interval = 2.0
-var stable_updates_required = 3
-var bunnymark_update_elapsed_time = 0.0
-var stable_updates = 0
+var bunnymark_target := 60.0
+var bunnymark_target_error := 0.1
+var benchmark_is_bunnymark := false
+var bunnymark_update_interval := 2.0
+var stable_updates_required := 3
+var bunnymark_update_elapsed_time := 0.0
+var stable_updates := 0
 
-export(String, "BunnymarkV2", "BunnymarkV1Sprites", "BunnymarkV1DrawTexture", "BunnymarkV3") var benchmark: String = "BunnymarkV2"
-export(String, "gd", "kt", "cs") var language: String = "gd"
+var bunny_number := 0
+var ping_pong_counter := 0
+var increasing := true
+
+@export_enum("BunnymarkV2", "BunnymarkV1Sprites", "BunnymarkV1DrawTexture", "BunnymarkV3") var benchmark: String = "BunnymarkV2"
+@export_enum("gd", "gdj", "cs") var language: String = "gd"
 
 func _ready():
 	set_process(false)
@@ -44,12 +48,12 @@ func _process(delta):
 		update_bunnymark(delta)
 
 func get_script_path(benchmark_name, language):
-	if language == "kt":
-		return "res://src/main/kotlin/godot/benchmark/bunnymark/" + benchmark_name + ".kt"
+	if language == "gdj":
+		return "res://scripts/godot/benchmark/bunnymark/" + benchmark_name + ".gdj"
 	else:
 		return "res://benchmarks/" + benchmark_name + "/" + language + "/" + benchmark_name + "." + language
 
-func start_benchmark(benchmark_name, language):
+func start_benchmark(benchmark_name: String, language: String):
 	var language_extension = language
 	var script_path = get_script_path(benchmark_name, language)
 	benchmark_is_bunnymark = benchmark_name.begins_with("Bunnymark")
@@ -58,8 +62,10 @@ func start_benchmark(benchmark_name, language):
 	benchmark_node = Node2D.new()
 	benchmark_node.set_script(script)
 	benchmark_node.add_user_signal("benchmark_finished", ["output"])
-	benchmark_node.connect("benchmark_finished", self, "benchmark_finished")
+	benchmark_node.connect("benchmark_finished", Callable(self, "benchmark_finished"))
 	benchmark_container.add_child(benchmark_node)
+	bunny_number = 0
+	ping_pong_counter = 0
 	if benchmark_node.has_method("add_bunny"):
 		set_process(true)
 	else:
@@ -73,48 +79,58 @@ func benchmark_finished(output):
 
 func write_result(output):
 	print("written ", output)
-	var file = File.new()
-	file.open(output_path, File.READ)
-	var parse_result = JSON.parse(file.get_as_text())
-	var benchmark_file = null
-	if parse_result.get_error() == 0:
-		benchmark_file = parse_result.get_result()
+	var file := FileAccess.open(output_path, FileAccess.READ)
+	var test_json_conv = JSON.new()
+	var error := test_json_conv.parse(file.get_as_text())
+	var benchmark_file: Variant = null
+	if error == 0:
+		benchmark_file = test_json_conv.get_parsed_text()
 	if benchmark_file == null or typeof(benchmark_file) != TYPE_DICTIONARY:
 		benchmark_file = {
 			"benchmark_results": {}
 		}
 	file.close()
 	benchmark_file["benchmark_results"][benchmark + "_" + language] = output
-	var dir = Directory.new()
+	var dir := DirAccess.open("res://")
 	dir.remove(output_path)
-	file = File.new()
-	file.open(output_path, File.WRITE)
-	benchmark_file["run_date"] = OS.get_datetime()
-	file.store_string(JSON.print(benchmark_file))
+	file = FileAccess.open(output_path, FileAccess.WRITE)
+	benchmark_file["run_date"] = Time.get_datetime_dict_from_system()
+	file.store_string(JSON.stringify(benchmark_file))
 
 func update_bunnymark(delta):
 	bunnymark_update_elapsed_time += delta
 	if bunnymark_update_elapsed_time > bunnymark_update_interval:
 		var fps = Engine.get_frames_per_second()
 		var difference = fps - bunnymark_target
-		print(difference)
-		var bunny_difference = 0
-		if difference > bunnymark_target_error:
-			bunny_difference = min(1000, max(1, floor(20 * difference)))
-		elif difference < -bunnymark_target_error:
-			bunny_difference = max(-1000, min(-1, -1*ceil(20 * difference)))
-		if abs(difference) < bunnymark_target_error:
+		var bunny_difference := 0
+		var current_stability_target = bunnymark_target_error * ping_pong_counter
+		print("Tolerance: " + str(current_stability_target))
+		if difference > current_stability_target:
+			bunny_difference = clamp(difference * max(100, bunny_number/1000), 10, 2000)
+			bunny_number += bunny_difference
+			if !increasing:
+				increasing = true
+				ping_pong_counter += 1
+			print("New Bunnies: " + str(bunny_difference))
+		elif difference < -current_stability_target:
+			bunny_difference = clamp(difference * max(100, bunny_number/1000), -2000, -10)
+			bunny_number -= bunny_difference
+			if increasing:
+				increasing = false
+				ping_pong_counter += 1
+			print("Deleted Bunnies: " + str(bunny_difference))
+		if abs(difference) < current_stability_target:
 			stable_updates += 1
+			print("Current Bunnies: " + str(bunny_number))
 			if stable_updates == stable_updates_required:
-				benchmark_node.finish()
+				benchmark_node.call("finish")
 		else:
 			if bunny_difference > 0:
 				for i in range(bunny_difference):
-					benchmark_node.add_bunny()
+					benchmark_node.call("add_bunny")
 			else:
 				for i in range(-1*bunny_difference):
-					benchmark_node.remove_bunny()
-
+					benchmark_node.call("remove_bunny")
 			stable_updates = 0
 
 		bunnymark_update_elapsed_time = 0.0

--- a/harness/bunnymark/Benchmarker.tscn
+++ b/harness/bunnymark/Benchmarker.tscn
@@ -1,24 +1,27 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=2 format=3 uid="uid://rpq5yfx8hlbw"]
 
-[ext_resource path="res://Benchmarker.gd" type="Script" id=1]
+[ext_resource type="Script" path="res://Benchmarker.gd" id="1"]
 
 [node name="Benchmarker" type="Control"]
+layout_mode = 3
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
-script = ExtResource( 1 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-benchmark = "BunnymarkV1DrawTexture"
-language = "kt"
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1")
+benchmark = "BunnymarkV3"
+language = "gdj"
 
 [node name="BenchmarkContainer" type="Node2D" parent="."]
 
 [node name="Panel" type="Panel" parent="."]
-margin_right = 83.0
-margin_bottom = 14.0
+layout_mode = 0
+offset_right = 83.0
+offset_bottom = 14.0
 
 [node name="FPS" type="Label" parent="Panel"]
+layout_mode = 0
 anchor_right = 1.0
 anchor_bottom = 1.0
 text = "FPS:"

--- a/harness/bunnymark/README.md
+++ b/harness/bunnymark/README.md
@@ -10,7 +10,7 @@ Example: `../../../../bin/godot.x11.opt.tools.64.mono --bench=BunnymarkV2 --lang
 
 Renders an increasing number of bunny sprites until a stable 60fps is hit.  This is a decent test of real world usage as it combines Godot api usage with raw computation.
 
-## Benchmark Run - Pre-Alpha, February 17, 2021
+## Benchmark Run - Alpha 0.7.2, October 17th, 2023 
 
 ### BunnymarkV3
 
@@ -19,9 +19,9 @@ This benchmark's goal is to measure the cost of calling many small scripts from 
 
 | Language             | Bunnies Rendered |
 |----------------------|------------------|
-| GDScript             | 8328             |
-| Kotlin               | 7056             |
-| CSharp               | 8813             |
+| Typed GDScript       | 22500            |
+| Kotlin(JVM)          | 20300            |
+| Kotlin(Native image) | 12600            |
 
 ### BunnymarkV2
 
@@ -29,9 +29,9 @@ Attempts to draw as many sprites as possible using Sprite nodes.  It calls GetCh
 
 | Language             | Bunnies Rendered |
 |----------------------|------------------|
-| GDScript             | 10272            |
-| Kotlin               | 10587            |
-| CSharp               | 13920            |
+| Typed GDScript       | 24700            |
+| Kotlin(JVM)          | 34300            |
+| Kotlin(Native image) | 17900            |
 
 ### BunnymarkV1 - DrawTexture
 
@@ -39,9 +39,9 @@ Attempts to draw as many sprites to the screen as possible by drawing textures d
 
 | Language             | Bunnies Rendered |
 |----------------------|------------------|
-| GDScript             | 10910            |
-| Kotlin               | 24340            |
-| CSharp               | 22100            |
+| Typed GDScript       | 35040            |
+| Kotlin(JVM)          | 82400            |
+| Kotlin(Native image) | 47100            |
 
 ### BunnymarkV1 - Sprites
 
@@ -49,21 +49,22 @@ Attempts to draw as many sprites to the screen as possible by adding Sprite node
 
 | Language             | Bunnies Rendered |
 |----------------------|------------------|
-| GDScript             | 10117            |
-| Kotlin               | 18958            |
-| CSharp               | 21500            |
+| Typed GDScript       | 23500            |
+| Kotlin(JVM)          | 47400            |
+| Kotlin(Native image) | 22200            |
 
 
 ### Hardware:
 
-* CPU: Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz
-* GPU: AMD Radeon RX 5700 XT
-* RAM: 64GB DDR4 @ 2133 MT/s
+* CPU: 13th Gen Intel(R) Core(TM) i5-13600K 3.50 GHz
+* GPU: Nvidia RTX 3070
+* RAM: 32GB DDR5 @ 5800 MT/s
 
 ### Build Info:
-* OS: 5.4.95-1-MANJARO (Arch)
-* Godot 3.2 branch (Commit: 7897cf44722a1e4a9a18fb666f819ba19268d6a1), Target: template_debug 
-* Kotlin 1.4.30
+* OS: Windows 10
+* Godot 4.1.2-stable, Target: editor 
+* Kotlin 1.9.0
+* JDK 17
 
 
 

--- a/harness/bunnymark/benchmarks/BunnymarkV1DrawTexture/cs/BunnymarkV1DrawTexture.cs
+++ b/harness/bunnymark/benchmarks/BunnymarkV1DrawTexture/cs/BunnymarkV1DrawTexture.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using System.Collections.Generic;
 
-public class BunnymarkV1DrawTexture : Node2D
+public partial class BunnymarkV1DrawTexture : Node2D
 {
     private class Pair
     {
@@ -12,7 +12,7 @@ public class BunnymarkV1DrawTexture : Node2D
 
     List<Pair> bunnies = new List<Pair>();
     Vector2 screenSize;
-    Texture bunnyTexture = (Texture)GD.Load("res://images/godot_bunny.png");
+    Texture2D bunnyTexture = (Texture2D)GD.Load("res://images/godot_bunny.png");
     Random random = new Random();
     int gravity = 500;
 

--- a/harness/bunnymark/benchmarks/BunnymarkV1DrawTexture/gd/BunnymarkV1DrawTexture.gd
+++ b/harness/bunnymark/benchmarks/BunnymarkV1DrawTexture/gd/BunnymarkV1DrawTexture.gd
@@ -1,20 +1,20 @@
 extends Node2D
 
-var bunnies = []
-var bunny_texture = load("res://images/godot_bunny.png")
-var grav = 500
-var screen_size
+var bunnies: Array[Array] = []
+var bunny_texture = load("res://images/godot_bunny.png") as Texture2D
+var grav := 500
+var screen_size := Vector2()
 
 func _draw():
 	for bunny in bunnies:
-		draw_texture(bunny_texture, bunny[0])
+		draw_texture(bunny_texture, bunny[0] as Vector2)
 
 func _process(delta):
 	screen_size = get_viewport_rect().size
 	
 	for bunny in bunnies:
-		var pos = bunny[0]
-		var newPosition = bunny[1]
+		var pos: Vector2 = bunny[0]
+		var newPosition: Vector2 = bunny[1]
 		
 		pos.x += newPosition.x * delta
 		pos.y += newPosition.y * delta
@@ -42,7 +42,7 @@ func _process(delta):
 		
 		bunny[0] = pos
 		bunny[1] = newPosition
-	update()
+	queue_redraw()
 
 func add_bunny():
 	bunnies.append([Vector2(screen_size.x / 2, screen_size.y / 2), Vector2(randi() % 200 + 50, randi() % 200 + 50)])

--- a/harness/bunnymark/benchmarks/BunnymarkV1Sprites/cs/BunnymarkV1Sprites.cs
+++ b/harness/bunnymark/benchmarks/BunnymarkV1Sprites/cs/BunnymarkV1Sprites.cs
@@ -2,18 +2,18 @@ using Godot;
 using System;
 using System.Collections.Generic;
 
-public class BunnymarkV1Sprites : Node2D
+public partial class BunnymarkV1Sprites : Node2D
 {
     private class Pair
     {
-        public Sprite Sprite;
+        public Sprite2D Sprite2D;
         public Vector2 Vector;
     }
 
     List<Pair> bunnies = new List<Pair>();
     Vector2 screenSize;
 
-    Texture bunnyTexture = (Texture)GD.Load("res://images/godot_bunny.png");
+    Texture2D bunnyTexture = (Texture2D)GD.Load("res://images/godot_bunny.png");
     Random random = new Random();
     int gravity = 500;
 
@@ -23,7 +23,7 @@ public class BunnymarkV1Sprites : Node2D
 
         foreach (var bunny in bunnies)
         {
-            var position = bunny.Sprite.Position;
+            var position = bunny.Sprite2D.Position;
             var newPosition = bunny.Vector;
 
             position.x += newPosition.x * delta;
@@ -62,18 +62,18 @@ public class BunnymarkV1Sprites : Node2D
                 position.y = 0;
             }
 
-            bunny.Sprite.Position = position;
+            bunny.Sprite2D.Position = position;
             bunny.Vector = newPosition;
         }
     }
 
     public void add_bunny()
     {
-        var bunny = new Sprite();
+        var bunny = new Sprite2D();
         bunny.SetTexture(bunnyTexture);
         AddChild(bunny);
         bunny.Position = new Vector2(screenSize.x / 2, screenSize.y / 2);
-        bunnies.Add(new Pair() { Sprite = bunny, Vector = new Vector2(random.Next() % 200 + 50, random.Next() % 200 + 50) });
+        bunnies.Add(new Pair() { Sprite2D = bunny, Vector = new Vector2(random.Next() % 200 + 50, random.Next() % 200 + 50) });
     }
 
     public void remove_bunny()
@@ -84,8 +84,8 @@ public class BunnymarkV1Sprites : Node2D
 
         var bunny = bunnies[bunnies.Count - 1];
         bunnies.RemoveAt(bunnies.Count - 1);
-        RemoveChild(bunny.Sprite);
-        bunny.Sprite.QueueFree();
+        RemoveChild(bunny.Sprite2D);
+        bunny.Sprite2D.QueueFree();
     }
 
     public void finish()

--- a/harness/bunnymark/benchmarks/BunnymarkV1Sprites/gd/BunnymarkV1Sprites.gd
+++ b/harness/bunnymark/benchmarks/BunnymarkV1Sprites/gd/BunnymarkV1Sprites.gd
@@ -1,46 +1,46 @@
 extends Node2D
 
-var bunnies = []
-var grav = 500
-var bunny_texture = load("res://images/godot_bunny.png")
-var screen_size
+var bunnies: Array[Array] = []
+var bunny_texture = load("res://images/godot_bunny.png") as Texture2D
+var grav := 500
+var screen_size := Vector2()
 
 func _process(delta):
 	screen_size = get_viewport_rect().size
 	
 	for bunny in bunnies:
-		var pos = bunny[0].position
-		var newPosition = bunny[1]
+		var pos: Vector2 = (bunny[0] as Sprite2D).position
+		var speed: Vector2 = bunny[1]
 		
-		pos.x += newPosition.x * delta
-		pos.y += newPosition.y * delta
+		pos.x += speed.x * delta
+		pos.y += speed.y * delta
 	
-		newPosition.y += grav * delta
+		speed.y += grav * delta
 	
 		if pos.x > screen_size.x:
-			newPosition.x *= -1
+			speed.x *= -1
 			pos.x = screen_size.x
 		
 		if pos.x < 0:
-			newPosition.x *= -1
+			speed.x *= -1
 			pos.x = 0
 			
 		if pos.y > screen_size.y:
 			pos.y = screen_size.y
 			if randf() > 0.5:
-				newPosition.y = -(randi() % 1100 + 50)
+				speed.y = -(randi() % 1100 + 50)
 			else:
-				newPosition.y *= -0.85
+				speed.y *= -0.85
 			
 		if pos.y < 0:
-			newPosition.y = 0
+			speed.y = 0
 			pos.y = 0
 		
 		bunny[0].position = pos
-		bunny[1] = newPosition
+		bunny[1] = speed
 
 func add_bunny():
-	var bunny = Sprite.new()
+	var bunny := Sprite2D.new()
 	bunny.set_texture(bunny_texture)
 	add_child(bunny)
 	bunny.position = Vector2(screen_size.x / 2, screen_size.y / 2)
@@ -49,10 +49,10 @@ func add_bunny():
 func remove_bunny():
 	if bunnies.size() == 0:
 		return
-	var bunny = bunnies[bunnies.size() - 1]
-	remove_child(bunny[0])
+	var bunny: Array = bunnies[bunnies.size() - 1]
+	remove_child(bunny[0] as Sprite2D)
 	bunnies.pop_back()
-	bunny[0].queue_free()
+	(bunny[0] as Sprite2D).queue_free()
 
 func finish():
 	emit_signal("benchmark_finished", bunnies.size())

--- a/harness/bunnymark/benchmarks/BunnymarkV2/cs/BunnymarkV2.cs
+++ b/harness/bunnymark/benchmarks/BunnymarkV2/cs/BunnymarkV2.cs
@@ -2,11 +2,11 @@ using Godot;
 using System;
 using System.Collections.Generic;
 
-public class BunnymarkV2 : Node2D
+public partial class BunnymarkV2 : Node2D
 {
     Vector2 screenSize;
 
-    Texture bunnyTexture = (Texture)GD.Load("res://images/godot_bunny.png");
+    Texture2D bunnyTexture = (Texture2D)GD.Load("res://images/godot_bunny.png");
     List<Vector2> speeds = new List<Vector2>();
     Random random = new Random();
     int gravity = 500;
@@ -16,7 +16,7 @@ public class BunnymarkV2 : Node2D
     public override void _Ready()
     {
         AddChild(bunnies);
-        label.RectPosition = new Vector2(0, 20);
+        label.Position = new Vector2(0, 20);
         AddChild(label);
     }
 
@@ -28,7 +28,7 @@ public class BunnymarkV2 : Node2D
         var bunnyChildren = bunnies.GetChildren();
         for (var i = 0; i < bunnyChildren.Count; i++)
         {
-            var bunny = (Sprite)bunnyChildren[i];
+            var bunny = (Sprite2D)bunnyChildren[i];
             var position = bunny.Position;
             var speed = speeds[i];
 
@@ -75,7 +75,7 @@ public class BunnymarkV2 : Node2D
 
     public void add_bunny()
     {
-        var bunny = new Sprite();
+        var bunny = new Sprite2D();
         bunny.SetTexture(bunnyTexture);
         bunnies.AddChild(bunny);
         bunny.Position = new Vector2(screenSize.x / 2, screenSize.y / 2);

--- a/harness/bunnymark/benchmarks/BunnymarkV2/gd/BunnymarkV2.gd
+++ b/harness/bunnymark/benchmarks/BunnymarkV2/gd/BunnymarkV2.gd
@@ -1,27 +1,27 @@
 extends Node2D
 
-var grav = 500
-var bunny_texture = load("res://images/godot_bunny.png")
-var bunny_speeds = []
-var label = Label.new()
-var bunnies = Node2D.new()
-var screen_size
+var grav := 500
+var bunny_texture := load("res://images/godot_bunny.png") as Texture2D
+var bunny_speeds := []
+var label := Label.new()
+var bunnies := Node2D.new()
+var screen_size := Vector2()
 
 func _ready():
 	add_child(bunnies)
 
-	label.rect_position = Vector2(0, 20)
+	label.position = Vector2(0, 20)
 	add_child(label)
 
 func _process(delta):
 	screen_size = get_viewport_rect().size
 	label.text = "Bunnies: " + str(bunnies.get_child_count())
 	
-	var bunny_children = bunnies.get_children()
+	var bunny_children := bunnies.get_children()
 	for i in range(0, bunny_children.size()):
-		var bunny = bunny_children[i]
-		var pos = bunny.position
-		var speed = bunny_speeds[i]
+		var bunny: Sprite2D = bunny_children[i]
+		var pos: Vector2 = bunny.position
+		var speed: Vector2 = bunny_speeds[i]
 		
 		pos.x += speed.x * delta
 		pos.y += speed.y * delta
@@ -51,17 +51,17 @@ func _process(delta):
 		bunny_speeds[i] = speed
 
 func add_bunny():
-	var bunny = Sprite.new()
+	var bunny := Sprite2D.new()
 	bunny.set_texture(bunny_texture)
 	bunnies.add_child(bunny)
 	bunny.position = Vector2(screen_size.x / 2, screen_size.y / 2)
 	bunny_speeds.push_back(Vector2(randi() % 200 + 50, randi() % 200 + 50))
 
 func remove_bunny():
-	var child_count = bunnies.get_child_count()
+	var child_count := bunnies.get_child_count()
 	if child_count == 0:
 		return
-	var bunny = bunnies.get_child(child_count - 1)
+	var bunny: Sprite2D = bunnies.get_child(child_count - 1)
 	bunny_speeds.pop_back()
 	bunnies.remove_child(bunny)
 	bunny.queue_free()

--- a/harness/bunnymark/benchmarks/BunnymarkV3/cs/Bunny.cs
+++ b/harness/bunnymark/benchmarks/BunnymarkV3/cs/Bunny.cs
@@ -1,7 +1,7 @@
 using Godot;
 
 // ReSharper disable once CheckNamespace
-public class Bunny : Sprite
+public partial class Bunny : Sprite2D
 {
     public Vector2 Speed = Vector2.Zero;
 

--- a/harness/bunnymark/benchmarks/BunnymarkV3/cs/BunnymarkV3.cs
+++ b/harness/bunnymark/benchmarks/BunnymarkV3/cs/BunnymarkV3.cs
@@ -1,14 +1,14 @@
 using Godot;
 
 // ReSharper disable once CheckNamespace
-public class BunnymarkV3 : Node2D
+public partial class BunnymarkV3 : Node2D
 {
     [Signal]
     // ReSharper disable once InconsistentNaming
     public delegate void benchmark_finished(long bunnyCount);
 
     private readonly RandomNumberGenerator randomNumberGenerator = new RandomNumberGenerator();
-    private readonly Texture bunnyTexture = ResourceLoader.Load<Texture>("res://images/godot_bunny.png");
+    private readonly Texture2D bunnyTexture = ResourceLoader.Load<Texture2D>("res://images/godot_bunny.png");
     private readonly Label label = new Label();
     private readonly Node2D bunnies = new Node2D();
 
@@ -31,7 +31,7 @@ public class BunnymarkV3 : Node2D
 
     public void add_bunny()
     {
-        var bunny = new Bunny {Texture = bunnyTexture};
+        var bunny = new Bunny {Texture2D = bunnyTexture};
         bunnies.AddChild(bunny);
         bunny.Position = new Vector2(screenSize.x / 2, screenSize.y / 2);
         bunny.Speed = new Vector2(randomNumberGenerator.Randi() % 200 + 50, randomNumberGenerator.Randi() % 200 + 50);

--- a/harness/bunnymark/benchmarks/BunnymarkV3/gd/Bunny.gd
+++ b/harness/bunnymark/benchmarks/BunnymarkV3/gd/Bunny.gd
@@ -1,9 +1,10 @@
-extends Sprite
 class_name Bunny
+extends Sprite2D
 
-var speed: Vector2
-var grav = 500
-var screen_size
+
+var speed := Vector2()
+var grav := 500
+var screen_size := Vector2()
 
 
 # Called when the node enters the scene tree for the first time.
@@ -14,8 +15,8 @@ func _ready():
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 	screen_size = get_viewport_rect().size
-	var pos = self.position
-	var speed = self.speed
+	var pos: Vector2 = self.position
+	var speeds: Vector2 = self.speed
 		
 	pos.x += speed.x * delta
 	pos.y += speed.y * delta

--- a/harness/bunnymark/benchmarks/BunnymarkV3/gd/BunnymarkV3.gd
+++ b/harness/bunnymark/benchmarks/BunnymarkV3/gd/BunnymarkV3.gd
@@ -1,14 +1,14 @@
 extends Node2D
 
-var bunny_texture = load("res://images/godot_bunny.png")
-var label = Label.new()
-var bunnies = Node2D.new()
-var screen_size
+var bunny_texture := load("res://images/godot_bunny.png") as Texture2D
+var label := Label.new()
+var bunnies := Node2D.new()
+var screen_size := Vector2()
 
 func _ready():
 	add_child(bunnies)
 
-	label.rect_position = Vector2(0, 20)
+	label.position = Vector2(0, 20)
 	add_child(label)
 
 func _process(delta):
@@ -23,10 +23,10 @@ func add_bunny():
 	bunny.speed = Vector2(randi() % 200 + 50, randi() % 200 + 50)
 
 func remove_bunny():
-	var child_count = bunnies.get_child_count()
+	var child_count: int = bunnies.get_child_count()
 	if child_count == 0:
 		return
-	var bunny = bunnies.get_child(child_count - 1)
+	var bunny: Bunny = bunnies.get_child(child_count - 1)
 	bunnies.remove_child(bunny)
 	bunny.queue_free()
 

--- a/harness/bunnymark/build.gradle.kts
+++ b/harness/bunnymark/build.gradle.kts
@@ -7,8 +7,6 @@ repositories {
 }
 
 godot {
-    //uncomment to test graal vm native image
-//    isGraalNativeImageExportEnabled.set(true)
-//    graalVmDirectory.set(System.getenv("GRAALVM_HOME"))
-//    windowsDeveloperVCVarsPath.set(System.getenv("VC_VARS_PATH"))
+    registrationFileBaseDir.set(projectDir.resolve("scripts"))
+    isRegistrationFileHierarchyEnabled.set(true)
 }

--- a/harness/bunnymark/default_env.tres
+++ b/harness/bunnymark/default_env.tres
@@ -1,7 +1,7 @@
-[gd_resource type="Environment" load_steps=2 format=2]
+[gd_resource type="Environment" load_steps=2 format=3 uid="uid://d0pqjjq0lgjqq"]
 
-[sub_resource type="ProceduralSky" id=1]
+[sub_resource type="Sky" id="1"]
 
 [resource]
 background_mode = 2
-background_sky = SubResource( 1 )
+sky = SubResource("1")

--- a/harness/bunnymark/gradle/wrapper/gradle-wrapper.properties
+++ b/harness/bunnymark/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/harness/bunnymark/icon.png.import
+++ b/harness/bunnymark/icon.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex"
+type="CompressedTexture2D"
+uid="uid://cuw8nt38ujgu3"
+path="res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://icon.png"
-dest_files=[ "res://.import/icon.png-487276ed1e3a0c39cad0279d744ee560.stex" ]
+dest_files=["res://.godot/imported/icon.png-487276ed1e3a0c39cad0279d744ee560.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/harness/bunnymark/images/banner.png.import
+++ b/harness/bunnymark/images/banner.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/banner.png-495447ee2000b5377e44fe44842d6fba.stex"
+type="CompressedTexture2D"
+uid="uid://djpdx4pq1a58u"
+path="res://.godot/imported/banner.png-495447ee2000b5377e44fe44842d6fba.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://images/banner.png"
-dest_files=[ "res://.import/banner.png-495447ee2000b5377e44fe44842d6fba.stex" ]
+dest_files=["res://.godot/imported/banner.png-495447ee2000b5377e44fe44842d6fba.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/harness/bunnymark/images/bunny.svg.import
+++ b/harness/bunnymark/images/bunny.svg.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/bunny.svg-3356eb39f02eb923a7afbd5300694760.stex"
+type="CompressedTexture2D"
+uid="uid://dlcetjmdybu5b"
+path="res://.godot/imported/bunny.svg-3356eb39f02eb923a7afbd5300694760.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,27 @@ metadata={
 [deps]
 
 source_file="res://images/bunny.svg"
-dest_files=[ "res://.import/bunny.svg-3356eb39f02eb923a7afbd5300694760.stex" ]
+dest_files=["res://.godot/imported/bunny.svg-3356eb39f02eb923a7afbd5300694760.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1
 svg/scale=1.0
+editor/scale_with_editor_scale=false
+editor/convert_colors_with_editor_theme=false

--- a/harness/bunnymark/images/godot_bunny.png.import
+++ b/harness/bunnymark/images/godot_bunny.png.import
@@ -1,8 +1,9 @@
 [remap]
 
 importer="texture"
-type="StreamTexture"
-path="res://.import/godot_bunny.png-5e0de01a4cf02b42e387f89806c8030b.stex"
+type="CompressedTexture2D"
+uid="uid://bqexjxhhgywba"
+path="res://.godot/imported/godot_bunny.png-5e0de01a4cf02b42e387f89806c8030b.ctex"
 metadata={
 "vram_texture": false
 }
@@ -10,25 +11,24 @@ metadata={
 [deps]
 
 source_file="res://images/godot_bunny.png"
-dest_files=[ "res://.import/godot_bunny.png-5e0de01a4cf02b42e387f89806c8030b.stex" ]
+dest_files=["res://.godot/imported/godot_bunny.png-5e0de01a4cf02b42e387f89806c8030b.ctex"]
 
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
-compress/hdr_mode=0
-compress/bptc_ldr=0
+compress/hdr_compression=1
 compress/normal_map=0
-flags/repeat=0
-flags/filter=true
-flags/mipmaps=false
-flags/anisotropic=false
-flags/srgb=2
+compress/channel_pack=0
+mipmaps/generate=false
+mipmaps/limit=-1
+roughness/mode=0
+roughness/src_normal=""
 process/fix_alpha_border=true
 process/premult_alpha=false
-process/HDR_as_SRGB=false
-process/invert_color=false
-stream=false
-size_limit=0
-detect_3d=true
-svg/scale=1.0
+process/normal_map_invert_y=false
+process/hdr_as_srgb=false
+process/hdr_clamp_exposure=false
+process/size_limit=0
+detect_3d/compress_to=1

--- a/harness/bunnymark/project.godot
+++ b/harness/bunnymark/project.godot
@@ -6,58 +6,26 @@
 ;   [section] ; section goes between []
 ;   param=value ; assign values to parameters
 
-config_version=4
-
-_global_script_classes=[ {
-"base": "Sprite",
-"class": "Bunny",
-"language": "GDScript",
-"path": "res://benchmarks/BunnymarkV3/gd/Bunny.gd"
-}, {
-"base": "Node2D",
-"class": "BunnymarkV1DrawTexture",
-"language": "Kotlin",
-"path": "res://src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1DrawTexture.kt"
-}, {
-"base": "Node2D",
-"class": "BunnymarkV1Sprites",
-"language": "Kotlin",
-"path": "res://src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1Sprites.kt"
-}, {
-"base": "Node2D",
-"class": "BunnymarkV2",
-"language": "Kotlin",
-"path": "res://src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV2.kt"
-}, {
-"base": "Node2D",
-"class": "BunnymarkV3",
-"language": "Kotlin",
-"path": "res://src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV3.kt"
-}, {
-"base": "Sprite",
-"class": "godot_benchmark_bunnymark_v3_Bunny",
-"language": "Kotlin",
-"path": "res://src/main/kotlin/godot/benchmark/bunnymark/v3/Bunny.kt"
-} ]
-_global_script_class_icons={
-"Bunny": "",
-"BunnymarkV1DrawTexture": "",
-"BunnymarkV1Sprites": "",
-"BunnymarkV2": "",
-"BunnymarkV3": "",
-"godot_benchmark_bunnymark_v3_Bunny": ""
-}
+config_version=5
 
 [application]
 
 config/name="Bunnymark"
 run/main_scene="res://Benchmarker.tscn"
+config/features=PackedStringArray("4.1")
 config/icon="res://icon.png"
+
+[debug]
+
+gdscript/warnings/unsafe_property_access=2
+gdscript/warnings/unsafe_method_access=2
+gdscript/warnings/unsafe_cast=1
+gdscript/warnings/unsafe_call_argument=2
 
 [display]
 
-window/vsync/use_vsync=false
+window/vsync/vsync_mode=false
 
 [rendering]
 
-environment/default_environment="res://default_env.tres"
+environment/defaults/default_environment="res://default_env.tres"

--- a/harness/bunnymark/settings.gradle.kts
+++ b/harness/bunnymark/settings.gradle.kts
@@ -2,19 +2,18 @@ rootProject.name = "godot-kotlin-bunnymark"
 
 includeBuild("../../kt/api-generator") {
     dependencySubstitution {
-        substitute(module("com.utopia-rise:api-generator")).with(project(":"))
+        substitute(module("com.utopia-rise:api-generator")).using(project(":"))
     }
 }
 includeBuild("../../kt") {
     dependencySubstitution {
-        substitute(module("com.utopia-rise:godot-gradle-plugin")).with(project(":godot-gradle-plugin"))
-        substitute(module("com.utopia-rise:godot-runtime")).with(project(":godot-runtime"))
-        substitute(module("com.utopia-rise:godot-library")).with(project(":godot-library"))
-        substitute(module("com.utopia-rise:godot-bootstrap")).with(project(":godot-bootstrap"))
-        substitute(module("com.utopia-rise:godot-kotlin-symbol-processor")).with(project(":godot-kotlin-symbol-processor"))
-        substitute(module("com.utopia-rise:godot-entry-generator")).with(project(":godot-entry-generator"))
+        substitute(module("com.utopia-rise:godot-gradle-plugin")).using(project(":godot-gradle-plugin"))
+        substitute(module("com.utopia-rise:godot-library")).using(project(":godot-library"))
+        substitute(module("com.utopia-rise:godot-kotlin-symbol-processor")).using(project(":godot-kotlin-symbol-processor"))
+        substitute(module("com.utopia-rise:godot-entry-generator")).using(project(":godot-entry-generator"))
     }
 }
+
 
 pluginManagement {
     repositories {

--- a/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1DrawTexture.kt
+++ b/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1DrawTexture.kt
@@ -3,7 +3,7 @@ package godot.benchmark.bunnymark
 import godot.Node2D
 import godot.RandomNumberGenerator
 import godot.ResourceLoader
-import godot.Texture
+import godot.Texture2D
 import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 import godot.annotation.RegisterSignal
@@ -14,13 +14,13 @@ import godot.signals.signal
 class BunnymarkV1DrawTexture : Node2D() {
 
 	@RegisterSignal
-	val signalBenchmarkFinished by signal<Int>("bunnyCount")
+	val benchmarkFinished by signal<Int>("bunnyCount")
 
 	data class Bunny(var position: Vector2, var speed: Vector2)
 
 	private val bunnies = mutableListOf<Bunny>()
 	private val gravity = 500
-	private val bunnyTexture = ResourceLoader.load("res://images/godot_bunny.png") as Texture
+	private val bunnyTexture = ResourceLoader.load("res://images/godot_bunny.png") as Texture2D
 	private val randomNumberGenerator = RandomNumberGenerator()
 
 	private lateinit var screenSize: Vector2
@@ -77,7 +77,7 @@ class BunnymarkV1DrawTexture : Node2D() {
 			bunny.position = pos
 			bunny.speed = speed
 		}
-		update()
+		queueRedraw()
 	}
 
 	@RegisterFunction
@@ -98,6 +98,6 @@ class BunnymarkV1DrawTexture : Node2D() {
 
 	@RegisterFunction
 	fun finish() {
-		signalBenchmarkFinished.emit(bunnies.size)
+        benchmarkFinished.emit(bunnies.size)
 	}
 }

--- a/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1Sprites.kt
+++ b/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1Sprites.kt
@@ -11,13 +11,13 @@ import godot.signals.signal
 class BunnymarkV1Sprites : Node2D() {
 
 	@RegisterSignal
-	val signalBenchmarkFinished by signal<Int>("bunnyCount")
+	val benchmarkFinished by signal<Int>("bunnyCount")
 
-	private data class Bunny(var sprite: Sprite, var speed: Vector2)
+	private data class Bunny(var sprite: Sprite2D, var speed: Vector2)
 
 	private val bunnies = mutableListOf<Bunny>()
 	private val gravity = 500
-	private val bunnyTexture = ResourceLoader.load("res://images/godot_bunny.png") as Texture
+	private val bunnyTexture = ResourceLoader.load("res://images/godot_bunny.png") as Texture2D
 	private val randomNumberGenerator = RandomNumberGenerator()
 
 	private lateinit var screenSize: Vector2
@@ -71,7 +71,7 @@ class BunnymarkV1Sprites : Node2D() {
 
 	@RegisterFunction
 	fun addBunny() {
-		val bunny = Sprite()
+		val bunny = Sprite2D()
 		bunny.texture = bunnyTexture
 		addChild(bunny)
 		bunny.position = Vector2(screenSize.x / 2, screenSize.y / 2)
@@ -94,6 +94,6 @@ class BunnymarkV1Sprites : Node2D() {
 
 	@RegisterFunction
 	fun finish() {
-		signalBenchmarkFinished.emit(bunnies.size)
+        benchmarkFinished.emit(bunnies.size)
 	}
 }

--- a/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV2.kt
+++ b/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV2.kt
@@ -11,13 +11,13 @@ import godot.signals.signal
 class BunnymarkV2 : Node2D() {
 
 	@RegisterSignal
-	val signalBenchmarkFinished by signal<Int>("bunnyCount")
+	val benchmarkFinished by signal<Int>("bunnyCount")
 
 	private val gravity = 500
 	private val bunnySpeeds = mutableListOf<Vector2>()
 	private val label = Label()
 	private val bunnies = Node2D()
-	private val bunnyTexture = ResourceLoader.load("res://images/godot_bunny.png") as Texture
+	private val bunnyTexture = ResourceLoader.load("res://images/godot_bunny.png") as Texture2D
 	private val randomNumberGenerator = RandomNumberGenerator()
 
 	private lateinit var screenSize: Vector2
@@ -37,7 +37,7 @@ class BunnymarkV2 : Node2D() {
 
 		val bunnyChildren = bunnies.getChildren()
 		for (i in 0 until bunnyChildren.size) {
-			val bunny = bunnyChildren[i]!! as Sprite
+			val bunny = bunnyChildren[i] as Sprite2D
 			val pos = bunny.position
 			val speed = bunnySpeeds[i]
 
@@ -77,7 +77,7 @@ class BunnymarkV2 : Node2D() {
 
 	@RegisterFunction
 	fun addBunny() {
-		val bunny = Sprite()
+		val bunny = Sprite2D()
 		bunny.texture = bunnyTexture
 		bunnies.addChild(bunny)
 		bunny.position = Vector2(screenSize.x / 2, screenSize.y / 2)
@@ -89,7 +89,7 @@ class BunnymarkV2 : Node2D() {
 	@RegisterFunction
 	fun removeBunny() {
 		val childCount = bunnies.getChildCount()
-		if (childCount == 0L) return
+		if (childCount == 0) return
 		bunnies
 			.getChild(childCount - 1)
 			?.let { bunny ->
@@ -101,6 +101,6 @@ class BunnymarkV2 : Node2D() {
 
 	@RegisterFunction
 	fun finish() {
-		signalBenchmarkFinished.emit(bunnySpeeds.size)
+        benchmarkFinished.emit(bunnySpeeds.size)
 	}
 }

--- a/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV3.kt
+++ b/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV3.kt
@@ -12,10 +12,10 @@ import godot.signals.signal
 class BunnymarkV3 : Node2D() {
 
 	@RegisterSignal
-	val signalBenchmarkFinished by signal<Long>("bunnyCount")
+	val benchmarkFinished by signal<Int>("bunnyCount")
 
 	private val randomNumberGenerator = RandomNumberGenerator()
-	private val bunnyTexture = ResourceLoader.load("res://images/godot_bunny.png") as Texture
+	private val bunnyTexture = ResourceLoader.load("res://images/godot_bunny.png") as Texture2D
 	private val label = Label()
 	private val bunnies = Node2D()
 
@@ -48,7 +48,7 @@ class BunnymarkV3 : Node2D() {
 	@RegisterFunction
 	fun removeBunny() {
 		val childCount = bunnies.getChildCount()
-		if (childCount != 0L) {
+		if (childCount != 0) {
 			val bunny = bunnies.getChild(childCount - 1)
 			bunnies.removeChild(bunny!!)
 			bunny.queueFree()
@@ -57,6 +57,6 @@ class BunnymarkV3 : Node2D() {
 
 	@RegisterFunction
 	fun finish() {
-		signalBenchmarkFinished.emit(bunnies.getChildCount())
+        benchmarkFinished.emit(bunnies.getChildCount())
 	}
 }

--- a/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/v3/Bunny.kt
+++ b/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/v3/Bunny.kt
@@ -1,13 +1,13 @@
 package godot.benchmark.bunnymark.v3
 
 import godot.RandomNumberGenerator
-import godot.Sprite
+import godot.Sprite2D
 import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 import godot.core.Vector2
 
 @RegisterClass
-class Bunny : Sprite() {
+class Bunny : Sprite2D() {
 
 	var speed = Vector2()
 


### PR DESCRIPTION
- Kotlin scripts updated for Godot 4
- Gdscripts updated for Godot 4 and now typed to get the best performance out of them.
- I didn't test C#. I have never used that language and don't want to spend 4h trying to set it on my computer. If someone is willing they can do it but I don't think it's much relevant for us anyway.
- Also updated the benchmark script, so it can reach stability faster.

Kotlin JVM is incredibly faster than before, compared to GDScript (even with the extra performance from types) Our worst case is still the BunnymarkV3. That one is supposed to stress JNI calls. Despite this, we are still holding decently well.
Native images are a disappointment, I expected less performance overall because of the absence of JIT, but it seems that even BunnymarkV3 is way slower too. It doesn't seem native compilation is helping with JNI calls.