### PR TITLE
fix: allow godot-kotlin-jvm gradle plugin to participate in multi-module projects

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/configureThirdPartyPlugins.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/configureThirdPartyPlugins.kt
@@ -16,6 +16,14 @@ fun Project.configureThirdPartyPlugins() {
     pluginManager.apply(IdeaExtPlugin::class.java) //needed so idea can find and index the generated sources from ksp
     pluginManager.apply(ShadowPlugin::class.java)
 
+    // apply the idea plugin to the *root* project.
+    // this is necessary because the IntelliJ IDEA plugin is used for managing some
+    // of our tasks, and its capabilities are available only on the root project.
+    if(this.rootProject != this.project) {
+        this.rootProject.pluginManager.apply(IdeaPlugin::class.java)
+        this.rootProject.pluginManager.apply(IdeaExtPlugin::class.java)
+    }
+
     addKspGeneratedSourcesToMainSourceSet()
 
     afterEvaluate {

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/generateGdIgnoreFilesTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/generateGdIgnoreFilesTask.kt
@@ -8,18 +8,26 @@ fun Project.generateGdIgnoreFilesTask(): TaskProvider<Task> {
     return tasks.register("generateGdIgnoreFiles") {
         with(it) {
             group = "godot-kotlin-jvm"
-            description = "Generates .gdignore files to hide gradle files, kotlin build files and jre files from the godot editor"
+            description = "Generates .gdignore files to hide gradle files, kotlin build files and jre files from the godot editor."
 
             doFirst {
-                val dirsToIgnore = listOf(
+
+                // safety check: make sure that the target project has our plugin
+                if (!this.project.pluginManager.hasPlugin("com.utopia-rise.godot-kotlin-jvm")) {
+                    // the target project doesn't seem to have our plugin; skip.
+                    return@doFirst
+                }
+
+                val projectDir = this.project.projectDir
+                val buildDir = this.project.buildDir
+
+                val targetDirSequence = sequenceOf(
                     buildDir,
                     projectDir.resolve("gradle"),
                     projectDir.resolve("jre-arm64"),
                     projectDir.resolve("jre-amd64"),
                 )
-
-                dirsToIgnore
-                    .filter { dirToIgnore -> dirToIgnore.exists() && dirToIgnore.isDirectory }
+                targetDirSequence.filter { dirToIgnore -> dirToIgnore.exists() && dirToIgnore.isDirectory }
                     .forEach { dirToIgnore ->
                         dirToIgnore.resolve(".gdignore").createNewFile()
                     }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/setupSyncTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/setupSyncTask.kt
@@ -10,9 +10,16 @@ import org.jetbrains.gradle.ext.taskTriggers
 fun Project.setupAfterIdeaSyncTasks(
     generateGdIgnoreFilesTask: TaskProvider<out Task>,
 ) {
-    ideaExtension.project.settings {
+
+    // note: do NOT use "ideaExtension.project.settings" here!
+    // This doesn't work when our plugin is applied to a sub-project in a multi-module gradle build
+    // (the "ideaExtension.project" will return NULL). We can only manage the idea triggers in
+    // the *root* project. From the root project, the task will find the projects which require
+    // further processing on its own.
+    rootProject.ideaExtension.project.settings {
         taskTriggers {
             afterSync(generateGdIgnoreFilesTask)
         }
     }
+
 }


### PR DESCRIPTION
Previously, any attempt at applying the godot-kotlin-jvm gradle plugin to a sub project would fail with a NullPointerException becuase "ideaExtension.project" returns NULL for every gradle project except for the root project. This update addresses the issue by redirecting the task to the root project. This also means that we implicitly have to add the "idea" plugin to the root project as well.

*Edit from @chippmann :* Fixes: #546