### PR TITLE
chore: update to godot 4.2.1 and bump module version to 0.8.2

### DIFF
--- a/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
+++ b/.github/workflows/check-pr-engine-editor-debug-and-tests.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       # TODO: remove once on godot 4.2.2 or newer!
       - name: Cherry pick macos fix
         run: |
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       # TODO: remove once on godot 4.2.2 or newer!
       - name: Cherry pick macos fix
         run: |
@@ -174,7 +174,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       # TODO: remove once on godot 4.2.2 or newer!
       - name: Cherry pick macos fix
         run: |

--- a/.github/workflows/check-pr-engine-editor-release.yaml
+++ b/.github/workflows/check-pr-engine-editor-release.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-export-template-debug.yaml
+++ b/.github/workflows/check-pr-engine-export-template-debug.yaml
@@ -3,8 +3,8 @@ on: [pull_request]
 
 env:
   SCONS_CACHE_MSVC_CONFIG: true
-  GODOT_BASE_VERSION: 4.2.0
-  GODOT_BASE_BRANCH: 4.2.0
+  GODOT_BASE_VERSION: 4.2.1
+  GODOT_BASE_BRANCH: 4.2.1
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-check-pr-engine-export-template-debug
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       # TODO: remove once on godot 4.2.2 or newer!
       - name: Cherry pick macos fix
         run: |
@@ -129,7 +129,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-engine-export-template-release.yaml
+++ b/.github/workflows/check-pr-engine-export-template-release.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-entry-generator.yaml
+++ b/.github/workflows/check-pr-entry-generator.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-godot-kotlin-symbol-processor.yaml
+++ b/.github/workflows/check-pr-godot-kotlin-symbol-processor.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/check-pr-jvm-godot-library.yaml
+++ b/.github/workflows/check-pr-jvm-godot-library.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-export-template.yaml
+++ b/.github/workflows/deploy-export-template.yaml
@@ -165,7 +165,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
 
       # TODO: remove once on godot 4.2.2 or newer!
       - name: Cherry pick macos fix
@@ -266,7 +266,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
 
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
@@ -418,7 +418,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
 
       - name: Get release export template binary
         uses: actions/download-artifact@v3
@@ -477,7 +477,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
 
       - name: Get release export template binary
         uses: actions/download-artifact@v3
@@ -618,7 +618,7 @@ jobs:
 
       - name: Create version.txt
         run: |
-          refVersion=4.2-stable #for easier search and replace with other `ref` occurrences
+          refVersion=4.2.1-stable #for easier search and replace with other `ref` occurrences
           templatesVersion=${refVersion//-/.} #replace `-` with `.` in templates version
           echo "$templatesVersion" > templates/version.txt
         shell: bash

--- a/.github/workflows/deploy-godot-editor-release.yaml
+++ b/.github/workflows/deploy-godot-editor-release.yaml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
 
       # TODO: remove once on godot 4.2.2 or newer!
       - name: Cherry pick macos fix
@@ -237,7 +237,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
 
       - name: Get editor binary
         uses: actions/download-artifact@v3

--- a/.github/workflows/deploy-godot-entry-generator.yaml
+++ b/.github/workflows/deploy-godot-entry-generator.yaml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-godot-kotlin-symbol-processor.yaml
+++ b/.github/workflows/deploy-godot-kotlin-symbol-processor.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/deploy-godot-library.yaml
+++ b/.github/workflows/deploy-godot-library.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: godotengine/godot
-          ref: 4.2-stable
+          ref: 4.2.1-stable
       - name: Clone Godot JVM module.
         uses: actions/checkout@v2
         with:

--- a/docs/src/doc/user-guide/versioning.md
+++ b/docs/src/doc/user-guide/versioning.md
@@ -1,7 +1,7 @@
 The module uses semantic versioning for its own versions but adds a suffix for the supported Godot version:
 
-Full version: `0.8.1-4.2.0`
+Full version: `0.8.2-4.2.0`
 
-Module Version: `0.8.1`
+Module Version: `0.8.2`
 
 Supported Godot Version: `4.2.0`

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/BaseMaterial3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/BaseMaterial3D.kt
@@ -2049,27 +2049,27 @@ public open class BaseMaterial3D internal constructor() : Material() {
     id: Long,
   ) {
     /**
-     * The texture filter reads from the nearest pixel only. The simplest and fastest method of filtering, but the texture will look pixelized.
+     * The texture filter reads from the nearest pixel only. This makes the texture look pixelated from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     TEXTURE_FILTER_NEAREST(0),
     /**
-     * The texture filter blends between the nearest 4 pixels. Use this when you want to avoid a pixelated style, but do not want mipmaps.
+     * The texture filter blends between the nearest 4 pixels. This makes the texture look smooth from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     TEXTURE_FILTER_LINEAR(1),
     /**
-     * The texture filter reads from the nearest pixel in the nearest mipmap. The fastest way to read from textures with mipmaps.
+     * The texture filter reads from the nearest pixel and blends between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look pixelated from up close, and smooth from a distance.
      */
     TEXTURE_FILTER_NEAREST_WITH_MIPMAPS(2),
     /**
-     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps. Use this for most cases as mipmaps are important to smooth out pixels that are far from the camera.
+     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look smooth from up close, and smooth from a distance.
      */
     TEXTURE_FILTER_LINEAR_WITH_MIPMAPS(3),
     /**
-     * The texture filter reads from the nearest pixel, but selects a mipmap based on the angle between the surface and the camera view. This reduces artifacts on surfaces that are almost in line with the camera. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
+     * The texture filter reads from the nearest pixel and blends between 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`) based on the angle between the surface and the camera view. This makes the texture look pixelated from up close, and smooth from a distance. Anisotropic filtering improves texture quality on surfaces that are almost in line with the camera, but is slightly slower. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
      */
     TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC(4),
     /**
-     * The texture filter blends between the nearest 4 pixels and selects a mipmap based on the angle between the surface and the camera view. This reduces artifacts on surfaces that are almost in line with the camera. This is the slowest of the filtering options, but results in the highest quality texturing. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
+     * The texture filter blends between the nearest 4 pixels and blends between 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`) based on the angle between the surface and the camera view. This makes the texture look smooth from up close, and smooth from a distance. Anisotropic filtering improves texture quality on surfaces that are almost in line with the camera, but is slightly slower. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
      */
     TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC(5),
     /**

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/CameraAttributesPhysical.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/CameraAttributesPhysical.kt
@@ -107,7 +107,7 @@ public open class CameraAttributesPhysical : CameraAttributes() {
     }
 
   /**
-   * Time for shutter to open and close, measured in seconds. A higher value will let in more light leading to a brighter image, while a lower amount will let in less light leading to a darker image.
+   * Time for shutter to open and close, evaluated as `1 / shutter_speed` seconds. A higher value will allow less light (leading to a darker image), while a lower value will allow more light (leading to a brighter image).
    *
    * Only available when [godot.ProjectSettings.rendering/lightsAndShadows/usePhysicalLightUnits] is enabled.
    */

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/CanvasItem.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/CanvasItem.kt
@@ -1118,31 +1118,35 @@ public open class CanvasItem internal constructor() : Node() {
      */
     TEXTURE_FILTER_PARENT_NODE(0),
     /**
-     * The texture filter reads from the nearest pixel only. The simplest and fastest method of filtering. Useful for pixel art.
+     * The texture filter reads from the nearest pixel only. This makes the texture look pixelated from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     TEXTURE_FILTER_NEAREST(1),
     /**
-     * The texture filter blends between the nearest four pixels. Use this for most cases where you want to avoid a pixelated style.
+     * The texture filter blends between the nearest 4 pixels. This makes the texture look smooth from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     TEXTURE_FILTER_LINEAR(2),
     /**
-     * The texture filter reads from the nearest pixel in the nearest mipmap. This is the fastest way to read from textures with mipmaps.
+     * The texture filter reads from the nearest pixel and blends between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look pixelated from up close, and smooth from a distance.
+     *
+     * Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom or sprite scaling), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
      */
     TEXTURE_FILTER_NEAREST_WITH_MIPMAPS(3),
     /**
-     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps. Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
+     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look smooth from up close, and smooth from a distance.
+     *
+     * Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom or sprite scaling), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
      */
     TEXTURE_FILTER_LINEAR_WITH_MIPMAPS(4),
     /**
-     * The texture filter reads from the nearest pixel, but selects a mipmap based on the angle between the surface and the camera view. This reduces artifacts on surfaces that are almost in line with the camera. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
+     * The texture filter reads from the nearest pixel and blends between 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`) based on the angle between the surface and the camera view. This makes the texture look pixelated from up close, and smooth from a distance. Anisotropic filtering improves texture quality on surfaces that are almost in line with the camera, but is slightly slower. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
      *
-     * **Note:** This texture filter is rarely useful in 2D projects. [TEXTURE_FILTER_NEAREST_WITH_MIPMAPS] is usually more appropriate.
+     * **Note:** This texture filter is rarely useful in 2D projects. [TEXTURE_FILTER_NEAREST_WITH_MIPMAPS] is usually more appropriate in this case.
      */
     TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC(5),
     /**
-     * The texture filter blends between the nearest 4 pixels and selects a mipmap based on the angle between the surface and the camera view. This reduces artifacts on surfaces that are almost in line with the camera. This is the slowest of the filtering options, but results in the highest quality texturing. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
+     * The texture filter blends between the nearest 4 pixels and blends between 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`) based on the angle between the surface and the camera view. This makes the texture look smooth from up close, and smooth from a distance. Anisotropic filtering improves texture quality on surfaces that are almost in line with the camera, but is slightly slower. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
      *
-     * **Note:** This texture filter is rarely useful in 2D projects. [TEXTURE_FILTER_LINEAR_WITH_MIPMAPS] is usually more appropriate.
+     * **Note:** This texture filter is rarely useful in 2D projects. [TEXTURE_FILTER_LINEAR_WITH_MIPMAPS] is usually more appropriate in this case.
      */
     TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC(6),
     /**

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/NavigationLink2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/NavigationLink2D.kt
@@ -9,12 +9,14 @@ package godot
 import godot.`annotation`.CoreTypeHelper
 import godot.`annotation`.CoreTypeLocalCopy
 import godot.`annotation`.GodotBaseType
+import godot.core.RID
 import godot.core.TypeManager
 import godot.core.VariantType.BOOL
 import godot.core.VariantType.DOUBLE
 import godot.core.VariantType.LONG
 import godot.core.VariantType.NIL
 import godot.core.VariantType.VECTOR2
+import godot.core.VariantType._RID
 import godot.core.Vector2
 import godot.core.memory.TransferContext
 import godot.util.VoidPtr
@@ -206,6 +208,15 @@ public open class NavigationLink2D : Node2D() {
 
 
   /**
+   * Returns the [RID] of this link on the [godot.NavigationServer2D].
+   */
+  public fun getRid(): RID {
+    TransferContext.writeArguments()
+    TransferContext.callMethod(rawPtr, MethodBindings.getRidPtr, _RID)
+    return (TransferContext.readReturnValue(_RID, false) as RID)
+  }
+
+  /**
    * Based on [value], enables or disables the specified layer in the [navigationLayers] bitmask, given a [layerNumber] between 1 and 32.
    */
   public fun setNavigationLayerValue(layerNumber: Int, `value`: Boolean): Unit {
@@ -259,6 +270,8 @@ public open class NavigationLink2D : Node2D() {
   public companion object
 
   internal object MethodBindings {
+    public val getRidPtr: VoidPtr = TypeManager.getMethodBindPtr("NavigationLink2D", "get_rid")
+
     public val setEnabledPtr: VoidPtr =
         TypeManager.getMethodBindPtr("NavigationLink2D", "set_enabled")
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/NavigationLink3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/NavigationLink3D.kt
@@ -9,12 +9,14 @@ package godot
 import godot.`annotation`.CoreTypeHelper
 import godot.`annotation`.CoreTypeLocalCopy
 import godot.`annotation`.GodotBaseType
+import godot.core.RID
 import godot.core.TypeManager
 import godot.core.VariantType.BOOL
 import godot.core.VariantType.DOUBLE
 import godot.core.VariantType.LONG
 import godot.core.VariantType.NIL
 import godot.core.VariantType.VECTOR3
+import godot.core.VariantType._RID
 import godot.core.Vector3
 import godot.core.memory.TransferContext
 import godot.util.VoidPtr
@@ -206,6 +208,15 @@ public open class NavigationLink3D : Node3D() {
 
 
   /**
+   * Returns the [RID] of this link on the [godot.NavigationServer3D].
+   */
+  public fun getRid(): RID {
+    TransferContext.writeArguments()
+    TransferContext.callMethod(rawPtr, MethodBindings.getRidPtr, _RID)
+    return (TransferContext.readReturnValue(_RID, false) as RID)
+  }
+
+  /**
    * Based on [value], enables or disables the specified layer in the [navigationLayers] bitmask, given a [layerNumber] between 1 and 32.
    */
   public fun setNavigationLayerValue(layerNumber: Int, `value`: Boolean): Unit {
@@ -259,6 +270,8 @@ public open class NavigationLink3D : Node3D() {
   public companion object
 
   internal object MethodBindings {
+    public val getRidPtr: VoidPtr = TypeManager.getMethodBindPtr("NavigationLink3D", "get_rid")
+
     public val setEnabledPtr: VoidPtr =
         TypeManager.getMethodBindPtr("NavigationLink3D", "set_enabled")
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/NavigationRegion2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/NavigationRegion2D.kt
@@ -180,6 +180,15 @@ public open class NavigationRegion2D : Node2D() {
   }
 
   /**
+   * Returns the [RID] of this region on the [godot.NavigationServer2D]. Combined with [godot.NavigationServer2D.mapGetClosestPointOwner] can be used to identify the [godot.NavigationRegion2D] closest to a point on the merged navigation map.
+   */
+  public fun getRid(): RID {
+    TransferContext.writeArguments()
+    TransferContext.callMethod(rawPtr, MethodBindings.getRidPtr, _RID)
+    return (TransferContext.readReturnValue(_RID, false) as RID)
+  }
+
+  /**
    * Sets the [RID] of the navigation map this region should use. By default the region will automatically join the [godot.World2D] default navigation map so this function is only required to override the default map.
    */
   public fun setNavigationMap(navigationMap: RID): Unit {
@@ -231,7 +240,9 @@ public open class NavigationRegion2D : Node2D() {
   }
 
   /**
-   * Returns the [RID] of this region on the [godot.NavigationServer2D]. Combined with [godot.NavigationServer2D.mapGetClosestPointOwner] can be used to identify the [godot.NavigationRegion2D] closest to a point on the merged navigation map.
+   * Returns the [RID] of this region on the [godot.NavigationServer2D].
+   *
+   * *Deprecated.* Use [getRid] instead.
    */
   public fun getRegionRid(): RID {
     TransferContext.writeArguments()
@@ -251,6 +262,8 @@ public open class NavigationRegion2D : Node2D() {
   public companion object
 
   internal object MethodBindings {
+    public val getRidPtr: VoidPtr = TypeManager.getMethodBindPtr("NavigationRegion2D", "get_rid")
+
     public val setNavigationPolygonPtr: VoidPtr =
         TypeManager.getMethodBindPtr("NavigationRegion2D", "set_navigation_polygon")
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/NavigationRegion3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/NavigationRegion3D.kt
@@ -150,6 +150,15 @@ public open class NavigationRegion3D : Node3D() {
   }
 
   /**
+   * Returns the [RID] of this region on the [godot.NavigationServer3D]. Combined with [godot.NavigationServer3D.mapGetClosestPointOwner] can be used to identify the [godot.NavigationRegion3D] closest to a point on the merged navigation map.
+   */
+  public fun getRid(): RID {
+    TransferContext.writeArguments()
+    TransferContext.callMethod(rawPtr, MethodBindings.getRidPtr, _RID)
+    return (TransferContext.readReturnValue(_RID, false) as RID)
+  }
+
+  /**
    * Sets the [RID] of the navigation map this region should use. By default the region will automatically join the [godot.World3D] default navigation map so this function is only required to override the default map.
    */
   public fun setNavigationMap(navigationMap: RID): Unit {
@@ -184,7 +193,9 @@ public open class NavigationRegion3D : Node3D() {
   }
 
   /**
-   * Returns the [RID] of this region on the [godot.NavigationServer3D]. Combined with [godot.NavigationServer3D.mapGetClosestPointOwner] can be used to identify the [godot.NavigationRegion3D] closest to a point on the merged navigation map.
+   * Returns the [RID] of this region on the [godot.NavigationServer3D].
+   *
+   * *Deprecated.* Use [getRid] instead.
    */
   public fun getRegionRid(): RID {
     TransferContext.writeArguments()
@@ -204,6 +215,8 @@ public open class NavigationRegion3D : Node3D() {
   public companion object
 
   internal object MethodBindings {
+    public val getRidPtr: VoidPtr = TypeManager.getMethodBindPtr("NavigationRegion3D", "get_rid")
+
     public val setNavigationMeshPtr: VoidPtr =
         TypeManager.getMethodBindPtr("NavigationRegion3D", "set_navigation_mesh")
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/RenderingServer.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/RenderingServer.kt
@@ -7449,27 +7449,35 @@ public object RenderingServer : Object() {
      */
     CANVAS_ITEM_TEXTURE_FILTER_DEFAULT(0),
     /**
-     * The texture filter reads from the nearest pixel only. The simplest and fastest method of filtering, but the texture will look pixelized.
+     * The texture filter reads from the nearest pixel only. This makes the texture look pixelated from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     CANVAS_ITEM_TEXTURE_FILTER_NEAREST(1),
     /**
-     * The texture filter blends between the nearest 4 pixels. Use this when you want to avoid a pixelated style, but do not want mipmaps.
+     * The texture filter blends between the nearest 4 pixels. This makes the texture look smooth from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     CANVAS_ITEM_TEXTURE_FILTER_LINEAR(2),
     /**
-     * The texture filter reads from the nearest pixel in the nearest mipmap. The fastest way to read from textures with mipmaps.
+     * The texture filter reads from the nearest pixel and blends between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look pixelated from up close, and smooth from a distance.
+     *
+     * Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom or sprite scaling), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
      */
     CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS(3),
     /**
-     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps.
+     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look smooth from up close, and smooth from a distance.
+     *
+     * Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom or sprite scaling), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
      */
     CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS(4),
     /**
-     * The texture filter reads from the nearest pixel, but selects a mipmap based on the angle between the surface and the camera view. This reduces artifacts on surfaces that are almost in line with the camera.
+     * The texture filter reads from the nearest pixel and blends between 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`) based on the angle between the surface and the camera view. This makes the texture look pixelated from up close, and smooth from a distance. Anisotropic filtering improves texture quality on surfaces that are almost in line with the camera, but is slightly slower. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
+     *
+     * **Note:** This texture filter is rarely useful in 2D projects. [CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS] is usually more appropriate in this case.
      */
     CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC(5),
     /**
-     * The texture filter blends between the nearest 4 pixels and selects a mipmap based on the angle between the surface and the camera view. This reduces artifacts on surfaces that are almost in line with the camera. This is the slowest of the filtering options, but results in the highest quality texturing.
+     * The texture filter blends between the nearest 4 pixels and blends between 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`) based on the angle between the surface and the camera view. This makes the texture look smooth from up close, and smooth from a distance. Anisotropic filtering improves texture quality on surfaces that are almost in line with the camera, but is slightly slower. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
+     *
+     * **Note:** This texture filter is rarely useful in 2D projects. [CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS] is usually more appropriate in this case.
      */
     CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC(6),
     /**

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/VideoStreamPlayer.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/VideoStreamPlayer.kt
@@ -39,8 +39,6 @@ import kotlin.Unit
  *
  * Supported video formats are [godot.Ogg Theora](https://www.theora.org/) (`.ogv`, [godot.VideoStreamTheora]) and any format exposed via a GDExtension plugin.
  *
- * **Note:** Due to a bug, VideoStreamPlayer does not support localization remapping yet.
- *
  * **Warning:** On Web, video playback *will* perform poorly due to missing architecture-specific assembly optimizations.
  */
 @GodotBaseType

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Viewport.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Viewport.kt
@@ -1420,19 +1420,23 @@ public open class Viewport internal constructor() : Node() {
     id: Long,
   ) {
     /**
-     * The texture filter reads from the nearest pixel only. The simplest and fastest method of filtering, but the texture will look pixelized.
+     * The texture filter reads from the nearest pixel only. This makes the texture look pixelated from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_NEAREST(0),
     /**
-     * The texture filter blends between the nearest 4 pixels. Use this when you want to avoid a pixelated style, but do not want mipmaps.
+     * The texture filter blends between the nearest 4 pixels. This makes the texture look smooth from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_LINEAR(1),
     /**
-     * The texture filter reads from the nearest pixel in the nearest mipmap. The fastest way to read from textures with mipmaps.
+     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look smooth from up close, and smooth from a distance.
+     *
+     * Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom or sprite scaling), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
      */
     DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS(2),
     /**
-     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps.
+     * The texture filter reads from the nearest pixel and blends between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look pixelated from up close, and smooth from a distance.
+     *
+     * Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom or sprite scaling), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
      */
     DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS(3),
     /**

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/VisualShaderNodeTextureParameter.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/VisualShaderNodeTextureParameter.kt
@@ -174,31 +174,35 @@ public open class VisualShaderNodeTextureParameter internal constructor() :
      */
     FILTER_DEFAULT(0),
     /**
-     * The texture filter reads from the nearest pixel only. The simplest and fastest method of filtering, but the texture will look pixelized.
+     * The texture filter reads from the nearest pixel only. This makes the texture look pixelated from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     FILTER_NEAREST(1),
     /**
-     * The texture filter blends between the nearest four pixels. Use this for most cases where you want to avoid a pixelated style.
+     * The texture filter blends between the nearest 4 pixels. This makes the texture look smooth from up close, and grainy from a distance (due to mipmaps not being sampled).
      */
     FILTER_LINEAR(2),
     /**
-     * The texture filter reads from the nearest pixel in the nearest mipmap. This is the fastest way to read from textures with mipmaps.
+     * The texture filter reads from the nearest pixel and blends between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look pixelated from up close, and smooth from a distance.
+     *
+     * Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom or sprite scaling), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
      */
     FILTER_NEAREST_MIPMAP(3),
     /**
-     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps. Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
+     * The texture filter blends between the nearest 4 pixels and between the nearest 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`). This makes the texture look smooth from up close, and smooth from a distance.
+     *
+     * Use this for non-pixel art textures that may be viewed at a low scale (e.g. due to [godot.Camera2D] zoom or sprite scaling), as mipmaps are important to smooth out pixels that are smaller than on-screen pixels.
      */
     FILTER_LINEAR_MIPMAP(4),
     /**
-     * The texture filter reads from the nearest pixel, but selects a mipmap based on the angle between the surface and the camera view. This reduces artifacts on surfaces that are almost in line with the camera. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
+     * The texture filter reads from the nearest pixel and blends between 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`) based on the angle between the surface and the camera view. This makes the texture look pixelated from up close, and smooth from a distance. Anisotropic filtering improves texture quality on surfaces that are almost in line with the camera, but is slightly slower. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
      *
-     * **Note:** This texture filter is rarely useful in 2D projects. [FILTER_LINEAR_MIPMAP] is usually more appropriate.
+     * **Note:** This texture filter is rarely useful in 2D projects. [FILTER_NEAREST_MIPMAP] is usually more appropriate in this case.
      */
     FILTER_NEAREST_MIPMAP_ANISOTROPIC(5),
     /**
-     * The texture filter blends between the nearest 4 pixels and selects a mipmap based on the angle between the surface and the camera view. This reduces artifacts on surfaces that are almost in line with the camera. This is the slowest of the filtering options, but results in the highest quality texturing. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
+     * The texture filter blends between the nearest 4 pixels and blends between 2 mipmaps (or uses the nearest mipmap if [godot.ProjectSettings.rendering/textures/defaultFilters/useNearestMipmapFilter] is `true`) based on the angle between the surface and the camera view. This makes the texture look smooth from up close, and smooth from a distance. Anisotropic filtering improves texture quality on surfaces that are almost in line with the camera, but is slightly slower. The anisotropic filtering level can be changed by adjusting [godot.ProjectSettings.rendering/textures/defaultFilters/anisotropicFilteringLevel].
      *
-     * **Note:** This texture filter is rarely useful in 2D projects. [FILTER_LINEAR_MIPMAP] is usually more appropriate.
+     * **Note:** This texture filter is rarely useful in 2D projects. [FILTER_LINEAR_MIPMAP] is usually more appropriate in this case.
      */
     FILTER_LINEAR_MIPMAP_ANISOTROPIC(6),
     /**

--- a/kt/gradle/libs.versions.toml
+++ b/kt/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 
-godotKotlinJvm = "0.8.1"
+godotKotlinJvm = "0.8.2"
 kotlin = "1.9.0"
-godot = "4.2.0"
+godot = "4.2.1"
 
 shadowJar = "8.1.1" # https://github.com/johnrengelman/shadow/releases
 kotlinPoet = "1.12.0" # https://github.com/square/kotlinpoet/releases


### PR DESCRIPTION
This updates api to godot `4.2.1`.
This bump module version to `0.8.2`.