### PR TITLE
fix(intellij-plugins): remove unused declaration extensions in psiClass.kt

### DIFF
--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/extension/psiClass.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/extension/psiClass.kt
@@ -46,9 +46,3 @@ fun PsiClass.resolveToDescriptor(): ClassDescriptor? {
         else -> getJavaClassDescriptor()
     }
 }
-
-val PsiClass.declarations: List<PsiElement>
-    get() = when (this) {
-        is KtClass -> this.declarations
-        else -> this.ownDeclarations.map { symbolDeclaration -> symbolDeclaration.declaringElement }
-    }


### PR DESCRIPTION
This extension wasn't used anymore and was causing troubles in intellij plugin verification.