### PR TITLE
Fix comilation of unit tests in modules with out gradle plugin

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/setupConfigurationsAndCompilations.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/setupConfigurationsAndCompilations.kt
@@ -18,7 +18,7 @@ fun Project.setupConfigurationsAndCompilations() {
     //add our dependencies to the main compilation -> convenience for the user
     kotlinJvmExtension.target.compilations.getByName("main").apply {
         dependencies {
-            compileOnly("com.utopia-rise:$godotLibraryArtifactName:${GodotBuildProperties.assembledGodotKotlinJvmVersion}")
+            implementation("com.utopia-rise:$godotLibraryArtifactName:${GodotBuildProperties.assembledGodotKotlinJvmVersion}")
             compileOnly("com.utopia-rise:godot-kotlin-symbol-processor:${GodotBuildProperties.assembledGodotKotlinJvmVersion}")
         }
         dependencies.add(


### PR DESCRIPTION
Fixes #519

Defines our godot library as implementation so it can be used by test source sets as well.
Wile the library get's added to the main jar as well, there are no conflicts with the one added by bootstrap jar.