### PR TITLE
Fix template project and ide banner showing indefinitely on gradle sync failure

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
@@ -207,7 +207,10 @@ open class GodotExtension(objects: ObjectFactory) {
         additionalGraalReflectionConfigurationFiles.set(arrayOf())
         additionalGraalResourceConfigurationFiles.set(arrayOf())
         isGraalVmNativeImageGenerationVerbose.set(false)
-        windowsDeveloperVCVarsPath.set(File(System.getenv("VC_VARS_PATH")))
+
+        System.getenv("VC_VARS_PATH")?.let {
+            windowsDeveloperVCVarsPath.set(File(it))
+        }
 
         isIOSExportEnabled.set(false)
     }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
@@ -135,7 +135,7 @@ open class GodotExtension(objects: ObjectFactory) {
      *
      * example: ${System.getenv("VC_VARS_PATH")}
      */
-    val windowsDeveloperVCVarsPath: Property<String> = objects.property(String::class.java)
+    val windowsDeveloperVCVarsPath: RegularFileProperty = objects.fileProperty()
 
     /**
      * Additional Graal JNI configurations.
@@ -207,7 +207,7 @@ open class GodotExtension(objects: ObjectFactory) {
         additionalGraalReflectionConfigurationFiles.set(arrayOf())
         additionalGraalResourceConfigurationFiles.set(arrayOf())
         isGraalVmNativeImageGenerationVerbose.set(false)
-        windowsDeveloperVCVarsPath.set("\"%VC_VARS_PATH%\"")
+        windowsDeveloperVCVarsPath.set(File(System.getenv("VC_VARS_PATH")))
 
         isIOSExportEnabled.set(false)
     }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/graal/createGraalNativeImage.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/graal/createGraalNativeImage.kt
@@ -78,7 +78,7 @@ fun Project.createGraalNativeImageTask(
 
                         "(",
 
-                        godotJvmExtension.windowsDeveloperVCVarsPath.get(),
+                        godotJvmExtension.windowsDeveloperVCVarsPath.get().asFile.absolutePath,
 
                         "&&",
 

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/gradle/GradleSystemListener.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/gradle/GradleSystemListener.kt
@@ -20,4 +20,14 @@ class GradleSystemListener : ExternalSystemTaskNotificationListenerAdapter() {
             }
         }
     }
+
+    override fun onFailure(id: ExternalSystemTaskId, e: Exception) {
+        if (id.projectSystemId == GRADLE_SYSTEM_ID && id.type == RESOLVE_PROJECT) {
+            // Gradle sync failed, pause our existing import if one is happening and hide our message banner
+            id.findProject()?.let { project ->
+                GodotKotlinJvmSettings.close()
+                SettingsFetchingNotification.getInstance(project).hide()
+            }
+        }
+    }
 }


### PR DESCRIPTION
This fixes our template project by changing the expected type of `windowsDeveloperVCVarsPath` from string to a file property. This makes it more in line with our other properties with similar usages.

This also fixes the banner which is displayed when our ide plugin is not setup in the case of a gradle sync failure.