### PR TITLE
Fix local publications

### DIFF
--- a/docs/src/doc/contribution/setup.md
+++ b/docs/src/doc/contribution/setup.md
@@ -2,7 +2,7 @@ To build our module, you need to same dependencies as the ones described in the 
 
 Make sure that Java is installed and its PATH set in your system as well (at least Java 11 is needed!).
 
-1. Clone godot repo with the stable tag you want to develop for: `git clone git@github.com:godotengine/godot.git 4.1.1-stable --recursive`
+1. Clone godot repo with the stable tag you want to develop for: `git clone git@github.com:godotengine/godot.git 4.1.2-stable --recursive`
 
 2. In the `godot-root` dir, run the following command: `git submodule add git@github.com:utopia-rise/godot-kotlin-jvm.git modules/kotlin_jvm`
 
@@ -24,6 +24,30 @@ Make sure that Java is installed and its PATH set in your system as well (at lea
 
 6. In order to debug your JVM code, you should start Godot with command line `--jvm-debug-port=XXXX`, where `XXXX`
 stands for the JMX port of you choice. You can then set up remote debug configuration in Intellij IDEA.
+
+
+## Publishing locally
+In order to publish our artifacts locally, you'll need to run `gradlew :tools-common:publishToMavenLocal publishToMavenLocal`
+
+Check in you maven local repository what the version is you've just published: `ls ~/.m2/repository/com/utopia-rise/godot-gradle-plugin`. The version should look something like this: `0.7.2-4.1.2-c8df371-SNAPSHOT`.
+
+Your test project should use `mavenLocal()` in the repositories block in `build.gradle.kts` and the following in `settings.gradle.kts`:
+```kotlin
+pluginManagement {
+    repositories {
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+        google()
+    }
+
+    resolutionStrategy.eachPlugin {
+        if (requested.id.id == "com.utopia-rise.godot-kotlin-jvm") {
+            useModule("com.utopia-rise:godot-gradle-plugin:${requested.version}")
+        }
+    }
+}
+```
 
 ## Important things to note:
 When you build a sample, it generates a `godot-bootstrap.jar` in `build/libs`. This jar is needed by the engine to function correctly. You need to copy this jar to `<godot-root>/bin`. If you want to automate that, consider using the following gradle task in the samples `build.gradle.kts`- but don't commit it!

--- a/kt/utils/godot-build-props/build.gradle.kts
+++ b/kt/utils/godot-build-props/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.apache.tools.ant.filters.ReplaceTokens
+import versioninfo.fullGodotKotlinJvmVersion
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -15,6 +16,7 @@ tasks {
     val processResources by getting(Copy::class) {
         outputs.upToDateWhen { false }
         val tokens = mapOf(
+            "godot.kotlin.jvm.assembled.version" to fullGodotKotlinJvmVersion,
             "godot.kotlin.jvm.version" to libs.versions.godotKotlinJvm.get(),
             "godot.version" to libs.versions.godot.get(),
             "kotlin.version" to libs.versions.kotlin.get(),

--- a/kt/utils/godot-build-props/src/main/kotlin/godot/utils/GodotBuildProperties.kt
+++ b/kt/utils/godot-build-props/src/main/kotlin/godot/utils/GodotBuildProperties.kt
@@ -10,7 +10,7 @@ object GodotBuildProperties {
     }
 
     val assembledGodotKotlinJvmVersion by lazy {
-        "$godotKotlinJvmVersion-$godotVersion"
+        buildProperties["godot.kotlin.jvm.assembled.version"] as String
     }
 
     val godotKotlinJvmVersion by lazy {

--- a/kt/utils/godot-build-props/src/main/resources/build.properties
+++ b/kt/utils/godot-build-props/src/main/resources/build.properties
@@ -1,3 +1,4 @@
+godot.kotlin.jvm.assembled.version=@godot.kotlin.jvm.assembled.version@
 godot.kotlin.jvm.version=@godot.kotlin.jvm.version@
 godot.version=@godot.version@
 kotlin.version=@kotlin.version@


### PR DESCRIPTION
This fixes local maven publications by using the snapshot version for referenced dependencies in the gradle plugin through our build properties.

This also adds a section to our contributors documentation on how to do local publications.