### PR TITLE
Fix extension method name

### DIFF
--- a/kt/godot-library/src/main/kotlin/godot/extensions/PackedSceneExt.kt
+++ b/kt/godot-library/src/main/kotlin/godot/extensions/PackedSceneExt.kt
@@ -5,7 +5,7 @@ import godot.Node
 import godot.PackedScene
 
 @Suppress("NOTHING_TO_INLINE", "UNCHECKED_CAST")
-inline fun <T : Node> PackedScene.instanceAs(
+inline fun <T : Node> PackedScene.instantiateAs(
     editState: PackedScene.GenEditState = PackedScene.GenEditState.GEN_EDIT_STATE_DISABLED
 ): T? {
     return instantiate(editState) as T?


### PR DESCRIPTION
Little fix; when we migrated to godot 4, we forgot to rename this extension function