### PR TITLE
Make jre folder platform dependent

### DIFF
--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -67,6 +67,6 @@ jobs:
         run: |
           cd modules/kotlin_jvm/harness/tests/
           chmod +x ../../../../bin/godot.*
-          jlink --add-modules java.base,java.logging --output jre-amd64
+          jlink --add-modules java.base,java.logging --output jre-amd64-linux
           ./gradlew runGutTests
         timeout-minutes: 30

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -67,6 +67,6 @@ jobs:
         run: |
           cd modules/kotlin_jvm/harness/tests/
           chmod +x ../../../../bin/godot.*
-          jlink --add-modules java.base,java.logging --output jre-arm64
+          jlink --add-modules java.base,java.logging --output jre-arm64-macos
           ./gradlew runGutTests
         timeout-minutes: 30

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -66,6 +66,6 @@ jobs:
       - name: Run Tests
         run: |
           cd modules/kotlin_jvm/harness/tests/
-          jlink --add-modules java.base,java.logging --output jre-amd64
+          jlink --add-modules java.base,java.logging --output jre-amd64-windows
           ./gradlew runGutTests
         timeout-minutes: 30

--- a/docs/src/doc/contribution/setup.md
+++ b/docs/src/doc/contribution/setup.md
@@ -35,9 +35,9 @@ scons platform=linuxbsd # your target platform (windows, macos, ...)
     1. Navigate to `<module-root>/harness/tests`
     2. Create an embedded Java Virtual Machine:
         - For `amd64` systems:
-          - `jlink --add-modules java.base,java.logging --output jre-amd64`
+          - `jlink --add-modules java.base,java.logging --output jre-amd64-<platform ex. linux>`
         - For `arm64` (macOS with **Apple Silicon** chips) systems:
-          - `jlink --add-modules java.base,java.logging --output jre-arm64`
+          - `jlink --add-modules java.base,java.logging --output jre-arm64-<platform ex. macos>`
         - If you want to remote debug add module `jdk.jdwp.agent` to command.
         - If you want to enable `jmx`, add `jdk.management.agent` to command.
     3. Then build the project using the Gradle wrapper.

--- a/docs/src/doc/user-guide/debugging.md
+++ b/docs/src/doc/user-guide/debugging.md
@@ -5,8 +5,8 @@ In order to debug your code using an embedded JRE, make sure to include the foll
 - `jdk.jdwp.agent`
 
 !!! info
-    Example for AMD64 systems: `jlink --add-modules java.base,java.logging,jdk.jdwp.agent --output jre-amd64`  
-    Example for ARM64 systems: `jlink --add-modules java.base,java.logging,jdk.jdwp.agent --output jre-arm64`
+    Example for AMD64 systems: `jlink --add-modules java.base,java.logging,jdk.jdwp.agent --output jre-amd64-linux` (make sure to swap `linux` to your platform!)  
+    Example for ARM64 systems: `jlink --add-modules java.base,java.logging,jdk.jdwp.agent --output jre-arm64-macos` (make sure to swap `macos` to your platform!)
 
 If you're still using the JDK installed on your system though, you don't need to do this.
 

--- a/docs/src/doc/user-guide/exporting.md
+++ b/docs/src/doc/user-guide/exporting.md
@@ -21,12 +21,21 @@ To export your game, you need to have an embedded JRE created. Run the following
 
 - amd64 systems:
     ```shell
-    jlink --add-modules java.base,java.logging --output jre-amd64
+    jlink --add-modules java.base,java.logging --output jre-amd64-linux
     ```
 - arm64 systems:
     ```shell
-    jlink --add-modules java.base,java.logging --output jre-arm64
+    jlink --add-modules java.base,java.logging --output jre-arm64-macos
     ```
+
+!!! info
+    As the jre is platform dependent, you need to create a jre for each platform. Adjust the above command on a per-platform basis:  
+    - For Linux: `jre-amd64-linux`
+    - For Windows: `jre-amd64-windows`
+    - For MacOS: 
+        - `jre-amd64-macos`
+        - `jre-arm64-macos`
+    - For iOS and Android, no embedded JRE is needed
 
 The above command will create a very minimal JVM, if you need extra features you can include the following modules:
 

--- a/docs/src/doc/user-guide/exporting.md
+++ b/docs/src/doc/user-guide/exporting.md
@@ -30,11 +30,11 @@ To export your game, you need to have an embedded JRE created. Run the following
 
 !!! info
     As the jre is platform dependent, you need to create a jre for each platform. Adjust the above command on a per-platform basis:  
-    - For Linux: `jre-amd64-linux`
-    - For Windows: `jre-amd64-windows`
-    - For MacOS: 
-        - `jre-amd64-macos`
-        - `jre-arm64-macos`
+    - For Linux: `jre-amd64-linux`  
+    - For Windows: `jre-amd64-windows`  
+    - For MacOS:  
+        - `jre-amd64-macos`  
+        - `jre-arm64-macos`  
     - For iOS and Android, no embedded JRE is needed
 
 The above command will create a very minimal JVM, if you need extra features you can include the following modules:

--- a/docs/src/doc/user-guide/exporting.md
+++ b/docs/src/doc/user-guide/exporting.md
@@ -29,12 +29,12 @@ To export your game, you need to have an embedded JRE created. Run the following
     ```
 
 !!! info
-    As the jre is platform dependent, you need to create a jre for each platform. Adjust the above command on a per-platform basis:  
+    As the jre is platform dependent, you need to create a jre for each platform. Adjust the above command on a per-platform basis:    
     - For Linux: `jre-amd64-linux`  
-    - For Windows: `jre-amd64-windows`  
+    - For Windows: `jre-amd64-windows`    
     - For MacOS:  
         - `jre-amd64-macos`  
-        - `jre-arm64-macos`  
+        - `jre-arm64-macos`    
     - For iOS and Android, no embedded JRE is needed
 
 The above command will create a very minimal JVM, if you need extra features you can include the following modules:

--- a/harness/tests/.gitignore
+++ b/harness/tests/.gitignore
@@ -5,8 +5,8 @@
 # Ignore Gradle build output directory
 build
 
-jre-arm64
-jre-amd64
+jre-arm64-*
+jre-amd64-*
 
 graal/godot-kotlin-graal-jni-config.json
 

--- a/harness/tests/export_presets.cfg
+++ b/harness/tests/export_presets.cfg
@@ -1,6 +1,6 @@
 [preset.0]
 
-name="Windows Desktop"
+name="Windows"
 platform="Windows Desktop"
 runnable=true
 dedicated_server=false
@@ -8,7 +8,7 @@ custom_features=""
 export_filter="all_resources"
 include_filter="*.txt, *.cfg"
 exclude_filter=""
-export_path="../tests-win64-export/Godot Kotlin Tests.exe"
+export_path="./export/windows_export.exe"
 encryption_include_filters=""
 encryption_exclude_filters=""
 encrypt_pck=false
@@ -16,8 +16,8 @@ encrypt_directory=false
 
 [preset.0.options]
 
-custom_template/debug=""
-custom_template/release=""
+custom_template/debug="../../../../bin/godot.windows.template_debug.x86_64.exe"
+custom_template/release="../../../../bin/godot.windows.template_release.x86_64.exe"
 debug/export_console_wrapper=1
 binary_format/embed_pck=false
 texture_format/bptc=false
@@ -270,15 +270,15 @@ xr_features/passthrough=0
 
 [preset.2]
 
-name="Linux/X11"
+name="Linux"
 platform="Linux/X11"
 runnable=true
 dedicated_server=false
 custom_features=""
 export_filter="all_resources"
 include_filter="*.txt, *.cfg"
-exclude_filter=",res://godot_kotlin_configuration.json"
-export_path="./Godot Kotlin Tests.x86_64"
+exclude_filter=""
+export_path="./export/linux_export.x86_64"
 encryption_include_filters=""
 encryption_exclude_filters=""
 encrypt_pck=false
@@ -287,7 +287,7 @@ encrypt_directory=false
 [preset.2.options]
 
 custom_template/debug="../../../../bin/godot.linuxbsd.template_debug.x86_64"
-custom_template/release=""
+custom_template/release="../../../../bin/godot.linuxbsd.template_release.x86_64"
 debug/export_console_wrapper=1
 binary_format/embed_pck=false
 texture_format/bptc=false
@@ -393,7 +393,7 @@ custom_features=""
 export_filter="all_resources"
 include_filter=""
 exclude_filter=",res://godot_kotlin_configuration.json,res://godot_kotlin_configuration.json,res://godot_kotlin_configuration.json,res://godot_kotlin_configuration.json,res://godot_kotlin_configuration.json,res://godot_kotlin_configuration.json,res://godot_kotlin_configuration.json"
-export_path="../../../../../../godot-kotlin-tests-macos-export/ios-export-java17.dmg"
+export_path="./export/macos_export.dmg"
 encryption_include_filters=""
 encryption_exclude_filters=""
 encrypt_pck=false

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/generateGdIgnoreFilesTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/generateGdIgnoreFilesTask.kt
@@ -24,8 +24,11 @@ fun Project.generateGdIgnoreFilesTask(): TaskProvider<Task> {
                 val targetDirSequence = sequenceOf(
                     buildDir,
                     projectDir.resolve("gradle"),
-                    projectDir.resolve("jre-arm64"),
-                    projectDir.resolve("jre-amd64"),
+                    *(projectDir
+                        .listFiles()
+                        ?.filter { it.name.startsWith("jre-") }
+                        ?.toTypedArray()
+                        ?: emptyArray()),
                 )
                 targetDirSequence.filter { dirToIgnore -> dirToIgnore.exists() && dirToIgnore.isDirectory }
                     .forEach { dirToIgnore ->

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -323,7 +323,7 @@ bool GDKotlin::load_dynamic_lib() {
 
 #ifdef TOOLS_ENABLED
 String GDKotlin::get_path_to_embedded_jvm() {
-    String godot_path {String(RES_DIRECTORY).path_join(EMBEDDED_JRE_DIRECTORY).path_join(RELATIVE_JVM_LIB_PATH)};
+    String godot_path {String(RES_DIRECTORY).path_join(HOST_EMBEDDED_JRE_DIRECTORY).path_join(RELATIVE_JVM_LIB_PATH)};
     return ProjectSettings::get_singleton()->globalize_path(godot_path);
 }
 
@@ -347,7 +347,7 @@ String GDKotlin::get_path_to_embedded_jvm() {
 #if defined(MACOS_ENABLED)
       .path_join("../PlugIns/")
 #endif
-      .path_join(EMBEDDED_JRE_DIRECTORY)
+      .path_join(HOST_EMBEDDED_JRE_DIRECTORY)
       .path_join(RELATIVE_JVM_LIB_PATH);
 }
 

--- a/src/lifecycle/paths.h
+++ b/src/lifecycle/paths.h
@@ -23,6 +23,37 @@ static constexpr const char* IOS_BOOTSTRAP_FILE {""};
 static constexpr const char* IOS_USER_CODE_FILE {""};
 static constexpr const char* IOS_GRAAL_NATIVE_IMAGE_FILE {"usercode.a"};
 
+static constexpr const char* LINUX_EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64-linux"};
+static constexpr const char* LINUX_EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64-linux"};
+
+static constexpr const char* WINDOWS_EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64-windows"};
+static constexpr const char* WINDOWS_EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64-windows"};
+
+static constexpr const char* MACOS_EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64-macos"};
+static constexpr const char* MACOS_EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64-macos"};
+
+#ifdef X11_ENABLED
+#ifdef __arm64__
+static constexpr const char* HOST_EMBEDDED_JRE_DIRECTORY {LINUX_EMBEDDED_JRE_ARM_DIRECTORY};
+#else
+static constexpr const char* HOST_EMBEDDED_JRE_DIRECTORY {LINUX_EMBEDDED_JRE_AMD_DIRECTORY};
+#endif
+
+#elif WINDOWS_ENABLED
+#ifdef __arm64__
+static constexpr const char* HOST_EMBEDDED_JRE_DIRECTORY {WINDOWS_EMBEDDED_JRE_ARM_DIRECTORY};
+#else
+static constexpr const char* HOST_EMBEDDED_JRE_DIRECTORY {WINDOWS_EMBEDDED_JRE_AMD_DIRECTORY};
+#endif
+
+#elif MACOS_ENABLED
+#ifdef __arm64__
+static constexpr const char* HOST_EMBEDDED_JRE_DIRECTORY {MACOS_EMBEDDED_JRE_ARM_DIRECTORY};
+#else
+static constexpr const char* HOST_EMBEDDED_JRE_DIRECTORY {MACOS_EMBEDDED_JRE_AMD_DIRECTORY};
+#endif
+#endif
+
 #ifdef X11_ENABLED
 
 static constexpr const char* RELATIVE_JVM_LIB_PATH {LINUX_RELATIVE_JVM_LIB_PATH};
@@ -63,26 +94,6 @@ static constexpr const char* BOOTSTRAP_FILE {IOS_BOOTSTRAP_FILE};
 static constexpr const char* USER_CODE_FILE {IOS_USER_CODE_FILE};
 static constexpr const char* GRAAL_NATIVE_IMAGE_FILE {IOS_GRAAL_NATIVE_IMAGE_FILE};
 
-#endif
-
-#ifdef X11_ENABLED
-static constexpr const char* EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64-linux"};
-static constexpr const char* EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64-linux"};
-#elif WINDOWS_ENABLED
-static constexpr const char* EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64-windows"};
-static constexpr const char* EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64-windows"};
-#elif OSX_ENABLED
-static constexpr const char* EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64-macos"};
-static constexpr const char* EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64-macos"};
-#else
-static constexpr const char* EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64"};
-static constexpr const char* EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64"};
-#endif
-
-#ifdef __arm64__
-static constexpr const char* EMBEDDED_JRE_DIRECTORY {EMBEDDED_JRE_ARM_DIRECTORY};
-#else
-static constexpr const char* EMBEDDED_JRE_DIRECTORY {EMBEDDED_JRE_AMD_DIRECTORY};
 #endif
 
 static constexpr const char* ENTRY_DIRECTORY {"res://build/generated/ksp"};

--- a/src/lifecycle/paths.h
+++ b/src/lifecycle/paths.h
@@ -65,8 +65,19 @@ static constexpr const char* GRAAL_NATIVE_IMAGE_FILE {IOS_GRAAL_NATIVE_IMAGE_FIL
 
 #endif
 
+#ifdef X11_ENABLED
+static constexpr const char* EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64-linux"};
+static constexpr const char* EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64-linux"};
+#elif WINDOWS_ENABLED
+static constexpr const char* EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64-windows"};
+static constexpr const char* EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64-windows"};
+#elif OSX_ENABLED
+static constexpr const char* EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64-macos"};
+static constexpr const char* EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64-macos"};
+#else
 static constexpr const char* EMBEDDED_JRE_ARM_DIRECTORY {"jre-arm64"};
 static constexpr const char* EMBEDDED_JRE_AMD_DIRECTORY {"jre-amd64"};
+#endif
 
 #ifdef __arm64__
 static constexpr const char* EMBEDDED_JRE_DIRECTORY {EMBEDDED_JRE_ARM_DIRECTORY};

--- a/src/logging.h
+++ b/src/logging.h
@@ -9,6 +9,9 @@
 #define LOG_INFO(message) print_line(vformat("Godot-JVM: %s", message))
 #define LOG_WARNING(message) WARN_PRINT(vformat("Godot-JVM: %s", message))
 #define LOG_ERROR(message) ERR_PRINT(vformat("Godot-JVM: %s", message))
+#define LOG_ERROR_WITH_ALERT(message)                   \
+    OS::get_singleton()->alert(message, "Fatal error"); \
+    ERR_PRINT(vformat("Godot-JVM: %s", message))
 
 #define JVM_ERR_FAIL_MSG(message) ERR_FAIL_EDMSG(vformat("Godot-JVM: %s", message))
 #define JVM_ERR_FAIL_V_MSG(ret_var, message) ERR_FAIL_V_EDMSG(ret_var, vformat("Godot-JVM: %s", message))


### PR DESCRIPTION
This makes the jre folder platform dependent.

This makes it possible for a project to have multiple jre folder simultaneously on the file system. The module then automatically picks the correct one for the current platform.
The main advantage of this is that on a project with multiple people working on it, the embedded jre can be committed to the repository for each platform together with the built jar and a project member does not need to have java locally installed and JAVA_HOME set. Which is especially useful if one is working with non programmers.

**Note:** Breaking change. Needs special notes in release notes!