### PR TITLE
Fix export iOS template 

### DIFF
--- a/.github/workflows/deploy-export-template.yaml
+++ b/.github/workflows/deploy-export-template.yaml
@@ -502,12 +502,12 @@ jobs:
 
       - name: Create iOS template app
         run: |
-          cp -r misc/dist/ios_xcode .
-          cp -r MoltenVK/Package/Release/MoltenVK/MoltenVK.xcframework ios_xcode/
+          cp -r misc/dist/ios .
+          cp -r MoltenVK/Package/Release/MoltenVK/MoltenVK.xcframework ios/
           mkdir -p macos_template.app/Contents/MacOS
-          cp libgodot.ios.template_release.arm64.a ios_xcode/libgodot.ios.release.xcframework/ios-arm64/libgodot.a
-          cp libgodot.ios.template_debug.arm64.a ios_xcode/libgodot.ios.debug.xcframework/ios-arm64/libgodot.a
-          zip -q -9 -r ios.zip ios_xcode
+          cp libgodot.ios.template_release.arm64.a ios/libgodot.ios.release.xcframework/ios-arm64/libgodot.a
+          cp libgodot.ios.template_debug.arm64.a ios/libgodot.ios.debug.xcframework/ios-arm64/libgodot.a
+          zip -q -9 -r ios.zip ios
 
       - name: Upload iOS template app
         uses: actions/upload-artifact@v3

--- a/docs/src/doc/user-guide/versioning.md
+++ b/docs/src/doc/user-guide/versioning.md
@@ -1,7 +1,7 @@
 The module uses semantic versioning for its own versions but adds a suffix for the supported Godot version:
 
-Full version: `0.8.2-4.2.0`
+Full version: `0.8.3-4.2.1`
 
-Module Version: `0.8.2`
+Module Version: `0.8.3`
 
-Supported Godot Version: `4.2.0`
+Supported Godot Version: `4.2.1`

--- a/kt/gradle/libs.versions.toml
+++ b/kt/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-godotKotlinJvm = "0.8.2"
+godotKotlinJvm = "0.8.3"
 kotlin = "1.9.0"
 godot = "4.2.1"
 


### PR DESCRIPTION
Export for iOS was failing because Godot was looking for the `ios` folder. However, the current artifact was named `ios_xcode`, so the resolution for the building files was unsuccessful.

