### PR TITLE
fix: add intellij gradle plugin to root project with apply false

### DIFF
--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     // prevents the kotlin plugin being applied multiple times (once per subproject) as this is not supported. Done as suggested by the kotlin plugin
     alias(libs.plugins.kotlin.jvm) apply false
     id("com.utopia-rise.versioninfo")
+    alias(libs.plugins.gradleIntelliJPlugin) apply false
 }
 
 version = fullGodotKotlinJvmVersion


### PR DESCRIPTION
quick fix for: https://youtrack.jetbrains.com/issue/IDEA-339602/Gradle-IDEA-Ext-support-classloader-isolation