### PR TITLE
fix function moveToward

### DIFF
--- a/kt/godot-library/src/main/kotlin/godot/global/GDMath.kt
+++ b/kt/godot-library/src/main/kotlin/godot/global/GDMath.kt
@@ -13,6 +13,8 @@ import godot.util.isEqualApprox
 import godot.util.isZeroApprox
 import godot.util.toRealT
 import kotlin.math.pow
+import kotlin.math.abs
+import kotlin.math.sign
 
 //Necessary for stepDecimal function
 const val MAX_N = 10
@@ -348,19 +350,19 @@ internal interface GDMath {
 
     /** Moves from toward to by the delta value.
      *  Use a negative delta value to move away. */
-    fun moveToward(from: Int, to: Int, delta: Int) = from + kotlin.math.min(to - from, delta)
+    fun moveToward(from: Int, to: Int, delta: Int) = if (abs(to - from) <= delta) to else from + (to - from).sign * delta
 
     /** Moves from toward to by the delta value.
      *  Use a negative delta value to move away. */
-    fun moveToward(from: Long, to: Long, delta: Long) = from + kotlin.math.min(to - from, delta)
+    fun moveToward(from: Long, to: Long, delta: Long) = if (abs(to - from) <= delta) to else from + (to - from).sign * delta
 
     /** Moves from toward to by the delta value.
      *  Use a negative delta value to move away. */
-    fun moveToward(from: Float, to: Float, delta: Float) = from + kotlin.math.min(to - from, delta)
+    fun moveToward(from: Float, to: Float, delta: Float) = if (abs(to - from) <= delta) to else from + (to - from).sign * delta
 
     /** Moves from toward to by the delta value.
      *  Use a negative delta value to move away. */
-    fun moveToward(from: Double, to: Double, delta: Double) = from + kotlin.math.min(to - from, delta)
+    fun moveToward(from: Double, to: Double, delta: Double) = if (abs(to - from) <= delta) to else from + (to - from).sign * delta
 
 
     /** Returns the nearest larger power of 2 for integer value. */


### PR DESCRIPTION
The moveToward function in GDMath class under godot.global package has wrong behavior when it goes from 0 to negative value.
I query realized the Godot source code,as follows.
`static _ALWAYS_INLINE_ float move_toward(float p_from, float p_to, float p_delta) { return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta; }`
The implementation in Kotlin should be as follows.
`fun moveToward(from: Float, to: Float, delta: Float) = if (abs(to - from) <= delta) to else from + (to - from).sign * delta`