### PR TITLE
Source files are now exported without the code.

### DIFF
--- a/src/kotlin_editor_export_plugin.h
+++ b/src/kotlin_editor_export_plugin.h
@@ -14,6 +14,12 @@ public:
     void _export_begin(const HashSet<String>& p_features, bool p_debug, const String& p_path, int p_flags) override;
     String get_name() const override;
 
+    // Source files editions
+    bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) override;
+    uint64_t _get_customization_configuration_hash() const override;
+    Ref<Resource> _customize_resource(const Ref<Resource> &p_resource, const String &p_path) override;
+
+
 private:
     void _generate_export_configuration_file(jni::Jvm::Type vm_type);
     static void _copy_jre_to(const char* jre_folder, Ref<DirAccess> dir_access);


### PR DESCRIPTION
Implements #591
Pretty straightforward to implement.
It's not easy to check if the exported files are actually empty because Godot embeds all of them in its own file format full of meta-data and with the content encoded (even without encryption)

So I compared the size of a simple script exported by the editor before/after this commit.
Before: 767 Bytes
After: 241 Bytes

I think it's safe to say that it's working.