### PR TITLE
Don't fetch default value for Object properties

### DIFF
--- a/src/jvm_wrapper/registration/kt_property.cpp
+++ b/src/jvm_wrapper/registration/kt_property.cpp
@@ -67,17 +67,3 @@ void KtProperty::call_set(jni::Env& p_env, KtObject* instance, const Variant& p_
     jvalue args[1] = {jni::to_jni_arg(instance->get_wrapped())};
     wrapped.call_void_method(p_env, CALL_SET, args);
 }
-
-#ifdef TOOLS_ENABLED
-void KtProperty::safe_call_get(jni::Env& p_env, KtObject* instance, Variant& r_ret) {
-    jvalue call_args[1] = {jni::to_jni_arg(instance->get_wrapped())};
-    wrapped.call_void_method<false>(p_env, CALL_GET, call_args);
-    if (p_env.exception_check()) {
-        Callable::CallError error;
-        Variant::construct(propertyInfo->type, r_ret, {}, 0, error);
-        p_env.exception_clear();
-        return;
-    }
-    TransferContext::get_instance().read_return_value(p_env, r_ret);
-}
-#endif

--- a/src/jvm_wrapper/registration/kt_property.h
+++ b/src/jvm_wrapper/registration/kt_property.h
@@ -73,10 +73,6 @@ public:
 
     void call_get(jni::Env& p_env, KtObject* instance, Variant& r_ret);
     void call_set(jni::Env& p_env, KtObject* instance, const Variant& p_value);
-
-#ifdef TOOLS_ENABLED
-    void safe_call_get(jni::Env& p_env, KtObject* instance, Variant& r_ret);
-#endif
 };
 
 #endif// GODOT_JVM_KT_PROPERTY_H

--- a/src/script/jvm_instance.cpp
+++ b/src/script/jvm_instance.cpp
@@ -76,7 +76,7 @@ bool JvmInstance::get_or_default(const StringName& p_name, Variant& r_ret) const
 
     KtProperty* ktProperty {kt_class->get_property(p_name)};
     if (ktProperty) {
-        ktProperty->safe_call_get(env, kt_object, r_ret);
+        ktProperty->call_get(env, kt_object, r_ret);
         return true;
     } else {
         return false;

--- a/src/script/jvm_script.cpp
+++ b/src/script/jvm_script.cpp
@@ -231,6 +231,7 @@ void JvmScript::update_script() {
     get_script_exported_property_list(&exported_properties);
 
     for (auto& exported_property : exported_properties) {
+        if(exported_property.type == Variant::OBJECT) { continue;}
         Variant default_value;
         const String& property_name {exported_property.name};
         kotlin_script_instance->get_or_default(property_name, default_value);


### PR DESCRIPTION
C++ counterpart to the lateinit change #668. The editor won't try to get the default value for Object anymore.
Object is the only allowed lateinit, but Godot doesn't handle default values for that type anyway.

Here a simple proof using GDScript, a property is declared with a default value, but the inspector can't see it:
![image](https://github.com/user-attachments/assets/76f8f3bb-7a08-4fff-8950-c6aafa7eee71)
