### PR TITLE
Improve Env class and its uses

### DIFF
--- a/src/binding/kotlin_binding.cpp
+++ b/src/binding/kotlin_binding.cpp
@@ -13,7 +13,8 @@ void KotlinBinding::refcount_incremented_unsafe() {
     if (refcount > 1 && kt_binding->is_ref_weak()) {
         // The JVM holds a reference to that object already, if the counter is greater than 1, it means the native side holds a reference as well.
         // The reference is changed to a strong one so the JVM instance is not collected if it is not referenced anymore on the JVM side.
-        kt_binding->swap_to_strong_unsafe();
+        jni::Env env {jni::Jvm::current_env()};
+        kt_binding->swap_to_strong_unsafe(env);
     }
 }
 
@@ -28,7 +29,8 @@ bool KotlinBinding::refcount_decremented_unsafe() {
     if (refcount == 1 && !kt_binding->is_ref_weak()) {
         // The JVM holds a reference to that object already, if the counter is equal to 1, it means the JVM is the only side with a reference to the object.
         // The reference is changed to a weak one so the JVM instance can be collected if it is not referenced anymore on the JVM side.
-        kt_binding->swap_to_weak_unsafe();
+        jni::Env env {jni::Jvm::current_env()};
+        kt_binding->swap_to_weak_unsafe(env);
     }
     // Return true when the counter is 0, it means that the JVM and the native side are no longer using the reference, so it can be safely deleted.
     return refcount == 0;
@@ -36,7 +38,9 @@ bool KotlinBinding::refcount_decremented_unsafe() {
 
 void KotlinBinding::set_kt_binding(jni::JObject j_object) {
     JVM_CRASH_COND_MSG(kt_binding, "Trying to set a KtBinding on an already bound Object");
-    kt_binding = memnew(KtBinding(j_object));
+
+    jni::Env env {jni::Jvm::current_env()};
+    kt_binding = memnew(KtBinding(env, j_object));
 
     if (!owner->is_ref_counted()) {
         return;
@@ -48,7 +52,7 @@ void KotlinBinding::set_kt_binding(jni::JObject j_object) {
     if (refcount == 1 && !kt_binding->is_ref_weak()) {
         // The JVM holds a reference to that object already, if the counter is equal to 1, it means the JVM is the only side with a reference to the object.
         // The reference is changed to a weak one so the JVM instance can be collected if it is not referenced anymore on the JVM side.
-        kt_binding->swap_to_weak_unsafe();
+        kt_binding->swap_to_weak_unsafe(env);
     }
     status = BindingStatus::BOUND;
 }

--- a/src/jni/env.h
+++ b/src/jni/env.h
@@ -19,7 +19,7 @@ namespace jni {
     class Env {
     public:
         explicit Env(JNIEnv*);
-        // todo delete copy ctor and assignment?
+
         Env(const Env&) = default;
         Env& operator=(const Env&) = default;
 

--- a/src/jni/jvm.h
+++ b/src/jni/jvm.h
@@ -36,7 +36,6 @@ namespace jni {
     private:
         Jvm() = default;
         static JavaVM* vm;
-        static Env* env;
         static jint version;
         static Type vm_type;
 

--- a/src/jni/platforms/jvm_android.cpp
+++ b/src/jni/platforms/jvm_android.cpp
@@ -6,7 +6,6 @@
 
 namespace jni {
     JavaVM* Jvm::vm = nullptr;
-    Env* Jvm::env = nullptr;
     jint Jvm::version = 0;
     Jvm::Type Jvm::vm_type {Jvm::ART};
 

--- a/src/jni_lifecycle_manager.cpp
+++ b/src/jni_lifecycle_manager.cpp
@@ -21,44 +21,44 @@
 #include "jvm_wrapper/memory/transfer_context.h"
 #include "jvm_wrapper/registration//kt_class.h"
 
-void JniLifecycleManager::initialize_jni_classes() {
+void JniLifecycleManager::initialize_jni_classes(jni::Env& p_env) {
     // Singleton
-    TransferContext::initialize();
-    TypeManager::initialize();
-    LongStringQueue::initialize();
-    MemoryManager::initialize();
+    TransferContext::initialize(p_env);
+    TypeManager::initialize(p_env);
+    LongStringQueue::initialize(p_env);
+    MemoryManager::initialize(p_env);
 
-    bridges::GDPrintBridge::initialize();
+    bridges::GDPrintBridge::initialize(p_env);
 
-    bridges::CallableBridge::initialize();
-    bridges::DictionaryBridge::initialize();
-    bridges::RidBridge::initialize();
-    bridges::StringNameBridge::initialize();
-    bridges::NodePathBridge::initialize();
-    bridges::VariantArrayBridge::initialize();
+    bridges::CallableBridge::initialize(p_env);
+    bridges::DictionaryBridge::initialize(p_env);
+    bridges::RidBridge::initialize(p_env);
+    bridges::StringNameBridge::initialize(p_env);
+    bridges::NodePathBridge::initialize(p_env);
+    bridges::VariantArrayBridge::initialize(p_env);
 
-    bridges::PackedByteArrayBridge::initialize();
-    bridges::PackedColorArrayBridge::initialize();
-    bridges::PackedFloat32ArrayBridge::initialize();
-    bridges::PackedFloat64ArrayBridge::initialize();
-    bridges::PackedInt32IntArrayBridge::initialize();
-    bridges::PackedInt64IntArrayBridge::initialize();
-    bridges::PackedStringArrayBridge::initialize();
-    bridges::PackedVector2ArrayBridge::initialize();
-    bridges::PackedVector3ArrayBridge::initialize();
+    bridges::PackedByteArrayBridge::initialize(p_env);
+    bridges::PackedColorArrayBridge::initialize(p_env);
+    bridges::PackedFloat32ArrayBridge::initialize(p_env);
+    bridges::PackedFloat64ArrayBridge::initialize(p_env);
+    bridges::PackedInt32IntArrayBridge::initialize(p_env);
+    bridges::PackedInt64IntArrayBridge::initialize(p_env);
+    bridges::PackedStringArrayBridge::initialize(p_env);
+    bridges::PackedVector2ArrayBridge::initialize(p_env);
+    bridges::PackedVector3ArrayBridge::initialize(p_env);
 
     //Instance
-    Bootstrap::initialize_jni_binding();
-    KtObject::initialize_jni_binding();
+    Bootstrap::initialize_jni_binding(p_env);
+    KtObject::initialize_jni_binding(p_env);
 
-    KtPropertyInfo::initialize_jni_binding();
-    KtProperty::initialize_jni_binding();
-    KtConstructor::initialize_jni_binding();
-    KtSignalInfo::initialize_jni_binding();
-    KtRpcConfig::initialize_jni_binding();
-    KtFunctionInfo::initialize_jni_binding();
-    KtFunction::initialize_jni_binding();
-    KtClass::initialize_jni_binding();
+    KtPropertyInfo::initialize_jni_binding(p_env);
+    KtProperty::initialize_jni_binding(p_env);
+    KtConstructor::initialize_jni_binding(p_env);
+    KtSignalInfo::initialize_jni_binding(p_env);
+    KtRpcConfig::initialize_jni_binding(p_env);
+    KtFunctionInfo::initialize_jni_binding(p_env);
+    KtFunction::initialize_jni_binding(p_env);
+    KtClass::initialize_jni_binding(p_env);
 }
 
 void JniLifecycleManager::destroy_jni_classes() {

--- a/src/jni_lifecycle_manager.h
+++ b/src/jni_lifecycle_manager.h
@@ -1,9 +1,11 @@
 #ifndef GODOT_JVM_JNI_LIFECYCLE_MANAGER_H
 #define GODOT_JVM_JNI_LIFECYCLE_MANAGER_H
 
+#include "jni/env.h"
+
 class JniLifecycleManager {
 public:
-    static void initialize_jni_classes();
+    static void initialize_jni_classes(jni::Env& p_env);
     static void destroy_jni_classes();
 };
 

--- a/src/jvm_wrapper/bootstrap.cpp
+++ b/src/jvm_wrapper/bootstrap.cpp
@@ -34,7 +34,7 @@ void Bootstrap::register_engine_type(JNIEnv* p_env, jobject p_this, jobjectArray
 #endif
 }
 
-Bootstrap::Bootstrap(jni::JObject p_wrapped) : JvmInstanceWrapper(p_wrapped) {}
+Bootstrap::Bootstrap(jni::Env& p_env, jni::JObject p_wrapped) : JvmInstanceWrapper(p_env, p_wrapped) {}
 
 
 void Bootstrap::init(jni::Env& p_env, bool p_is_editor, const String& p_project_path, const String& p_jar_path, const String& p_jar_file, const jni::JObject& p_class_loader) {

--- a/src/jvm_wrapper/bootstrap.h
+++ b/src/jvm_wrapper/bootstrap.h
@@ -25,7 +25,7 @@ public:
       jobjectArray p_singleton_names
     );
 
-    explicit Bootstrap(jni::JObject p_wrapped);
+    Bootstrap(jni::Env& p_env, jni::JObject p_wrapped);
     ~Bootstrap() = default;
 
     void init(jni::Env& p_env, bool p_is_editor, const String& p_project_path, const String& p_jar_path, const String& p_jar_file, const jni::JObject& p_class_loader);

--- a/src/jvm_wrapper/jvm_singleton_wrapper.h
+++ b/src/jvm_wrapper/jvm_singleton_wrapper.h
@@ -1,24 +1,25 @@
 #ifndef GODOT_JVM_JVM_SINGLETON_WRAPPER_H
 #define GODOT_JVM_JVM_SINGLETON_WRAPPER_H
 
-#include "jvm_instance_wrapper.h"
 #include "jni_lifecycle_manager.h"
+#include "jvm_instance_wrapper.h"
 
-#define JVM_SINGLETON_WRAPPER(NAME, FQNAME)        \
+#define JVM_SINGLETON_WRAPPER(NAME, FQNAME)               \
     inline constexpr char NAME##QualifiedName[] = FQNAME; \
     class NAME : public JvmSingletonWrapper<NAME, NAME##QualifiedName>
 
-#define SINGLETON_CLASS(NAME)                                                                            \
-    friend class JvmSingletonWrapper<NAME, NAME##QualifiedName>;                                         \
-                                                                                                         \
-public:                                                                                                  \
-    NAME(const NAME&) = delete;                                                                          \
-    void operator=(const NAME&) = delete;                                                                \
-    NAME& operator=(NAME&&) noexcept = delete;                                                           \
-    NAME(NAME&&) noexcept = delete;                                                                      \
-                                                                                                         \
-protected:                                                                                               \
-    explicit NAME(jni::JObject p_wrapped) : JvmSingletonWrapper<NAME, NAME##QualifiedName>(p_wrapped) {} \
+#define SINGLETON_CLASS(NAME)                                             \
+    friend class JvmSingletonWrapper<NAME, NAME##QualifiedName>;          \
+                                                                          \
+public:                                                                   \
+    NAME(const NAME&) = delete;                                           \
+    void operator=(const NAME&) = delete;                                 \
+    NAME& operator=(NAME&&) noexcept = delete;                            \
+    NAME(NAME&&) noexcept = delete;                                       \
+                                                                          \
+protected:                                                                \
+    explicit NAME(jni::Env& p_env, jni::JObject p_wrapped) :              \
+      JvmSingletonWrapper<NAME, NAME##QualifiedName>(p_env, p_wrapped) {} \
     ~NAME();
 
 /**
@@ -36,11 +37,11 @@ class JvmSingletonWrapper : public JvmInstanceWrapper<Derived, FqName> {
 
     static Derived* _instance;
 
-    static void initialize();
+    static void initialize(jni::Env& p_env);
     static void destroy();
 
 protected:
-    explicit JvmSingletonWrapper(jni::JObject p_wrapped);
+    JvmSingletonWrapper(jni::Env& p_env, jni::JObject p_wrapped);
     ~JvmSingletonWrapper() = default;
 
 public:
@@ -51,11 +52,11 @@ public:
     JvmSingletonWrapper<Derived, FqName>& operator=(JvmSingletonWrapper<Derived, FqName>&&) noexcept = delete;
     JvmSingletonWrapper(JvmSingletonWrapper<Derived, FqName>&& instance) noexcept = delete;
 
-    static Derived* create_instance();
+    static Derived* create_instance(jni::Env& p_env);
 };
 
 template<class Derived, const char* FqName>
-Derived* JvmSingletonWrapper<Derived, FqName>::create_instance() {
+Derived* JvmSingletonWrapper<Derived, FqName>::create_instance(jni::Env& p_env) {
     LOG_ERROR("Can't create a new instance of a this class. Returning the singleton instead");
     return _instance;
 }
@@ -70,22 +71,21 @@ Derived& JvmSingletonWrapper<Derived, FqName>::get_instance() {
 }
 
 template<class Derived, const char* FqName>
-void JvmSingletonWrapper<Derived, FqName>::initialize() {
+void JvmSingletonWrapper<Derived, FqName>::initialize(jni::Env& p_env) {
     JVM_CRASH_COND_MSG(_instance, String(FqName) + " singleton is already initialized.");
 
-    jni::Env env {jni::Jvm::current_env()};
     jni::JObject class_loader = ClassLoader::get_default_loader();
 
-    jni::JClass singleton_cls = env.load_class(FqName, class_loader);
+    jni::JClass singleton_cls = p_env.load_class(FqName, class_loader);
     jni::FieldId singleton_instance_field =
-      singleton_cls.get_static_field_id(env, "INSTANCE", vformat("L%s;", FqName).replace(".", "/").utf8().ptr());
-    jni::JObject singleton_instance = singleton_cls.get_static_object_field(env, singleton_instance_field);
+      singleton_cls.get_static_field_id(p_env, "INSTANCE", vformat("L%s;", FqName).replace(".", "/").utf8().ptr());
+    jni::JObject singleton_instance = singleton_cls.get_static_object_field(p_env, singleton_instance_field);
 
     JVM_CRASH_COND_MSG(singleton_instance.is_null(), "Failed to retrieve " + String(FqName) + " singleton");
 
-    _instance = new Derived(singleton_instance);
+    _instance = new Derived(p_env, singleton_instance);
 
-    Derived::initialize_jni_binding();
+    Derived::initialize_jni_binding(p_env);
 }
 
 template<class Derived, const char* FqName>
@@ -95,7 +95,7 @@ void JvmSingletonWrapper<Derived, FqName>::destroy() {
 }
 
 template<class Derived, const char* FqName>
-JvmSingletonWrapper<Derived, FqName>::JvmSingletonWrapper(jni::JObject p_wrapped) :
-  JvmInstanceWrapper<Derived, FqName>(p_wrapped) {}
+JvmSingletonWrapper<Derived, FqName>::JvmSingletonWrapper(jni::Env& p_env, jni::JObject p_wrapped) :
+  JvmInstanceWrapper<Derived, FqName>(p_env, p_wrapped) {}
 
 #endif// GODOT_JVM_JVM_SINGLETON_WRAPPER_H

--- a/src/jvm_wrapper/memory/kt_binding.cpp
+++ b/src/jvm_wrapper/memory/kt_binding.cpp
@@ -1,5 +1,5 @@
 #include "kt_binding.h"
 
-KtBinding::KtBinding(jni::JObject p_wrapped) : JvmInstanceWrapper(p_wrapped) {}
+KtBinding::KtBinding(jni::Env& p_env, jni::JObject p_wrapped) : JvmInstanceWrapper(p_env, p_wrapped) {}
 
 KtBinding::~KtBinding() = default;

--- a/src/jvm_wrapper/memory/kt_binding.h
+++ b/src/jvm_wrapper/memory/kt_binding.h
@@ -6,7 +6,7 @@
 
 JVM_INSTANCE_WRAPPER(KtBinding, "godot.core.memory.GodotBinding") {
 public:
-    explicit KtBinding(jni::JObject p_wrapped);
+    explicit KtBinding(jni::Env& p_env, jni::JObject p_wrapped);
     ~KtBinding();
 };
 

--- a/src/jvm_wrapper/memory/long_string_queue.cpp
+++ b/src/jvm_wrapper/memory/long_string_queue.cpp
@@ -8,11 +8,10 @@ int LongStringQueue::max_string_size = 512;
 thread_local static List<String> string_queue;// NOLINT(cert-err58-cpp)
 
 
-void LongStringQueue::set_string_max_size(int max_size) {
-    jni::Env env {jni::Jvm::current_env()};
+void LongStringQueue::set_string_max_size(jni::Env& p_env, int max_size) {
     LongStringQueue::max_string_size = max_size;
     jvalue buffer_size[1] = {jni::to_jni_arg(max_size)};
-    wrapped.call_void_method(env, SET_STRING_MAX_SIZE, buffer_size);
+    wrapped.call_void_method(p_env, SET_STRING_MAX_SIZE, buffer_size);
 }
 
 String LongStringQueue::poll_string() {
@@ -25,32 +24,16 @@ void LongStringQueue::queue_string(const String& str) {
     string_queue.push_back(str);
 }
 
-void LongStringQueue::send_string_to_jvm(const String& str) {
-    jni::Env env {jni::Jvm::current_env()};
-    jni::JString java_string = env.new_string(str.utf8().get_data());
+void LongStringQueue::send_string_to_jvm(jni::Env& p_env, const String& str) {
+    jni::JString java_string = p_env.new_string(str.utf8().get_data());
     jvalue args[1] = {jni::to_jni_arg(java_string)};
-    wrapped.call_void_method(env, QUEUE_STRING, args);
+    wrapped.call_void_method(p_env, QUEUE_STRING, args);
 }
 
 void LongStringQueue::send_string_to_cpp(JNIEnv* p_raw_env, jobject p_instance, jstring p_string) {
     jni::Env env {p_raw_env};
     const String nativeString = env.from_jstring(jni::JString {p_string});
     queue_string(nativeString);
-}
-
-LongStringQueue* LongStringQueue::init() {
-    jni::Env env {jni::Jvm::current_env()};
-    jni::JObject class_loader = ClassLoader::get_default_loader();
-
-    jni::JClass long_string_queue_cls = env.load_class("godot.core.LongStringQueue", class_loader);
-    jni::FieldId long_string_queue_instance_field = long_string_queue_cls.get_static_field_id(env, "INSTANCE", "Lgodot/core/LongStringQueue;");
-    jni::JObject long_string_queue_instance = long_string_queue_cls.get_static_object_field(env, long_string_queue_instance_field);
-    JVM_CRASH_COND_MSG(long_string_queue_instance.is_null(), "Failed to retrieve LongStringQueue instance");
-
-    auto* instance {new LongStringQueue(long_string_queue_instance)};
-    long_string_queue_cls.delete_local_ref(env);
-
-    return instance;
 }
 
 LongStringQueue::~LongStringQueue() = default;

--- a/src/jvm_wrapper/memory/long_string_queue.h
+++ b/src/jvm_wrapper/memory/long_string_queue.h
@@ -19,17 +19,13 @@ JVM_SINGLETON_WRAPPER(LongStringQueue, "godot.core.LongStringQueue") {
 public:
     static int max_string_size;
 
-    void set_string_max_size(int max_size);
+    void set_string_max_size(jni::Env& p_env, int max_size);
+    void send_string_to_jvm(jni::Env& p_env, const String& str);
 
     static String poll_string();
-
     static void queue_string(const String& str);
 
-    void send_string_to_jvm(const String& str);
-
     static void send_string_to_cpp(JNIEnv* p_raw_env, jobject p_instance, jstring p_string);
-
-    static LongStringQueue* init();
 
 };
 

--- a/src/jvm_wrapper/memory/memory_manager.cpp
+++ b/src/jvm_wrapper/memory/memory_manager.cpp
@@ -104,31 +104,26 @@ void MemoryManager::notify_leak(JNIEnv* p_raw_env, jobject p_instance) {
 #endif
 }
 
-void MemoryManager::start(bool force_gc) {
-    jni::Env env {jni::Jvm::current_env()};
+void MemoryManager::start(jni::Env& p_env, bool force_gc) {
     jvalue start_args[1] = {jni::to_jni_arg(force_gc)};
-    wrapped.call_void_method(env, START, start_args);
+    wrapped.call_void_method(p_env, START, start_args);
 }
 
-void MemoryManager::setDisplayLeaks(bool b) {
-    jni::Env env {jni::Jvm::current_env()};
+void MemoryManager::setDisplayLeaks(jni::Env& p_env, bool b) {
     jvalue args[1] = {jni::to_jni_arg(b)};
-    wrapped.call_void_method(env, SET_DISPLAY, args);
+    wrapped.call_void_method(p_env, SET_DISPLAY, args);
 }
 
-void MemoryManager::clean_up() {
-    jni::Env env {jni::Jvm::current_env()};
-    wrapped.call_void_method(env, CLEAN_UP);
+void MemoryManager::clean_up(jni::Env& p_env) {
+    wrapped.call_void_method(p_env, CLEAN_UP);
 }
 
-bool MemoryManager::is_closed() {
-    jni::Env env {jni::Jvm::current_env()};
-    return wrapped.call_boolean_method(env, IS_CLOSED);
+bool MemoryManager::is_closed(jni::Env& p_env) {
+    return wrapped.call_boolean_method(p_env, IS_CLOSED);
 }
 
-void MemoryManager::close() {
-    jni::Env env {jni::Jvm::current_env()};
-    wrapped.call_void_method(env, CLOSE);
+void MemoryManager::close(jni::Env& p_env) {
+    wrapped.call_void_method(p_env, CLOSE);
 }
 
 MemoryManager::~MemoryManager() = default;

--- a/src/jvm_wrapper/memory/memory_manager.h
+++ b/src/jvm_wrapper/memory/memory_manager.h
@@ -43,11 +43,11 @@ JVM_SINGLETON_WRAPPER(MemoryManager, "godot.core.memory.MemoryManager") {
     static void notify_leak(JNIEnv* p_raw_env, jobject p_instance);
 
 public:
-    void start(bool force_gc);
-    void setDisplayLeaks(bool b);
-    void clean_up();
-    bool is_closed();
-    void close();
+    void start(jni::Env& p_env, bool force_gc);
+    void setDisplayLeaks(jni::Env& p_env, bool b);
+    void clean_up(jni::Env& p_env);
+    bool is_closed(jni::Env& p_env);
+    void close(jni::Env& p_env);
 };
 // clang-format on
 #endif// GODOT_JVM_MEMORY_MANAGER_H

--- a/src/jvm_wrapper/memory/transfer_context.h
+++ b/src/jvm_wrapper/memory/transfer_context.h
@@ -24,21 +24,15 @@ JVM_SINGLETON_WRAPPER(TransferContext, "godot.core.memory.TransferContext") {
 public:
 
     void write_return_value(jni::Env& p_env, Variant& variant);
-
     void read_return_value(jni::Env& p_env, Variant& r_ret);
-
     void write_args(jni::Env& p_env, const Variant** p_args, int args_size);
-
     uint32_t read_args(jni::Env& p_env, Variant* args);
 
-    void remove_script_instance(uint64_t id);
+    void remove_script_instance(jni::Env& p_env, uint64_t id);
 
     static void icall(JNIEnv* rawEnv, jobject instance, jlong j_ptr, jlong j_method_ptr, jint expectedReturnType);
-
     static void create_native_object(JNIEnv* p_raw_env, jobject instance, jint p_class_index, jobject p_object, jint p_script_index);
-
     static void get_singleton(JNIEnv* p_raw_env, jobject p_instance, jint p_class_index);
-
     static void free_object(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr);
 
 private:

--- a/src/jvm_wrapper/memory/type_manager.h
+++ b/src/jvm_wrapper/memory/type_manager.h
@@ -24,8 +24,8 @@ public:
     const Ref<NamedScript>& get_user_script_for_index(int p_index) const;
     Ref<NamedScript> get_user_script_from_name(const StringName& name) const;
 
-    void register_engine_types(jni::Env & p_env, jni::JObjectArray & p_engine_types);
-    void register_engine_singletons(jni::Env & p_env, jni::JObjectArray & p_singletons);
+    void register_engine_types(jni::Env& p_env, jni::JObjectArray & p_engine_types);
+    void register_engine_singletons(jni::Env& p_env, jni::JObjectArray & p_singletons);
     void create_and_update_scripts(Vector<KtClass*> & classes);
 
     template<class C>

--- a/src/jvm_wrapper/registration/kt_class.h
+++ b/src/jvm_wrapper/registration/kt_class.h
@@ -49,7 +49,7 @@ public:
     Vector<StringName> registered_supertypes;
     StringName base_godot_class;
 
-    explicit KtClass(jni::JObject p_wrapped);
+    explicit KtClass(jni::Env& p_env, jni::JObject p_wrapped);
 
     ~KtClass();
 
@@ -67,11 +67,11 @@ public:
 
     void get_signal_list(List<MethodInfo>* p_list);
 
-    void fetch_members();
+    void fetch_members(jni::Env& env);
 
     const Dictionary get_rpc_config();
 
-    void do_notification(KtObject* p_instance, int p_notification, bool p_reversed);
+    void do_notification(jni::Env& env, KtObject* p_instance, int p_notification, bool p_reversed);
 
 private:
     HashMap<StringName, KtFunction*> methods;

--- a/src/jvm_wrapper/registration/kt_constructor.cpp
+++ b/src/jvm_wrapper/registration/kt_constructor.cpp
@@ -2,18 +2,16 @@
 
 #include "gd_kotlin.h"
 
-KtConstructor::KtConstructor(jni::JObject p_wrapped) : JvmInstanceWrapper(p_wrapped),
+KtConstructor::KtConstructor(jni::Env& p_env, jni::JObject p_wrapped) : JvmInstanceWrapper(p_env, p_wrapped),
   parameter_count(0) {
-    jni::Env env {jni::Jvm::current_env()};
-    parameter_count = static_cast<int>(wrapped.call_int_method(env, GET_PARAMETER_COUNT));
+    parameter_count = static_cast<int>(wrapped.call_int_method(p_env, GET_PARAMETER_COUNT));
 }
 
-KtObject* KtConstructor::create_instance(const Variant** p_args, Object* p_owner) {
-    jni::Env env {jni::Jvm::current_env()};
-    TransferContext::get_instance().write_args(env, p_args, parameter_count);
+KtObject* KtConstructor::create_instance(jni::Env& p_env, const Variant** p_args, Object* p_owner) {
+    TransferContext::get_instance().write_args(p_env, p_args, parameter_count);
 
     uint64_t id = p_owner->get_instance_id();
     jvalue args[2] = {jni::to_jni_arg(p_owner), jni::to_jni_arg(id)};
-    jni::JObject j_kt_object = wrapped.call_object_method(env, CONSTRUCT, args);
-    return memnew(KtObject(j_kt_object, p_owner->is_ref_counted()));
+    jni::JObject j_kt_object = wrapped.call_object_method(p_env, CONSTRUCT, args);
+    return memnew(KtObject(p_env, j_kt_object, p_owner->is_ref_counted()));
 }

--- a/src/jvm_wrapper/registration/kt_constructor.h
+++ b/src/jvm_wrapper/registration/kt_constructor.h
@@ -16,9 +16,9 @@ JVM_INSTANCE_WRAPPER(KtConstructor, "godot.core.KtConstructor") {
     // clang-format on
 
 public:
-    explicit KtConstructor(jni::JObject p_wrapped);
+    explicit KtConstructor(jni::Env& p_env, jni::JObject p_wrapped);
     ~KtConstructor() = default;
-    KtObject* create_instance(const Variant** p_args, Object* p_owner);
+    KtObject* create_instance(jni::Env& env, const Variant** p_args, Object* p_owner);
 
 private:
     int parameter_count;

--- a/src/jvm_wrapper/registration/kt_function.h
+++ b/src/jvm_wrapper/registration/kt_function.h
@@ -23,7 +23,7 @@ JVM_INSTANCE_WRAPPER(KtFunctionInfo, "godot.core.KtFunctionInfo") {
 
     // clang-format on
 public:
-    explicit KtFunctionInfo(jni::JObject p_wrapped);
+    explicit KtFunctionInfo(jni::Env& p_env, jni::JObject p_wrapped);
     ~KtFunctionInfo();
 
     String name;
@@ -54,7 +54,7 @@ private:
     KtFunctionInfo* method_info;
 
 public:
-    explicit KtFunction(jni::JObject p_wrapped);
+    explicit KtFunction(jni::Env& p_env, jni::JObject p_wrapped);
     ~KtFunction();
 
     StringName get_name() const;
@@ -64,7 +64,7 @@ public:
     MethodInfo get_member_info();
     KtFunctionInfo* get_kt_function_info();
 
-    void invoke(const KtObject* instance, const Variant** p_args, int args_count, Variant& r_ret);
+    void invoke(jni::Env& p_env, const KtObject* instance, const Variant** p_args, int args_count, Variant& r_ret);
 };
 
 #endif// GODOT_JVM_KT_FUNCTION_H

--- a/src/jvm_wrapper/registration/kt_object.cpp
+++ b/src/jvm_wrapper/registration/kt_object.cpp
@@ -1,6 +1,6 @@
 #include "kt_object.h"
 
-KtObject::KtObject(jni::JObject p_wrapped, bool p_is_ref) : JvmInstanceWrapper(p_wrapped), is_ref(p_is_ref) {}
+KtObject::KtObject(jni::Env& p_env, jni::JObject p_wrapped, bool p_is_ref) : JvmInstanceWrapper(p_env, p_wrapped), is_ref(p_is_ref) {}
 
 KtObject::~KtObject() {
     if (is_ref) { return; }

--- a/src/jvm_wrapper/registration/kt_object.h
+++ b/src/jvm_wrapper/registration/kt_object.h
@@ -21,7 +21,7 @@ private:
     bool is_ref;
 
 public:
-    explicit KtObject(jni::JObject p_wrapped, bool p_is_ref);
+    explicit KtObject(jni::Env& p_env, jni::JObject p_wrapped, bool p_is_ref);
     ~KtObject();
 };
 

--- a/src/jvm_wrapper/registration/kt_property.h
+++ b/src/jvm_wrapper/registration/kt_property.h
@@ -27,7 +27,7 @@ JVM_INSTANCE_WRAPPER(KtPropertyInfo, "godot.core.KtPropertyInfo") {
     // clang-format on
 
 public:
-    explicit KtPropertyInfo(jni::JObject p_wrapped);
+    explicit KtPropertyInfo(jni::Env& p_env, jni::JObject p_wrapped);
     ~KtPropertyInfo() = default;
 
     Variant::Type type;
@@ -62,18 +62,18 @@ JVM_INSTANCE_WRAPPER(KtProperty, "godot.core.KtProperty") {
     bool is_ref;
 
 public:
-    explicit KtProperty(jni::JObject p_wrapped);
+    explicit KtProperty(jni::Env& p_env, jni::JObject p_wrapped);
     ~KtProperty();
 
     StringName get_name() const;
 
     PropertyInfo get_member_info();
 
-    void call_get(KtObject* instance, Variant& r_ret);
-    void call_set(KtObject* instance, const Variant& p_value);
+    void call_get(jni::Env& p_env, KtObject* instance, Variant& r_ret);
+    void call_set(jni::Env& p_env, KtObject* instance, const Variant& p_value);
 
 #ifdef TOOLS_ENABLED
-    void safe_call_get(KtObject* instance, Variant& r_ret);
+    void safe_call_get(jni::Env& p_env, KtObject* instance, Variant& r_ret);
 #endif
 };
 

--- a/src/jvm_wrapper/registration/kt_rpc_config.cpp
+++ b/src/jvm_wrapper/registration/kt_rpc_config.cpp
@@ -1,6 +1,6 @@
 #include "kt_rpc_config.h"
 
-KtRpcConfig::KtRpcConfig(jni::JObject p_wrapped) : JvmInstanceWrapper(p_wrapped) {
+KtRpcConfig::KtRpcConfig(jni::Env& p_env, jni::JObject p_wrapped) : JvmInstanceWrapper(p_env, p_wrapped) {
     jni::Env env {jni::Jvm::current_env()};
 
     rpc_mode = static_cast<MultiplayerAPI::RPCMode>(wrapped.call_int_method(env, GET_RPC_MODE_ID));

--- a/src/jvm_wrapper/registration/kt_rpc_config.h
+++ b/src/jvm_wrapper/registration/kt_rpc_config.h
@@ -23,7 +23,7 @@ JVM_INSTANCE_WRAPPER(KtRpcConfig, "godot.core.KtRpcConfig") {
     // clang-format on
 
 public:
-    explicit KtRpcConfig(jni::JObject p_wrapped);
+    explicit KtRpcConfig(jni::Env& p_env, jni::JObject p_wrapped);
     ~KtRpcConfig() = default;
 
     MultiplayerAPI::RPCMode rpc_mode;

--- a/src/jvm_wrapper/registration/kt_signal_info.cpp
+++ b/src/jvm_wrapper/registration/kt_signal_info.cpp
@@ -2,20 +2,19 @@
 
 #include "jni/class_loader.h"
 
-KtSignalInfo::KtSignalInfo(jni::JObject p_wrapped) : JvmInstanceWrapper(p_wrapped) {
-    jni::Env env {jni::Jvm::current_env()};
+KtSignalInfo::KtSignalInfo(jni::Env& p_env, jni::JObject p_wrapped) : JvmInstanceWrapper(p_env, p_wrapped) {
 
-    jni::JString string = wrapped.call_object_method(env, GET_NAME);
-    name = env.from_jstring(string);
+    jni::JString string = wrapped.call_object_method(p_env, GET_NAME);
+    name = p_env.from_jstring(string);
 
-    jni::JObjectArray args_array {wrapped.call_object_method(env, GET_ARGUMENTS)};
+    jni::JObjectArray args_array {wrapped.call_object_method(p_env, GET_ARGUMENTS)};
 
-    for (int i = 0; i < args_array.length(env); i++) {
-        arguments.push_back(new KtPropertyInfo(args_array.get(env, i)));
+    for (int i = 0; i < args_array.length(p_env); i++) {
+        arguments.push_back(new KtPropertyInfo(p_env, args_array.get(p_env, i)));
     }
 
-    string.delete_local_ref(env);
-    args_array.delete_local_ref(env);
+    string.delete_local_ref(p_env);
+    args_array.delete_local_ref(p_env);
 }
 
 KtSignalInfo::~KtSignalInfo() {

--- a/src/jvm_wrapper/registration/kt_signal_info.h
+++ b/src/jvm_wrapper/registration/kt_signal_info.h
@@ -18,7 +18,7 @@ JVM_INSTANCE_WRAPPER(KtSignalInfo, "godot.core.KtSignalInfo") {
     // clang-format on
 
 public:
-    explicit KtSignalInfo(jni::JObject p_wrapped);
+    explicit KtSignalInfo(jni::Env& p_env, jni::JObject p_wrapped);
     ~KtSignalInfo();
 
     String name;

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -48,7 +48,8 @@ namespace ktvariant {
         int size = char_string.size();
         if (unlikely(size > LongStringQueue::max_string_size)) {
             des->increment_position(encode_uint32(true, des->get_cursor()));
-            LongStringQueue::get_instance().send_string_to_jvm(str);
+            jni::Env env = jni::Jvm::current_env();
+            LongStringQueue::get_instance().send_string_to_jvm(env, str);
         } else {
             des->increment_position(encode_uint32(false, des->get_cursor()));
             des->increment_position(encode_uint32(char_string.size(), des->get_cursor()));

--- a/src/script/jvm_instance.h
+++ b/src/script/jvm_instance.h
@@ -15,7 +15,7 @@ private:
     bool delete_flag;
 
 public:
-    JvmInstance(Object* p_owner, KtObject* p_kt_object, JvmScript* p_script);
+    JvmInstance(jni::Env& p_env, Object* p_owner, KtObject* p_kt_object, JvmScript* p_script);
     ~JvmInstance() override;
 
     bool set(const StringName& p_name, const Variant& p_value) override;
@@ -30,7 +30,7 @@ public:
     void get_method_list(List<MethodInfo>* p_list) const override;
     bool has_method(const StringName& p_method) const override;
     Variant callp(const StringName& p_method, const Variant** p_args, int p_argcount, Callable::CallError& r_error) override;
-    void notification(int p_notification, bool p_reversed = false) override;
+    void notification(int p_notification, bool p_reversed) override;
     virtual void validate_property(PropertyInfo& p_property) const override;
     String to_string(bool* r_valid) override;
     void refcount_incremented() override;

--- a/src/script/jvm_script.cpp
+++ b/src/script/jvm_script.cpp
@@ -94,7 +94,7 @@ ScriptInstance* JvmScript::_instance_create(const Variant** p_args, int p_arg_co
 
     jni::Env env = jni::Jvm::current_env();
     KtObject* wrapped = kotlin_class->create_instance(env, p_args, p_arg_count, p_this);
-    return memnew(JvmInstance(p_this, wrapped, this));
+    return memnew(JvmInstance(env, p_this, wrapped, this));
 }
 
 bool JvmScript::instance_has(const Object* p_this) const {


### PR DESCRIPTION
I fixed an issue with the Env stored in the Jvm not being thread dependent, which could cause memory leak when multithread was used.
On top of that. I removed as many `jni::Jvm::current_env()` as possible. Opting to pass its reference to the deepest part of the api.
Most calls to that function now are going to be in the overridden Godot methods (like in Script or ScriptInstance).
I couldn't remove the use of it in destructors as they have no parameters.
