### PR TITLE
Fix exception describe

### DIFF
--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -41,7 +41,7 @@ namespace jni {
     String Env::exception_describe() {
 #ifdef DEBUG_ENABLED
         if (jthrowable e = env->ExceptionOccurred()) {
-            env->ExceptionClear(); // needs to be cleared now as otherwise it spams errors. We already have a ref to the exception.
+            env->ExceptionClear(); // needs to be cleared now as otherwise it throws warnings at us in the following two jni calls that we do jni calls with a pending exception
             jclass string_writer_class {env->FindClass("java/io/StringWriter")};
             jmethodID string_writer_constructor {env->GetMethodID(string_writer_class, "<init>", "()V")};
             jobject string_writer {env->NewObject(string_writer_class, string_writer_constructor)};
@@ -55,6 +55,7 @@ namespace jni {
             env->CallVoidMethod(e, print_stack_trace_method, print_writer);
 
             if (exception_check()) {
+                // if we get here, it means we got an exception while calling `printStackTrace`. Hence, we cannot retrieve the stacktrace. No need to report that to the user. We just return an empty string.
                 exception_clear();
                 return {};
             }
@@ -63,6 +64,7 @@ namespace jni {
             auto j_stack_trace_string {(jstring) env->CallObjectMethod(string_writer, to_string_method)};
 
             if (exception_check()) {
+                // if we get here, it means we got an exception while calling `toString`. Hence, we cannot retrieve the stacktrace. No need to report that to the user. We just return an empty string.
                 exception_clear();
                 return {};
             }


### PR DESCRIPTION
This fixes the spawning of jni warning logs when grabbing the stacktrace from the jvm.

When implementing it initially, i did not notice the spam of errors as i checked one exception. But if there are more than one (let's say in a progress call) then the console is spammed with jni warnings for not checked exceptions.