### PR TITLE
Fix gdj update in editor with custom android gradle project in godot

### DIFF
--- a/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/GodotKotlinSymbolProcessor.kt
+++ b/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/GodotKotlinSymbolProcessor.kt
@@ -112,6 +112,7 @@ class GodotKotlinSymbolProcessor(
     private fun provideExistingRegistrationFiles(): Map<String, File> {
         val excludedDirs = listOf(
             "build", // needs to be excluded so the registration files generated from ksp are not counted as existing registration files
+            "android", // needs to be excluded as godot copies every godot asset to the embedded android gradle project located in this directory which includes our gdj files. Thus we would never update them.
         )
         return settings
             .projectBaseDir


### PR DESCRIPTION
This fixes a reloading bug when the user creates a custom android gradle project inside the godot editor (see #581).
This thus is a follow up bugfix of #581

Whenever a build with such a custom godot android project is executed, godot copies all assets to the android project located at `res://android` which includes our gdj files.

When our gdj tasks run, they check the project for any existing gdj files to keep track of those the user moves manually to a different location and delete stale ones. This breaks if the user has such a custom godot android gradle project as there all the gdj files are containes as well.

As a fix, we simply exclude that directory from our search (like we already do for the build directory)