### PR TITLE
Improve ksp error handling upon compilation issues

### DIFF
--- a/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/ext/ksDeclarationExt.kt
+++ b/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/ext/ksDeclarationExt.kt
@@ -6,3 +6,7 @@ fun KSClassDeclaration.hasCompilationErrors(): Boolean = superTypes
     .toList()
     .any { superTypeDeclaration -> superTypeDeclaration.resolve().isError }
     || this.asStarProjectedType().isError
+    || this.getAllProperties().any { property -> property.type.resolve().isError }
+    || this.getAllFunctions().any { function ->
+        function.returnType?.resolve()?.isError == true || it.parameters.any { param -> param.type.resolve().isError }
+    }

--- a/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/ext/ksDeclarationExt.kt
+++ b/kt/entry-generation/godot-kotlin-symbol-processor/src/main/kotlin/godot/annotation/processor/ext/ksDeclarationExt.kt
@@ -8,5 +8,5 @@ fun KSClassDeclaration.hasCompilationErrors(): Boolean = superTypes
     || this.asStarProjectedType().isError
     || this.getAllProperties().any { property -> property.type.resolve().isError }
     || this.getAllFunctions().any { function ->
-        function.returnType?.resolve()?.isError == true || it.parameters.any { param -> param.type.resolve().isError }
+        function.returnType?.resolve()?.isError == true || function.parameters.any { param -> param.type.resolve().isError }
     }


### PR DESCRIPTION
This improves error handling if code of the user does not compile.

Before we only handled compilation errors at class level but with this we nod also handle errors on members we care about.