### PR TITLE
Add warning for invalid jvm scripts

### DIFF
--- a/src/script/jvm_placeholder_instance.cpp
+++ b/src/script/jvm_placeholder_instance.cpp
@@ -1,0 +1,23 @@
+
+#include "jvm_placeholder_instance.h"
+
+JvmPlaceHolderInstance::JvmPlaceHolderInstance(ScriptLanguage* p_language, Ref<Script> p_script, Object* p_owner) :
+  PlaceHolderScriptInstance(p_language, p_script, p_owner) {}
+
+bool JvmPlaceHolderInstance::has_method(const StringName& p_method) const {
+    if(p_method == SNAME("_get_configuration_warnings")) {
+        return true;
+    }
+    return PlaceHolderScriptInstance::has_method(p_method);
+}
+
+Variant JvmPlaceHolderInstance::callp(const StringName& p_method, const Variant** p_args, int p_argcount, Callable::CallError& r_error) {
+    if(p_method == SNAME("_get_configuration_warnings") && !get_script().is_valid()) {
+        PackedStringArray packed {};
+        packed.append("This script can't be found in your JVM project. Don't forget to build it and use a valid gdj/kt/java file.");
+        return packed;
+    }
+    return PlaceHolderScriptInstance::callp(p_method, p_args, p_argcount, r_error);
+}
+
+

--- a/src/script/jvm_placeholder_instance.h
+++ b/src/script/jvm_placeholder_instance.h
@@ -1,0 +1,15 @@
+#ifndef GODOT_JVM_JVM_PLACEHOLDER_INSTANCE_H
+#define GODOT_JVM_JVM_PLACEHOLDER_INSTANCE_H
+
+#include <core/object/script_language.h>
+
+class JvmPlaceHolderInstance : public PlaceHolderScriptInstance {
+public:
+    JvmPlaceHolderInstance(ScriptLanguage *p_language, Ref<Script> p_script, Object *p_owner);
+
+    bool has_method(const StringName &p_method) const override;
+    Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
+
+};
+
+#endif// GODOT_JVM_JVM_PLACEHOLDER_INSTANCE_H

--- a/src/script/jvm_script.cpp
+++ b/src/script/jvm_script.cpp
@@ -1,8 +1,11 @@
 #include "jvm_script.h"
 
+#include <scene/main/node.h>
+
 #include "core/os/thread.h"
 #include "gd_kotlin.h"
 #include "jvm_instance.h"
+#include "jvm_placeholder_instance.h"
 #include "language/jvm_language.h"
 #include "language/kotlin_language.h"
 #include "language/names.h"
@@ -208,7 +211,7 @@ String JvmScript::get_class_icon_path() const {
 }
 
 PlaceHolderScriptInstance* JvmScript::placeholder_instance_create(Object* p_this) {
-    PlaceHolderScriptInstance* placeholder {memnew(PlaceHolderScriptInstance(KotlinLanguage::get_instance(), Ref<Script>(this), p_this))};
+    PlaceHolderScriptInstance* placeholder {memnew(JvmPlaceHolderInstance(KotlinLanguage::get_instance(), Ref<Script>(this), p_this))};
 
     List<PropertyInfo> exported_properties;
     get_script_exported_property_list(&exported_properties);
@@ -243,6 +246,9 @@ void JvmScript::update_exports() {
 
     for (PlaceHolderScriptInstance* placeholder : placeholders) {
         placeholder->update(exported_properties, exported_members_default_value_cache);
+        if(Node* node = cast_to<Node>(placeholder->get_owner())){
+            node->update_configuration_warnings();
+        }
     }
 
     memdelete(tmp_object);


### PR DESCRIPTION
When the project is not build, or at least not rebuilt after adding new scripts or checking out your project, it's easy to use invalid scripts. This PR adds a warning to nodes with invalid jvm scripts.

![image](https://github.com/utopia-rise/godot-kotlin-jvm/assets/31470327/201ea2f5-739e-4085-b963-20d38cdef090)
