### PR TITLE
Fix fat jar creation if users project defines a version

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/packageBootstrapJarTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/packageBootstrapJarTask.kt
@@ -17,6 +17,7 @@ fun Project.packageBootstrapJarTask(
             archiveBaseName.set("godot-bootstrap")
             configurations.clear()
             configurations.add(this@packageBootstrapJarTask.configurations.getByName("bootstrap"))
+            archiveVersion.set("") // otherwise the version is appended to the name and our export plugin cannot find it anymore
 
             dependsOn(createBuildLockTask)
             finalizedBy(deleteBuildLockTask)


### PR DESCRIPTION
If the users project defines a version in gradle, the fat jar automatically inherits that.
If that is the case, our export plugin can no longer find the jar.
This fixes that by forcefully removing any version set for the fat jar artifact name.