### PR TITLE
Add option to pass arguments to scene JVM

### DIFF
--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -154,6 +154,10 @@ void GDKotlin::init() {
         }
     }
 
+    if (!Engine::get_singleton()->is_editor_hint()) {
+        args.option(configuration.get_scene_jvm_args().utf8());
+    }
+
     if (!jvm_debug_port.is_empty() || !jvm_debug_address.is_empty()) {
         if (jvm_debug_address.is_empty()) {
             jvm_debug_address = "*";

--- a/src/gd_kotlin_configuration.cpp
+++ b/src/gd_kotlin_configuration.cpp
@@ -54,7 +54,7 @@ GdKotlinConfiguration GdKotlinConfiguration::from_json(const String& json_string
     Variant max_string_size_variant {dictionary[max_string_size_identifier]};
     if (max_string_size_variant.get_type() == Variant::INT) { max_string_size = max_string_size_variant; }
 
-    String scene_jvm_args {""};
+    String scene_jvm_args;
     Variant scene_jvm_args_variant {dictionary[scene_jvm_args_identifier]};
     if (scene_jvm_args_variant.get_type() == Variant::STRING) { scene_jvm_args = scene_jvm_args_variant; }
 
@@ -97,20 +97,20 @@ void GdKotlinConfiguration::set_max_string_size(int p_max_string_size) {
     max_string_size = p_max_string_size;
 }
 
-String GdKotlinConfiguration::get_scene_jvm_args() const {
+const String& GdKotlinConfiguration::get_scene_jvm_args() const {
     return scene_jvm_args;
 }
 
-void GdKotlinConfiguration::set_jvm_scene_args(String p_scene_jvm_args) {
+void GdKotlinConfiguration::set_jvm_scene_args(const String& p_scene_jvm_args) {
     scene_jvm_args = p_scene_jvm_args;
 }
 
 GdKotlinConfiguration::GdKotlinConfiguration() :
   vm_type(jni::Jvm::JVM),
   max_string_size(LongStringQueue::max_string_size),
-  scene_jvm_args("") {}
+  scene_jvm_args() {}
 
-GdKotlinConfiguration::GdKotlinConfiguration(jni::Jvm::Type p_vm_type, int p_max_string_size, String p_scene_jvm_args) :
+GdKotlinConfiguration::GdKotlinConfiguration(jni::Jvm::Type p_vm_type, int p_max_string_size, const String& p_scene_jvm_args) :
   vm_type(p_vm_type),
   max_string_size(p_max_string_size),
   scene_jvm_args(p_scene_jvm_args) {}

--- a/src/gd_kotlin_configuration.cpp
+++ b/src/gd_kotlin_configuration.cpp
@@ -54,7 +54,11 @@ GdKotlinConfiguration GdKotlinConfiguration::from_json(const String& json_string
     Variant max_string_size_variant {dictionary[max_string_size_identifier]};
     if (max_string_size_variant.get_type() == Variant::INT) { max_string_size = max_string_size_variant; }
 
-    return GdKotlinConfiguration(vm_type, max_string_size);
+    String scene_jvm_args {""};
+    Variant scene_jvm_args_variant {dictionary[scene_jvm_args_identifier]};
+    if (scene_jvm_args_variant.get_type() == Variant::STRING) { scene_jvm_args = scene_jvm_args_variant; }
+
+    return GdKotlinConfiguration(vm_type, max_string_size, scene_jvm_args);
 }
 
 GdKotlinConfiguration GdKotlinConfiguration::load_gd_kotlin_configuration_or_default(const String& configuration_path) {
@@ -93,10 +97,20 @@ void GdKotlinConfiguration::set_max_string_size(int p_max_string_size) {
     max_string_size = p_max_string_size;
 }
 
+String GdKotlinConfiguration::get_scene_jvm_args() const {
+    return scene_jvm_args;
+}
+
+void GdKotlinConfiguration::set_jvm_scene_args(String p_scene_jvm_args) {
+    scene_jvm_args = p_scene_jvm_args;
+}
+
 GdKotlinConfiguration::GdKotlinConfiguration() :
   vm_type(jni::Jvm::JVM),
-  max_string_size(LongStringQueue::max_string_size) {}
+  max_string_size(LongStringQueue::max_string_size),
+  scene_jvm_args("") {}
 
-GdKotlinConfiguration::GdKotlinConfiguration(jni::Jvm::Type p_vm_type, int p_max_string_size) :
+GdKotlinConfiguration::GdKotlinConfiguration(jni::Jvm::Type p_vm_type, int p_max_string_size, String p_scene_jvm_args) :
   vm_type(p_vm_type),
-  max_string_size(p_max_string_size) {}
+  max_string_size(p_max_string_size),
+  scene_jvm_args(p_scene_jvm_args) {}

--- a/src/gd_kotlin_configuration.h
+++ b/src/gd_kotlin_configuration.h
@@ -15,8 +15,8 @@ public:
     int get_max_string_size() const;
     void set_max_string_size(int p_max_string_size);
 
-    String get_scene_jvm_args() const;
-    void set_jvm_scene_args(String p_scene_jvm_args);
+    const String& get_scene_jvm_args() const;
+    void set_jvm_scene_args(const String& p_scene_jvm_args);
 
     ~GdKotlinConfiguration() = default;
 
@@ -35,7 +35,7 @@ private:
     static constexpr const char* max_string_size_identifier {"max_string_size"};
     static constexpr const char* scene_jvm_args_identifier {"scene_jvm_args"};
 
-    GdKotlinConfiguration(jni::Jvm::Type p_vm_type, int p_max_string_size, String p_scene_jvm_args);
+    GdKotlinConfiguration(jni::Jvm::Type p_vm_type, int p_max_string_size, const String& p_scene_jvm_args);
 };
 
 #endif// GODOT_JVM_GD_KOTLIN_CONFIGURATION_H

--- a/src/gd_kotlin_configuration.h
+++ b/src/gd_kotlin_configuration.h
@@ -15,6 +15,9 @@ public:
     int get_max_string_size() const;
     void set_max_string_size(int p_max_string_size);
 
+    String get_scene_jvm_args() const;
+    void set_jvm_scene_args(String p_scene_jvm_args);
+
     ~GdKotlinConfiguration() = default;
 
     static constexpr const char* jvm_string_identifier {"jvm"};
@@ -26,11 +29,13 @@ public:
 private:
     jni::Jvm::Type vm_type;
     int max_string_size;
+    String scene_jvm_args;
 
     static constexpr const char* vm_type_identifier {"vm_type"};
     static constexpr const char* max_string_size_identifier {"max_string_size"};
+    static constexpr const char* scene_jvm_args_identifier {"scene_jvm_args"};
 
-    GdKotlinConfiguration(jni::Jvm::Type p_vm_type, int p_max_string_size);
+    GdKotlinConfiguration(jni::Jvm::Type p_vm_type, int p_max_string_size, String p_scene_jvm_args);
 };
 
 #endif// GODOT_JVM_GD_KOTLIN_CONFIGURATION_H


### PR DESCRIPTION
This add new parameter to `godot_kotlin_configuration.json` to pass argument to the JVM, which runs in the scene regardless of whether the scene was launch from editor or from command line.
My use case is possibility of writing Kotlin code and connecting debugger in IntelliJ and at the same time running scene from Godot editor. For example
```
{"max_string_size":512,"vm_type":"jvm","scene_jvm_args":"-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005"}
```
Also it can be used for any JVM arguments. I will add docs after we agree on parameter name.