### PR TITLE
Fix PathScript caching.

### DIFF
--- a/src/jvm_wrapper/bridge/variant_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/variant_array_bridge.cpp
@@ -23,7 +23,7 @@ uintptr_t VariantArrayBridge::engine_call_constructor_typed(JNIEnv* p_raw_env, j
     StringName base_class_name;
     Variant script;
     if (userTypeIndex != -1) {
-        const Ref<JvmScript>& kotlin_script {JvmScriptManager::get_instance().get_user_script_for_index(userTypeIndex)};
+        const Ref<JvmScript>& kotlin_script {JvmScriptManager::get_instance().get_named_script_for_index(userTypeIndex)};
         base_class_name = kotlin_script->get_instance_base_type();
         script = kotlin_script;
     } else if (engineTypeIndex != -1) {

--- a/src/jvm_wrapper/memory/transfer_context.cpp
+++ b/src/jvm_wrapper/memory/transfer_context.cpp
@@ -133,7 +133,7 @@ void TransferContext::create_native_object(JNIEnv* p_raw_env, jobject p_instance
     int script_index {static_cast<int>(p_script_index)};
     if (script_index != -1) {
         KtObject* kt_object = memnew(KtObject(env, jni::JObject(p_object), ptr->is_ref_counted()));
-        Ref<JvmScript> kotlin_script {JvmScriptManager::get_instance().get_user_script_for_index(script_index)};
+        Ref<JvmScript> kotlin_script {JvmScriptManager::get_instance().get_named_script_for_index(script_index)};
         JvmInstance* script = memnew(JvmInstance(env, ptr, kt_object, kotlin_script.ptr()));
         ptr->set_script_instance(script);
     }

--- a/src/jvm_wrapper/registration/kt_class.cpp
+++ b/src/jvm_wrapper/registration/kt_class.cpp
@@ -41,7 +41,7 @@ KtObject* KtClass::create_instance(jni::Env& env, const Variant** p_args, int p_
 #endif
 
     KtObject* jvm_instance {constructor->create_instance(env, p_args, p_owner)};
-    LOG_DEV_VERBOSE(vformat("Instantiated an object with resource path %s", registered_class_name));
+    LOG_DEV_VERBOSE(vformat("Instantiated a Jvm script: %s", registered_class_name));
 
     return jvm_instance;
 }

--- a/src/language/gdj_language.cpp
+++ b/src/language/gdj_language.cpp
@@ -35,13 +35,6 @@ void GdjLanguage::init() {
 #endif
 }
 
-void GdjLanguage::frame() {
-#ifdef TOOLS_ENABLED
-    JvmScriptManager::get_instance().update_all_scripts();
-#endif
-}
-
-
 void GdjLanguage::thread_enter() {
     jni::Jvm::attach();
 }

--- a/src/language/gdj_language.cpp
+++ b/src/language/gdj_language.cpp
@@ -37,9 +37,10 @@ void GdjLanguage::init() {
 
 void GdjLanguage::frame() {
 #ifdef TOOLS_ENABLED
-    JvmScriptManager::get_instance().update_all_exports_if_dirty();
+    JvmScriptManager::get_instance().update_all_scripts();
 #endif
 }
+
 
 void GdjLanguage::thread_enter() {
     jni::Jvm::attach();
@@ -85,7 +86,7 @@ String GdjLanguage::get_global_class_name(const String& p_path, String* r_base_t
     if (p_path.begins_with(ENTRY_DIRECTORY) || !p_path.ends_with(GODOT_JVM_REGISTRATION_FILE_EXTENSION)) { return {}; }
 
     String script_name = JvmScript::get_script_file_name(p_path);
-    Ref<NamedScript> named_script = JvmScriptManager::get_instance().get_user_script_from_name(script_name);
+    Ref<NamedScript> named_script = JvmScriptManager::get_instance().get_script_from_name(script_name);
     if (!named_script.is_null() && named_script.is_valid()) {
         if (r_base_type) {
             if (named_script->get_base_script().is_null()) {

--- a/src/language/gdj_language.h
+++ b/src/language/gdj_language.h
@@ -13,7 +13,6 @@ public:
     static GdjLanguage* get_instance();
 
     void init() override;
-    void frame() override;
 
     void thread_enter() override;
     void thread_exit() override;

--- a/src/script/jvm_script.cpp
+++ b/src/script/jvm_script.cpp
@@ -59,7 +59,7 @@ bool JvmScript::inherits_script(const Ref<Script>& p_script) const {
 Ref<Script> JvmScript::get_base_script() const {
     if (!is_valid() || kotlin_class->registered_supertypes.size() == 0) { return {}; }
     StringName parent_name = kotlin_class->registered_supertypes[0];
-    return JvmScriptManager::get_instance().get_user_script_from_name(parent_name);
+    return JvmScriptManager::get_instance().get_script_from_name(parent_name);
 }
 
 StringName JvmScript::get_instance_base_type() const {
@@ -220,13 +220,7 @@ PlaceHolderScriptInstance* JvmScript::placeholder_instance_create(Object* p_this
     return placeholder;
 }
 
-void JvmScript::update_exports() {
-    // TODO: Remove this when multithreading is fixed.
-    if (!Thread::is_main_thread()) {
-        MessageQueue::get_singleton()->push_callable(callable_mp(this, &JvmScript::update_exports));
-        return;
-    }
-
+void JvmScript::update_script() {
     exported_members_default_value_cache.clear();
     if (!is_valid()) { return; }
 

--- a/src/script/jvm_script.h
+++ b/src/script/jvm_script.h
@@ -63,7 +63,7 @@ private:
 
 public:
     PlaceHolderScriptInstance* placeholder_instance_create(Object* p_this) override;
-    void update_exports() override;
+    void update_script();
     Vector<DocData::ClassDoc> get_documentation() const override;
     PropertyInfo get_class_category() const override;
     String get_class_icon_path() const override;

--- a/src/script/jvm_script_manager.cpp
+++ b/src/script/jvm_script_manager.cpp
@@ -122,12 +122,12 @@ Ref<PathScript> JvmScriptManager::get_script_from_path(const String& p_path) con
 #ifdef TOOLS_ENABLED
 void JvmScriptManager::update_all_scripts() {
     for (const Ref<NamedScript>& script : named_scripts) {
-        // We have to delay the update_export. The engine is not fully initialized and scripts can cause undefined behaviors.
+        // We have to delay the call to update_script. The engine is not fully initialized and scripts can cause undefined behaviors.
         JvmScript* ptr = script.ptr();
         MessageQueue::get_singleton()->push_callable(callable_mp(ptr, &JvmScript::update_script));
     }
     for (const Ref<PathScript>& script : path_scripts) {
-        // We have to delay the update_export. The engine is not fully initialized and scripts can cause undefined behaviors.
+        // We have to delay the call to update_script. The engine is not fully initialized and scripts can cause undefined behaviors.
         JvmScript* ptr = script.ptr();
         MessageQueue::get_singleton()->push_callable(callable_mp(ptr, &JvmScript::update_script));
     }

--- a/src/script/jvm_script_manager.cpp
+++ b/src/script/jvm_script_manager.cpp
@@ -122,10 +122,14 @@ Ref<PathScript> JvmScriptManager::get_script_from_path(const String& p_path) con
 #ifdef TOOLS_ENABLED
 void JvmScriptManager::update_all_scripts() {
     for (const Ref<NamedScript>& script : named_scripts) {
-        script->update_script();
+        // We have to delay the update_export. The engine is not fully initialized and scripts can cause undefined behaviors.
+        JvmScript* ptr = script.ptr();
+        MessageQueue::get_singleton()->push_callable(callable_mp(ptr, &JvmScript::update_script));
     }
     for (const Ref<PathScript>& script : path_scripts) {
-        script->update_script();
+        // We have to delay the update_export. The engine is not fully initialized and scripts can cause undefined behaviors.
+        JvmScript* ptr = script.ptr();
+        MessageQueue::get_singleton()->push_callable(callable_mp(ptr, &JvmScript::update_script));
     }
 }
 #endif

--- a/src/script/jvm_script_manager.h
+++ b/src/script/jvm_script_manager.h
@@ -4,15 +4,13 @@
 #include "jvm_script.h"
 
 class JvmScriptManager {
-#ifdef TOOLS_ENABLED
-    bool scripts_dirty = false;
-#endif
+    Vector<Ref<NamedScript>> named_scripts;
+    HashMap<StringName, Ref<NamedScript>> named_scripts_map;
 
-    Vector<Ref<NamedScript>> named_user_scripts;
-    HashMap<StringName, Ref<NamedScript>> named_user_scripts_map;
-
-    Vector<Ref<PathScript>> path_user_scripts;
     HashMap<String, StringName> filepath_to_name_map;
+
+    Vector<Ref<PathScript>> path_scripts;
+    HashMap<String, Ref<PathScript>> path_scripts_map;
 
     JvmScriptManager() = default;
     ~JvmScriptManager() = default;
@@ -26,34 +24,57 @@ public:
     static JvmScriptManager& get_instance();
 
     void create_and_update_scripts(Vector<KtClass*>& classes);
-    const Ref<NamedScript>& get_user_script_for_index(int p_index) const;
-    Ref<NamedScript> get_user_script_from_name(const StringName& name) const;
+
+    Ref<NamedScript> get_script_from_name(const StringName& name) const;
+    const Ref<NamedScript>& get_named_script_for_index(int p_index) const;
+    Ref<PathScript> get_script_from_path(const String& p_path) const;
+
+    template<class SCRIPT>
+    Ref<SCRIPT> get_or_create_script(const String& p_path);
+
     void clear();
 
-    template<class C>
-    Ref<C> create_script(const String& p_path);
-
 #ifdef TOOLS_ENABLED
-    void update_all_exports_if_dirty();
+    void update_all_scripts();
 #endif
 };
 
-template<class C>
-Ref<C> JvmScriptManager::create_script(const String& p_path) {
-    if constexpr (!std::is_base_of<JvmScript, C>()) return {};
+template<class SCRIPT>
+Ref<SCRIPT> JvmScriptManager::get_or_create_script(const String& p_path) {
+    if constexpr (!std::is_base_of<JvmScript, SCRIPT>()) return {};
     // Placeholder scripts have to be registered in the TypeManager in order to be transformed in valid scripts when the jar is built.
-    Ref<C> ref;
-    ref.instantiate();
-    if constexpr (std::is_base_of<NamedScript, C>()) {
-        named_user_scripts_map[ref->get_global_name()] = ref;
-        named_user_scripts.push_back(ref);
-    } else if constexpr (std::is_base_of<PathScript, C>()) {
-        if (filepath_to_name_map.has(p_path)) {
-            ref->kotlin_class = named_user_scripts_map[filepath_to_name_map[p_path]]->kotlin_class;
-            path_user_scripts.push_back(ref);
+
+    Ref<SCRIPT> script;
+    if constexpr (std::is_base_of<NamedScript, SCRIPT>()) {
+        // Named scripts are created and cached when loading the usercode, we create a placeholder if missing.
+        String script_name = JvmScript::get_script_file_name(p_path);
+        script = get_script_from_name(script_name);
+        if (script.is_null()) {
+            script.instantiate();
+            named_scripts_map[script_name] = script;
+            named_scripts.push_back(script);
+#ifdef DEBUG_ENABLED
+            LOG_WARNING(vformat("Loaded an unregistered JVM Script named %s", script_name));
+#endif
+        }
+    } else if constexpr (std::is_base_of<PathScript, SCRIPT>()) {
+        // Path Scripts are created on the fly used the mapping from path to name. If mapping can't be found, we create a placeholder.
+        script = get_script_from_path(p_path);
+        if (script.is_null()) {
+            script.instantiate();
+            if (filepath_to_name_map.has(p_path)) {
+                script->kotlin_class = named_scripts_map[filepath_to_name_map[p_path]]->kotlin_class;
+            }
+#ifdef DEBUG_ENABLED
+            else {
+                LOG_WARNING(vformat("Loaded an unregistered JVM Script with path %s", p_path));
+            }
+#endif
+            path_scripts_map[p_path] = script;
+            path_scripts.push_back(script);
         }
     }
-    return ref;
+    return script;
 }
 
 #endif// GODOT_JVM_JVM_SCRIPT_MANAGER_H


### PR DESCRIPTION
We never properly cached the Kotlin and Java Scripts.
Each time you reload the .jar, new ones are created instead of updating the ones already here which triggers a nasty side effect.

The original Script is replaced inside the ResourceLoader by the new one. And its path taken as well.
The consequence is that if you got a Godot scene opened when reloading and then save, the script is no longer recognized as an external resource (because no path) and is stored as an internal script (which we don't support).

I also move the content of update_export to another method. The reason is that Godot calls that method whenever it detects a change in the source files, which is totally useless in our case because only the .jar matters.

This doesn't require testing on each OS, but I welcome if you can monkey proof the reloading behaviour with gdj and Kotlin scripts.