### PR TITLE
Add better jni error reporting inside the godot editor

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/exception/ExceptionTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/exception/ExceptionTest.kt
@@ -1,0 +1,14 @@
+package godot.tests.exception
+
+import godot.Node
+import godot.annotation.RegisterClass
+import godot.annotation.RegisterFunction
+
+@RegisterClass
+class ExceptionTest: Node() {
+
+    @RegisterFunction
+    fun throwException() {
+        throw RuntimeException("Test exception")
+    }
+}

--- a/harness/tests/test/unit/test_exception.gd
+++ b/harness/tests/test/unit/test_exception.gd
@@ -1,7 +1,7 @@
 extends "res://addons/gut/test.gd"
 
 
-func test_reflection_working() -> void:
+func test_exception_printing_in_editor() -> void:
 	var exception_test_script = load("res://scripts/godot/tests/exception/ExceptionTest.gdj").new()
 	exception_test_script.throw_exception()
 	assert_true(true) # fake assert; exception printed to console and godot editor

--- a/harness/tests/test/unit/test_exception.gd
+++ b/harness/tests/test/unit/test_exception.gd
@@ -1,0 +1,8 @@
+extends "res://addons/gut/test.gd"
+
+
+func test_reflection_working() -> void:
+	var exception_test_script = load("res://scripts/godot/tests/exception/ExceptionTest.gdj").new()
+	exception_test_script.throw_exception()
+	assert_true(true) # fake assert; exception printed to console and godot editor
+	exception_test_script.free()

--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -59,10 +59,8 @@ namespace jni {
                 jmethodID toStringMethod = env->GetMethodID(stringWriterClass, "toString", "()Ljava/lang/String;");
                 auto jStackTraceString = (jstring) env->CallObjectMethod(stringWriter, toStringMethod);
 
-                // Convert Java String to C++ string
                 const char* cStackTrace = env->GetStringUTFChars(jStackTraceString, nullptr);
                 String stackTrace {cStackTrace};
-                // Release memory
                 env->ReleaseStringUTFChars(jStackTraceString, cStackTrace);
 
                 return stackTrace;

--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -39,7 +39,7 @@ namespace jni {
     }
 
     String Env::exception_describe() {
-#ifdef TOOLS_ENABLED
+#ifdef DEBUG_ENABLED
         jthrowable e = env->ExceptionOccurred();
 
         if (e != nullptr) {

--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -44,22 +44,22 @@ namespace jni {
 
         if (e != nullptr) {
             try {
-                jclass stringWriterClass = env->FindClass("java/io/StringWriter");
-                jmethodID stringWriterConstructor = env->GetMethodID(stringWriterClass, "<init>", "()V");
-                jobject stringWriter = env->NewObject(stringWriterClass, stringWriterConstructor);
+                jclass stringWriterClass {env->FindClass("java/io/StringWriter")};
+                jmethodID stringWriterConstructor {env->GetMethodID(stringWriterClass, "<init>", "()V")};
+                jobject stringWriter {env->NewObject(stringWriterClass, stringWriterConstructor)};
 
-                jclass printWriterClass = env->FindClass("java/io/PrintWriter");
-                jmethodID printWriterConstructor = env->GetMethodID(printWriterClass, "<init>", "(Ljava/io/Writer;)V");
-                jobject printWriter = env->NewObject(printWriterClass, printWriterConstructor, stringWriter);
+                jclass printWriterClass {env->FindClass("java/io/PrintWriter")};
+                jmethodID printWriterConstructor {env->GetMethodID(printWriterClass, "<init>", "(Ljava/io/Writer;)V")};
+                jobject printWriter {env->NewObject(printWriterClass, printWriterConstructor, stringWriter)};
 
-                jclass throwableClass = env->FindClass("java/lang/Throwable");
-                jmethodID printStackTraceMethod = env->GetMethodID(throwableClass, "printStackTrace", "(Ljava/io/PrintWriter;)V");
+                jclass throwableClass {env->FindClass("java/lang/Throwable")};
+                jmethodID printStackTraceMethod {env->GetMethodID(throwableClass, "printStackTrace", "(Ljava/io/PrintWriter;)V")};
                 env->CallVoidMethod(e, printStackTraceMethod, printWriter);
 
-                jmethodID toStringMethod = env->GetMethodID(stringWriterClass, "toString", "()Ljava/lang/String;");
-                auto jStackTraceString = (jstring) env->CallObjectMethod(stringWriter, toStringMethod);
+                jmethodID toStringMethod {env->GetMethodID(stringWriterClass, "toString", "()Ljava/lang/String;")};
+                auto jStackTraceString {(jstring) env->CallObjectMethod(stringWriter, toStringMethod)};
 
-                const char* cStackTrace = env->GetStringUTFChars(jStackTraceString, nullptr);
+                const char* cStackTrace {env->GetStringUTFChars(jStackTraceString, nullptr)};
                 String stackTrace {cStackTrace};
                 env->ReleaseStringUTFChars(jStackTraceString, cStackTrace);
 
@@ -81,7 +81,7 @@ namespace jni {
 
     void Env::check_exceptions() {
         if (exception_check()) {
-            String exception = exception_describe();
+            String exception {exception_describe()};
             exception_clear();
 
             if (exception.is_empty()) {

--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -38,8 +38,42 @@ namespace jni {
         return env->ExceptionCheck();
     }
 
-    void Env::exception_describe() {
+    String Env::exception_describe() {
+#ifdef TOOLS_ENABLED
+        jthrowable e = env->ExceptionOccurred();
+
+        if (e != nullptr) {
+            try {
+                jclass stringWriterClass = env->FindClass("java/io/StringWriter");
+                jmethodID stringWriterConstructor = env->GetMethodID(stringWriterClass, "<init>", "()V");
+                jobject stringWriter = env->NewObject(stringWriterClass, stringWriterConstructor);
+
+                jclass printWriterClass = env->FindClass("java/io/PrintWriter");
+                jmethodID printWriterConstructor = env->GetMethodID(printWriterClass, "<init>", "(Ljava/io/Writer;)V");
+                jobject printWriter = env->NewObject(printWriterClass, printWriterConstructor, stringWriter);
+
+                jclass throwableClass = env->FindClass("java/lang/Throwable");
+                jmethodID printStackTraceMethod = env->GetMethodID(throwableClass, "printStackTrace", "(Ljava/io/PrintWriter;)V");
+                env->CallVoidMethod(e, printStackTraceMethod, printWriter);
+
+                jmethodID toStringMethod = env->GetMethodID(stringWriterClass, "toString", "()Ljava/lang/String;");
+                auto jStackTraceString = (jstring) env->CallObjectMethod(stringWriter, toStringMethod);
+
+                // Convert Java String to C++ string
+                const char* cStackTrace = env->GetStringUTFChars(jStackTraceString, nullptr);
+                String stackTrace {cStackTrace};
+                // Release memory
+                env->ReleaseStringUTFChars(jStackTraceString, cStackTrace);
+
+                return stackTrace;
+            } catch (...) {
+                return {};
+            }
+        }
+#else
         env->ExceptionDescribe();
+#endif
+        return {};
     }
 
     void Env::exception_clear() {
@@ -48,9 +82,13 @@ namespace jni {
 
     void Env::check_exceptions() {
         if (exception_check()) {
-            exception_describe();
+            String exception = exception_describe();
             exception_clear();
-            HANDLE_JVM_EXCEPTIONS(true, "An exception has occurred!");
+
+            if (exception.is_empty()) {
+                exception = "An exception has occurred!";
+            }
+            HANDLE_JVM_EXCEPTIONS(true, exception);
         }
     }
 

--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -40,9 +40,7 @@ namespace jni {
 
     String Env::exception_describe() {
 #ifdef DEBUG_ENABLED
-        jthrowable e = env->ExceptionOccurred();
-
-        if (e != nullptr) {
+        if (jthrowable e = env->ExceptionOccurred()) {
             jclass string_writer_class {env->FindClass("java/io/StringWriter")};
             jmethodID string_writer_constructor {env->GetMethodID(string_writer_class, "<init>", "()V")};
             jobject string_writer {env->NewObject(string_writer_class, string_writer_constructor)};

--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -44,26 +44,26 @@ namespace jni {
 
         if (e != nullptr) {
             try {
-                jclass stringWriterClass {env->FindClass("java/io/StringWriter")};
-                jmethodID stringWriterConstructor {env->GetMethodID(stringWriterClass, "<init>", "()V")};
-                jobject stringWriter {env->NewObject(stringWriterClass, stringWriterConstructor)};
+                jclass string_writer_class {env->FindClass("java/io/StringWriter")};
+                jmethodID string_writer_constructor {env->GetMethodID(string_writer_class, "<init>", "()V")};
+                jobject string_writer {env->NewObject(string_writer_class, string_writer_constructor)};
 
-                jclass printWriterClass {env->FindClass("java/io/PrintWriter")};
-                jmethodID printWriterConstructor {env->GetMethodID(printWriterClass, "<init>", "(Ljava/io/Writer;)V")};
-                jobject printWriter {env->NewObject(printWriterClass, printWriterConstructor, stringWriter)};
+                jclass print_writer_class {env->FindClass("java/io/PrintWriter")};
+                jmethodID print_writer_constructor {env->GetMethodID(print_writer_class, "<init>", "(Ljava/io/Writer;)V")};
+                jobject print_writer {env->NewObject(print_writer_class, print_writer_constructor, string_writer)};
 
-                jclass throwableClass {env->FindClass("java/lang/Throwable")};
-                jmethodID printStackTraceMethod {env->GetMethodID(throwableClass, "printStackTrace", "(Ljava/io/PrintWriter;)V")};
-                env->CallVoidMethod(e, printStackTraceMethod, printWriter);
+                jclass throwable_class {env->FindClass("java/lang/Throwable")};
+                jmethodID print_stack_trace_method {env->GetMethodID(throwable_class, "printStackTrace", "(Ljava/io/PrintWriter;)V")};
+                env->CallVoidMethod(e, print_stack_trace_method, print_writer);
 
-                jmethodID toStringMethod {env->GetMethodID(stringWriterClass, "toString", "()Ljava/lang/String;")};
-                auto jStackTraceString {(jstring) env->CallObjectMethod(stringWriter, toStringMethod)};
+                jmethodID to_string_method {env->GetMethodID(string_writer_class, "toString", "()Ljava/lang/String;")};
+                auto j_stack_trace_string {(jstring) env->CallObjectMethod(string_writer, to_string_method)};
 
-                const char* cStackTrace {env->GetStringUTFChars(jStackTraceString, nullptr)};
-                String stackTrace {cStackTrace};
-                env->ReleaseStringUTFChars(jStackTraceString, cStackTrace);
+                const char* c_stack_trace {env->GetStringUTFChars(j_stack_trace_string, nullptr)};
+                String stack_trace {c_stack_trace};
+                env->ReleaseStringUTFChars(j_stack_trace_string, c_stack_trace);
 
-                return stackTrace;
+                return stack_trace;
             } catch (...) {
                 env->ExceptionDescribe();
                 return {};

--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -43,31 +43,26 @@ namespace jni {
         jthrowable e = env->ExceptionOccurred();
 
         if (e != nullptr) {
-            try {
-                jclass string_writer_class {env->FindClass("java/io/StringWriter")};
-                jmethodID string_writer_constructor {env->GetMethodID(string_writer_class, "<init>", "()V")};
-                jobject string_writer {env->NewObject(string_writer_class, string_writer_constructor)};
+            jclass string_writer_class {env->FindClass("java/io/StringWriter")};
+            jmethodID string_writer_constructor {env->GetMethodID(string_writer_class, "<init>", "()V")};
+            jobject string_writer {env->NewObject(string_writer_class, string_writer_constructor)};
 
-                jclass print_writer_class {env->FindClass("java/io/PrintWriter")};
-                jmethodID print_writer_constructor {env->GetMethodID(print_writer_class, "<init>", "(Ljava/io/Writer;)V")};
-                jobject print_writer {env->NewObject(print_writer_class, print_writer_constructor, string_writer)};
+            jclass print_writer_class {env->FindClass("java/io/PrintWriter")};
+            jmethodID print_writer_constructor {env->GetMethodID(print_writer_class, "<init>", "(Ljava/io/Writer;)V")};
+            jobject print_writer {env->NewObject(print_writer_class, print_writer_constructor, string_writer)};
 
-                jclass throwable_class {env->FindClass("java/lang/Throwable")};
-                jmethodID print_stack_trace_method {env->GetMethodID(throwable_class, "printStackTrace", "(Ljava/io/PrintWriter;)V")};
-                env->CallVoidMethod(e, print_stack_trace_method, print_writer);
+            jclass throwable_class {env->FindClass("java/lang/Throwable")};
+            jmethodID print_stack_trace_method {env->GetMethodID(throwable_class, "printStackTrace", "(Ljava/io/PrintWriter;)V")};
+            env->CallVoidMethod(e, print_stack_trace_method, print_writer);
 
-                jmethodID to_string_method {env->GetMethodID(string_writer_class, "toString", "()Ljava/lang/String;")};
-                auto j_stack_trace_string {(jstring) env->CallObjectMethod(string_writer, to_string_method)};
+            jmethodID to_string_method {env->GetMethodID(string_writer_class, "toString", "()Ljava/lang/String;")};
+            auto j_stack_trace_string {(jstring) env->CallObjectMethod(string_writer, to_string_method)};
 
-                const char* c_stack_trace {env->GetStringUTFChars(j_stack_trace_string, nullptr)};
-                String stack_trace {c_stack_trace};
-                env->ReleaseStringUTFChars(j_stack_trace_string, c_stack_trace);
+            const char* c_stack_trace {env->GetStringUTFChars(j_stack_trace_string, nullptr)};
+            String stack_trace {c_stack_trace};
+            env->ReleaseStringUTFChars(j_stack_trace_string, c_stack_trace);
 
-                return stack_trace;
-            } catch (...) {
-                env->ExceptionDescribe();
-                return {};
-            }
+            return stack_trace;
         }
 #else
         env->ExceptionDescribe();

--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -67,6 +67,7 @@ namespace jni {
 
                 return stackTrace;
             } catch (...) {
+                env->ExceptionDescribe();
                 return {};
             }
         }

--- a/src/jni/env.h
+++ b/src/jni/env.h
@@ -35,7 +35,7 @@ namespace jni {
         String from_jstring(jni::JString str);
 
         bool exception_check();
-        void exception_describe();
+        String exception_describe();
         void exception_clear();
 
         void check_exceptions();


### PR DESCRIPTION
This improves the jni error reporting inside the godot editor by grabbing the stacktrace from the jvm and printing them using the godot print commands. Only applies to tool mode. In all other cases, we still print the error using the jni provided method which just prints to the console.


![2024-05-10T12:05:06,018362263+02:00](https://github.com/utopia-rise/godot-kotlin-jvm/assets/22662033/78798d9e-52d9-400e-b2bd-1374e9c1251c)
![2024-05-10T11:57:53,693923600+02:00](https://github.com/utopia-rise/godot-kotlin-jvm/assets/22662033/e6c800a1-30a5-45c0-86ff-f9048303e21b)
![2024-05-10T12:04:09,201022038+02:00](https://github.com/utopia-rise/godot-kotlin-jvm/assets/22662033/849e3d78-aee3-4229-b54d-43fe895d8ba5)
![2024-05-10T12:00:49,301472094+02:00](https://github.com/utopia-rise/godot-kotlin-jvm/assets/22662033/ed95c906-8cce-44eb-b53d-1b86988e012e)

