### PR TITLE
Add documentation on how to use the project state from a specific branch

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
     - Setup: contribution/setup.md
     - Build with C# support: contribution/build-with-csharp-support.md
     - Support for other JVM-based languages: contribution/support-for-other-jvm-based-languages.md
+    - Test changes from branch: contribution/test-change-from-branch.md
     - Knowledge base:
         - Artifact differentiation: contribution/knowledge-base/artifact-differentiation.md
         - Entry generation: contribution/knowledge-base/entry-generation.md

--- a/docs/src/doc/contribution/test-change-from-branch.md
+++ b/docs/src/doc/contribution/test-change-from-branch.md
@@ -4,7 +4,7 @@ In order to test a change from a specific branch in your own project, you'll nee
     Before following these steps, make sure you've done a proper backup of your project! Things can and will break! So ensure you can easily rollback all changes applied to your project
 
 !!! info
-    The building the project from source, requires that you've setup your system to be able to build godot. [Follow the official documentation](https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html) for the setup of your system! 
+    Building the project from source, requires that you've setup your system to be able to build godot. [Follow the official documentation](https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html) for the setup of your system! 
 
 1. Check against which godot branch/tag the branch is built against. (the current master is for 4.3-stable)
 2. Check out godot: `git clone git@github.com:godotengine/godot.git --branch 4.3-stable --recursive`
@@ -16,7 +16,7 @@ In order to test a change from a specific branch in your own project, you'll nee
 8. Move back to the godot root: `cd ../../..`
 9. Build godot: `scons debug_symbols=yes dev_build=yes`
 10. Make sure you have `mavenLocal()` as a repository configured in your gradle build
-11. Add the following plugin resolution to your:
+11. Add the following plugin resolution to your project:
     ```kotlin
     pluginManagement {
         // ...

--- a/docs/src/doc/contribution/test-change-from-branch.md
+++ b/docs/src/doc/contribution/test-change-from-branch.md
@@ -1,0 +1,35 @@
+In order to test a change from a specific branch in your own project, you'll need to follow the following steps:
+
+!!! warning
+    Before following these steps, make sure you've done a proper backup of your project! Things can and will break! So ensure you can easily rollback all changes applied to your project
+
+!!! info
+    The building the project from source, requires that you've setup your system to be able to build godot. [Follow the official documentation](https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html) for the setup of your system! 
+
+1. Check against which godot branch/tag the branch is built against. (the current master is for 4.3-stable)
+2. Check out godot: `git clone git@github.com:godotengine/godot.git --branch 4.3-stable --recursive`
+3. Move into the godot root: `cd godot`
+4. Check out our module: `git submodule add git@github.com:utopia-rise/godot-kotlin-jvm.git modules/kotlin_jvm`
+5. Move into the kotlin root of our module: `cd modules/kotlin_jvm`
+6. Check out the branch you want: `git checkout <branch_name>`
+7. Locally deploy our module: `./gradlew :tools-common:publishToMavenLocal publishToMavenLocal && ./gradlew publishToMavenLocal -Prelease=true`
+8. Move back to the godot root: `cd ../../..`
+9. Build godot: `scons debug_symbols=yes dev_build=yes`
+10. Make sure you have `mavenLocal()` as a repository configured in your gradle build
+11. Add the following plugin resolution to your:
+    ```kotlin
+    pluginManagement {
+        // ...
+        resolutionStrategy.eachPlugin {
+            if (requested.id.id == "com.utopia-rise.godot-kotlin-jvm") {
+                useModule("com.utopia-rise:godot-gradle-plugin:${requested.version}")
+            }
+        }
+    }
+    ```
+12. Check the version name which you've built: `ls ~/.m2/repository/com/utopia-rise/godot-gradle-plugin/`
+    It should be something like: `0.9.1-4.3.0-d68f299-SNAPSHOT`
+13. Use that version in your project
+14. Build your project
+15. Run your project with the editor binary you've built in step 9
+    You can find that binary in the godot root in the `bin` folder, and it should look something like this: `godot.macos.editor.dev.arm64`

--- a/docs/src/doc/contribution/test-change-from-branch.md
+++ b/docs/src/doc/contribution/test-change-from-branch.md
@@ -10,7 +10,7 @@ In order to test a change from a specific branch in your own project, you'll nee
 2. Check out godot: `git clone git@github.com:godotengine/godot.git --branch 4.3-stable --recursive`
 3. Move into the godot root: `cd godot`
 4. Check out our module: `git submodule add git@github.com:utopia-rise/godot-kotlin-jvm.git modules/kotlin_jvm`
-5. Move into the kotlin root of our module: `cd modules/kotlin_jvm`
+5. Move into the kotlin root of our module: `cd modules/kotlin_jvm/kt`
 6. Check out the branch you want: `git checkout <branch_name>`
 7. Locally deploy our module: `./gradlew :tools-common:publishToMavenLocal publishToMavenLocal && ./gradlew publishToMavenLocal -Prelease=true`
 8. Move back to the godot root: `cd ../../..`

--- a/docs/src/doc/contribution/test-change-from-branch.md
+++ b/docs/src/doc/contribution/test-change-from-branch.md
@@ -32,5 +32,5 @@ In order to test a change from a specific branch in your own project, you'll nee
     It should be something like: `0.9.1-4.3.0-d68f299-SNAPSHOT`
 14. Use that version in your project
 15. Build your project
-16. Run your project with the editor binary you've built in step 9
+16. Run your project with the editor binary you've built in step 10
     You can find that binary in the godot root in the `bin` folder, and it should look something like this: `godot.macos.editor.dev.arm64`

--- a/docs/src/doc/contribution/test-change-from-branch.md
+++ b/docs/src/doc/contribution/test-change-from-branch.md
@@ -6,17 +6,18 @@ In order to test a change from a specific branch in your own project, you'll nee
 !!! info
     Building the project from source, requires that you've setup your system to be able to build godot. [Follow the official documentation](https://docs.godotengine.org/en/stable/contributing/development/compiling/index.html) for the setup of your system! 
 
-1. Check against which godot branch/tag the branch is built against. (the current master is for 4.3-stable)
-2. Check out godot: `git clone git@github.com:godotengine/godot.git --branch 4.3-stable --recursive`
-3. Move into the godot root: `cd godot`
-4. Check out our module: `git submodule add git@github.com:utopia-rise/godot-kotlin-jvm.git modules/kotlin_jvm`
-5. Move into the kotlin root of our module: `cd modules/kotlin_jvm/kt`
-6. Check out the branch you want: `git checkout <branch_name>`
-7. Locally deploy our module: `./gradlew :tools-common:publishToMavenLocal publishToMavenLocal && ./gradlew publishToMavenLocal -Prelease=true`
-8. Move back to the godot root: `cd ../../..`
-9. Build godot: `scons debug_symbols=yes dev_build=yes`
-10. Make sure you have `mavenLocal()` as a repository configured in your gradle build
-11. Add the following plugin resolution to your project:
+1. Ensure the `JAVA_HOME` env variable is set. At least jdk 17 is required.
+2. Check against which godot branch/tag the branch is built against. (the current master is for 4.3-stable)
+3. Check out godot: `git clone git@github.com:godotengine/godot.git --branch 4.3-stable --recursive`
+4. Move into the godot root: `cd godot`
+5. Check out our module: `git submodule add git@github.com:utopia-rise/godot-kotlin-jvm.git modules/kotlin_jvm`
+6. Move into the kotlin root of our module: `cd modules/kotlin_jvm/kt`
+7. Check out the branch you want: `git checkout <branch_name>`
+8. Locally deploy our module: `./gradlew :tools-common:publishToMavenLocal publishToMavenLocal && ./gradlew publishToMavenLocal -Prelease=true`
+9. Move back to the godot root: `cd ../../..`
+10. Build godot: `scons debug_symbols=yes dev_build=yes`
+11. Make sure you have `mavenLocal()` as a repository configured in your gradle build
+12. Add the following plugin resolution to your project:
     ```kotlin
     pluginManagement {
         // ...
@@ -27,9 +28,9 @@ In order to test a change from a specific branch in your own project, you'll nee
         }
     }
     ```
-12. Check the version name which you've built: `ls ~/.m2/repository/com/utopia-rise/godot-gradle-plugin/`
+13. Check the version name which you've built: `ls ~/.m2/repository/com/utopia-rise/godot-gradle-plugin/`
     It should be something like: `0.9.1-4.3.0-d68f299-SNAPSHOT`
-13. Use that version in your project
-14. Build your project
-15. Run your project with the editor binary you've built in step 9
+14. Use that version in your project
+15. Build your project
+16. Run your project with the editor binary you've built in step 9
     You can find that binary in the godot root in the `bin` folder, and it should look something like this: `godot.macos.editor.dev.arm64`


### PR DESCRIPTION
This adds documentation on how to build this module from a specific branch and how to test that in a Godot Kotlin/JVM project