### PR TITLE
Add new core methods

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/Invocation.kt
@@ -511,7 +511,7 @@ class Invocation : Node3D() {
 	fun removeNullableNavMesh(navigationMesh: NavigationMesh?) = nullableArray.remove(navigationMesh)
 
 	@RegisterFunction
-	fun removeNullableNavMeshWithIndex(index: Int) = nullableArray.remove(index)
+	fun removeNullableNavMeshWithIndex(index: Int) = nullableArray.removeAt(index)
 
 //	TODO: This will fail to register as we cannot register nullable return type
 //	@RegisterFunction
@@ -530,7 +530,7 @@ class Invocation : Node3D() {
 	fun removeNavMesh(navigationMesh: NavigationMesh) = navMeshes.remove(navigationMesh)
 
 	@RegisterFunction
-	fun removeNavMeshWithIndex(index: Int) = navMeshes.remove(index)
+	fun removeNavMeshWithIndex(index: Int) = navMeshes.removeAt(index)
 
 	@RegisterFunction
 	fun getNavMeshFromArray(index: Int) = navMeshes[index]

--- a/kt/godot-library/src/main/kotlin/godot/core/bridge/Dictionary.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/bridge/Dictionary.kt
@@ -358,19 +358,21 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V> {
         external fun engine_call_operator_set(_handle: VoidPtr)
         external fun engine_call_equals(_handle: VoidPtr)
     }
-}
 
-@Suppress("FunctionName")
-inline fun <reified K, reified V> Dictionary(): Dictionary<K, V> {
-    val keyVariantType = variantMapper[K::class]
-    checkNotNull(keyVariantType) {
-        "Can't create a Dictionary with generic key ${K::class}."
+
+    companion object {
+        inline operator fun <reified K, reified V> invoke(): Dictionary<K, V> {
+            val keyVariantType = variantMapper[K::class]
+            checkNotNull(keyVariantType) {
+                "Can't create a Dictionary with generic key ${K::class}."
+            }
+            val valVariantType = variantMapper[V::class]
+            checkNotNull(valVariantType) {
+                "Can't create a Dictionary with generic value ${V::class}."
+            }
+            return Dictionary(keyVariantType, valVariantType)
+        }
     }
-    val valVariantType = variantMapper[V::class]
-    checkNotNull(valVariantType) {
-        "Can't create a Dictionary with generic value ${V::class}."
-    }
-    return Dictionary<K, V>(keyVariantType, valVariantType)
 }
 
 inline fun <reified K, reified V> dictionaryOf(vararg args: Pair<K, V>) = Dictionary<K, V>().also {
@@ -378,7 +380,7 @@ inline fun <reified K, reified V> dictionaryOf(vararg args: Pair<K, V>) = Dictio
 }
 
 /**
- * Convert an Map into a Dictionary
+ * Convert a Map into a Dictionary
  */
 inline fun <reified K, reified V> Map<K, V>.toDictionary() = Dictionary<K, V>().also {
     it.putAll(this)

--- a/kt/godot-library/src/main/kotlin/godot/core/bridge/VariantArray.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/bridge/VariantArray.kt
@@ -130,7 +130,7 @@ class VariantArray<T> : NativeCoreType, MutableCollection<T> {
     /**
      * Removes an element from the array by index.
      */
-    fun remove(position: Int) {
+    fun removeAt(position: Int) {
         TransferContext.writeArguments(VariantType.JVM_INT to position)
         Bridge.engine_call_removeAt(_handle)
     }
@@ -552,7 +552,7 @@ class VariantArray<T> : NativeCoreType, MutableCollection<T> {
     }
 
     override fun iterator(): MutableIterator<T> {
-        return IndexedIterator(this::size, this::get, this::remove)
+        return IndexedIterator(this::size, this::get, this::removeAt)
     }
 
     /**
@@ -628,20 +628,19 @@ class VariantArray<T> : NativeCoreType, MutableCollection<T> {
         external fun engine_call_operator_set(_handle: VoidPtr)
         external fun engine_call_operator_get(_handle: VoidPtr)
     }
-}
 
-
-//CONSTRUCTOR
-@Suppress("FunctionName")
-inline fun <reified T> VariantArray(): VariantArray<T> {
-    val variantType = variantMapper[T::class]
-    checkNotNull(variantType) {
-        "Can't create a VariantArray with generic ${T::class}."
+    companion object{
+        inline operator fun <reified T> invoke(): VariantArray<T> {
+            val variantType = variantMapper[T::class]
+            checkNotNull(variantType) {
+                "Can't create a VariantArray with generic ${T::class}."
+            }
+            return VariantArray(
+                variantType,
+                T::class
+            )
+        }
     }
-    return VariantArray<T>(
-        variantType,
-        T::class
-    )
 }
 
 //HELPER

--- a/kt/godot-library/src/main/kotlin/godot/core/math/Basis.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/math/Basis.kt
@@ -678,6 +678,19 @@ class Basis() : CoreType {
     }
 
     /**
+     * Just as before, there's no need for the param inside square brackets.
+     * Use the parameter names directly. Also, keep in mind that the description inside the brackets should match the actual parameter names used in the function signature.
+     */
+    fun rotateToward(to: Basis, delta: RealT): Basis {
+        return Basis(
+            getRotationQuaternion().rotateToward(
+                to.getRotationQuaternion(),
+                delta
+            )
+        )
+    }
+
+    /**
      * Introduce an additional scaling specified by the given 3D scaling factor.
      */
     fun scaled(scale: Vector3): Basis {

--- a/kt/godot-library/src/main/kotlin/godot/core/math/Basis.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/math/Basis.kt
@@ -678,8 +678,8 @@ class Basis() : CoreType {
     }
 
     /**
-     * Just as before, there's no need for the param inside square brackets.
-     * Use the parameter names directly. Also, keep in mind that the description inside the brackets should match the actual parameter names used in the function signature.
+     * Assuming that the matrix is a proper rotation matrix, returns the result of rotating toward [to] by [delta] (in radians).
+     * Passing a negative [delta] will rotate toward the inverse of [to].
      */
     fun rotateToward(to: Basis, delta: RealT): Basis {
         return Basis(

--- a/kt/godot-library/src/main/kotlin/godot/core/math/Quaternion.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/math/Quaternion.kt
@@ -215,6 +215,32 @@ class Quaternion(
     }
 
     /**
+     * Returns the result of rotating toward [to] by [delta] (in radians). Passing a negative [delta] will rotate toward the inverse of [to].
+     *
+     * **Note:** Both quaternions must be normalized.
+     */
+    fun rotateToward(to: Quaternion, delta: Double): Quaternion {
+        val unsignedDelta: RealT
+        val unsignedTo: Quaternion
+
+        if (delta < 0.0) {
+            unsignedDelta = -delta
+            unsignedTo = to.inverse()
+        } else {
+            unsignedDelta = delta
+            unsignedTo = to
+        }
+
+        val angle = angleTo(unsignedTo)
+
+        return if (angle < unsignedDelta) {
+            unsignedTo
+        } else {
+            slerp(unsignedTo, unsignedDelta / angle)
+        }
+    }
+
+    /**
      * Sets the quaternion to a rotation which rotates around axis by the specified angle, in radians. The axis must be a normalized vector.
      */
     fun setAxisAndAngle(axis: Vector3, angle: RealT) {

--- a/kt/godot-library/src/main/kotlin/godot/core/math/Vector3.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/math/Vector3.kt
@@ -9,6 +9,7 @@ import godot.util.bezierInterpolate
 import godot.util.cubicInterpolateInTime
 import godot.util.fposmod
 import godot.util.isEqualApprox
+import godot.util.isZeroApprox
 import godot.util.lerp
 import godot.util.snapped
 import godot.util.toRealT
@@ -492,6 +493,37 @@ class Vector3(
         this.x = ret.x
         this.y = ret.y
         this.z = ret.z
+    }
+
+    /**
+     * Returns the result of rotating this vector toward [to], by increment [delta] (in radians).
+     * Passing a negative [delta] will rotate toward the opposite of [to].
+     * This method supports vectors of different length, with the same behavior as [slerp].
+     * If the vectors are colinear, this method behaves like [moveToward]. If [to] has a length of zero, this method behaves like [lerp].
+     */
+    fun rotateToward(to: Vector3, delta: RealT): Vector3 {
+        val unsignedDelta: RealT
+        val unsignedTo: Vector3
+
+        if (delta < 0.0) {
+            unsignedDelta = -delta
+            unsignedTo = -to
+        } else {
+            unsignedDelta = delta
+            unsignedTo = to
+        }
+
+        val angle = abs(angleTo(to))
+
+        if (angle < unsignedDelta) {
+            if (unsignedTo.lengthSquared().isZeroApprox()) {
+                // Prevent locking up when to is (0, 0).
+                return lerp(unsignedTo, unsignedDelta)
+            }
+            return moveToward(unsignedTo, unsignedDelta * unsignedTo.length())
+        }
+
+        return slerp(unsignedTo, unsignedDelta / angle)
     }
 
     /**

--- a/kt/godot-library/src/test/kotlin/godot/core/Vector2Test.kt
+++ b/kt/godot-library/src/test/kotlin/godot/core/Vector2Test.kt
@@ -94,6 +94,32 @@ class TestVector2 {
 
         val moveTowardResult = Vector2(1, 0).moveToward(Vector2(10, 0), 3.0)
         checkMessage(moveTowardResult == Vector2(4, 0)) { "Vector2 move_toward should work as expected." }
+
+        checkMessage(
+            Vector2(0, 1).rotateToward(
+                Vector2(0, -1),
+                PI * 0.5
+            ).isEqualApprox(Vector2(1, 0))
+        ) { "Vector2 rotate_toward should work as expected." }
+
+        checkMessage(
+            Vector2(1, 0).rotateToward(
+                Vector2(0, 1),
+                -PI * 0.5
+            ).isEqualApprox(Vector2(0, -1))
+        ) { "Vector2 rotate_toward with negative delta should behave as expected." }
+        checkMessage(
+            Vector2(1, 1).rotateToward(
+                Vector2(10, 10),
+                0.5
+            ).isEqualApprox(Vector2(6, 6))
+        ) { "Vector2 rotate_toward with colinear inputs should behave as expected." }
+        checkMessage(
+            Vector2(10, 10).rotateToward(
+                Vector2(0, 0),
+                0.5
+            ).isEqualApprox(Vector2(5, 5))
+        ) { "Vector2 rotate_toward with second input as zero should behave as expected." }
     }
 
     @Test

--- a/kt/godot-library/src/test/kotlin/godot/core/Vector3Test.kt
+++ b/kt/godot-library/src/test/kotlin/godot/core/Vector3Test.kt
@@ -110,6 +110,28 @@ class TestVector3 {
                 0.0
             )
         ) { "moveToward() should return the expected result." }
+
+        checkMessage(
+            Vector3(1, 0, 0).rotateToward(
+                Vector3(0, 1, 0),
+                TAU / 8.0
+            ).isEqualApprox(Vector3(SQRT12, SQRT12, 0))
+        ) { "Vector3 rotate_toward should work as expected." }
+        checkMessage(
+            Vector3(1, 0, 0).rotateToward(
+                Vector3(0, 1, 0), -TAU / 8.0
+            ).isEqualApprox(Vector3(SQRT12, -SQRT12, 0))
+        ) { "Vector3 rotate_toward with negative delta should behave as expected." }
+        checkMessage(
+            Vector3(1, 1, 1).rotateToward(
+                Vector3(10, 10, 10), 0.5
+            ).isEqualApprox(Vector3(6, 6, 6))
+        ) { "Vector3 rotate_toward with colinear inputs should behave as expected." }
+        checkMessage(
+            Vector3(10, 10, 10).rotateToward(
+                Vector3(0, 0, 0), 0.5
+            ).isEqualApprox(Vector3(5, 5, 5))
+        ) { "Vector3 rotate_toward with second input as zero should behave as expected." }
     }
 
     @Test


### PR DESCRIPTION
Implement #505 

Also sneaking in a small change I wanted for VariantArray and Dictionary. It doesn't change anything for calling code, but it removes the part that complains about a function using the same name as a constructor.

I could have implemented #590 too, but I want to avoid touching bridges in the master with the GDKotlin rework branch around