### PR TITLE
Support multidex and fix export for android 14 devices

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/createMainDexFileTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/createMainDexFileTask.kt
@@ -1,5 +1,6 @@
 package godot.gradle.tasks.android
 
+import godot.gradle.GodotPlugin
 import godot.gradle.projectExt.godotJvmExtension
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -30,6 +31,12 @@ fun Project.createMainDexFileTask(
                 val libsDir = project.buildDir.resolve("libs")
                 val mainJar = File(libsDir, "main.jar")
                 val godotBootstrapJar = File(libsDir, "godot-bootstrap.jar")
+                val mainDexRules = project.buildDir.resolve("main-dex-rules.proguard").also { mainDexRules ->
+                    mainDexRules.outputStream().use { outputStream ->
+                        requireNotNull(GodotPlugin::class.java.getResourceAsStream("android/main-dex-rules.proguard"))
+                            .copyTo(outputStream)
+                    }
+                }.absolutePath
 
                 workingDir = libsDir
                 if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
@@ -42,6 +49,8 @@ fun Project.createMainDexFileTask(
                         "${godotJvmExtension.androidCompileSdkDir.get().asFile.absolutePath}${File.separator}android.jar",
                         "--min-api",
                         godotJvmExtension.androidMinApi.get(),
+                        "--main-dex-rules",
+                        mainDexRules,
                     )
                 } else {
                     commandLine(
@@ -53,6 +62,8 @@ fun Project.createMainDexFileTask(
                         godotBootstrapJar.absolutePath,
                         "--min-api",
                         godotJvmExtension.androidMinApi.get(),
+                        "--main-dex-rules",
+                        mainDexRules,
                     )
                 }
             }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageBootstrapDexJarTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageBootstrapDexJarTask.kt
@@ -1,5 +1,6 @@
 package godot.gradle.tasks.android
 
+import godot.gradle.GodotPlugin
 import godot.gradle.projectExt.godotJvmExtension
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -24,6 +25,12 @@ fun Project.packageBootstrapDexJarTask(
             doFirst {
                 val libsDir = project.buildDir.resolve("libs")
                 val godotBootstrapJar = File(libsDir, "godot-bootstrap.jar")
+                val mainDexRules = project.buildDir.resolve("main-dex-rules.proguard").also { mainDexRules ->
+                    mainDexRules.outputStream().use { outputStream ->
+                        requireNotNull(GodotPlugin::class.java.getResourceAsStream("android/main-dex-rules.proguard"))
+                            .copyTo(outputStream)
+                    }
+                }.absolutePath
 
                 workingDir = libsDir
                 if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
@@ -38,6 +45,8 @@ fun Project.packageBootstrapDexJarTask(
                         "${godotJvmExtension.androidCompileSdkDir.get().asFile.absolutePath}${File.separator}android.jar",
                         "--min-api",
                         godotJvmExtension.androidMinApi.get(),
+                        "--main-dex-rules",
+                        mainDexRules,
                     )
                 } else {
                     commandLine(
@@ -49,6 +58,8 @@ fun Project.packageBootstrapDexJarTask(
                         "${godotJvmExtension.androidCompileSdkDir.get().asFile.absolutePath}/android.jar",
                         "--min-api",
                         godotJvmExtension.androidMinApi.get(),
+                        "--main-dex-rules",
+                        mainDexRules,
                     )
                 }
             }

--- a/kt/plugins/godot-gradle-plugin/src/main/resources/godot/gradle/android/main-dex-rules.proguard
+++ b/kt/plugins/godot-gradle-plugin/src/main/resources/godot/gradle/android/main-dex-rules.proguard
@@ -1,0 +1,3 @@
+# rules for which classes need to go into the main dex file
+# in our case it doesn't really matter as at engine start, we basically load everything important upfront
+# because of this, this file can remain empty

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -99,12 +99,16 @@ String GDKotlin::copy_new_file_to_user_dir(const String& file_name) {
     String file_res_path {String(BUILD_DIRECTORY) + file_name};
     String file_user_path {String(USER_DIRECTORY) + file_name};
 
-#ifdef __ANDROID__
+#ifndef __ANDROID__
+    if (!FileAccess::exists(file_user_path) || FileAccess::get_md5(file_user_path) != FileAccess::get_md5(file_res_path)) {
+        LOG_VERBOSE(vformat("%s file has changed. Copying it from res:// to user://.", file_name));
+#else
     // as per suggestion of https://developer.android.com/about/versions/14/behavior-changes-14#safer-dynamic-code-loading, we first delete existing files and then copy them again
     // if we don't do this, subsequent app starts where the files already exist, error out
 
     String file_user_path_global {ProjectSettings::get_singleton()->globalize_path(file_user_path)};
     unlink(file_user_path_global.utf8().get_data()); // we do not really care about errors here
+#endif
 
     Error err;
     Ref<DirAccess> dir_access {DirAccess::open(BUILD_DIRECTORY, &err)};
@@ -112,18 +116,11 @@ String GDKotlin::copy_new_file_to_user_dir(const String& file_name) {
     JVM_ERR_FAIL_COND_V_MSG(err != OK, "", vformat("Cannot open %s file in res://.", file_name));
 
     dir_access->copy(file_res_path, file_user_path);
-#else
-    if (!FileAccess::exists(file_user_path) || FileAccess::get_md5(file_user_path) != FileAccess::get_md5(file_res_path)) {
-        LOG_VERBOSE(vformat("%s file has changed. Copying it from res:// to user://.", file_name));
 
-        Error err;
-        Ref<DirAccess> dir_access {DirAccess::open(BUILD_DIRECTORY, &err)};
-
-        JVM_ERR_FAIL_COND_V_MSG(err != OK, "", vformat("Cannot open %s file in res://.", file_name));
-
-        dir_access->copy(file_res_path, file_user_path);
+#ifndef __ANDROID__
     }
 #endif
+
     return file_user_path;
 }
 

--- a/src/lifecycle/class_loader.cpp
+++ b/src/lifecycle/class_loader.cpp
@@ -1,5 +1,9 @@
 #include "class_loader.h"
 
+#ifdef __ANDROID__
+#include <sys/stat.h>
+#endif
+
 #include <cassert>
 
 ClassLoader::ClassLoader(jni::Env& p_env, jni::JObject p_wrapped) {
@@ -31,6 +35,9 @@ jni::JObject to_java_url(jni::Env& env, const String& bootstrapJar) {
 
 ClassLoader* ClassLoader::create_instance(jni::Env& env, const String& full_jar_path, const jni::JObject& p_parent_loader) {
 #ifdef __ANDROID__
+    // mark file as read only. Needed since android 14: https://developer.android.com/about/versions/14/behavior-changes-14#safer-dynamic-code-loading
+    chmod(full_jar_path.utf8().get_data(), S_IRUSR | S_IRGRP | S_IROTH);
+
     jni::JClass class_loader_cls {env.find_class("dalvik/system/DexClassLoader")};
     jni::MethodId ctor {class_loader_cls.get_constructor_method_id(env, "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;)V")
     };


### PR DESCRIPTION
This implements multidex support for both usercode jar and bootstrap jar:
![2024-05-09T22:02:35,106757814+02:00](https://github.com/utopia-rise/godot-kotlin-jvm/assets/22662033/9e69c194-6d18-4b5f-b66c-232abeae5098)

This also fixes an issue regarding dynamic code loading on android 14 when built with the corresponding target sdk version: https://developer.android.com/about/versions/14/behavior-changes-14#safer-dynamic-code-loading

Android export tested on our tests project.
Will test the 3D demo project tomorrow as well