### PR TITLE
Fix property type generation

### DIFF
--- a/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedProperty.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedProperty.kt
@@ -1,17 +1,15 @@
 package godot.codegen.models.enriched
 
-import com.squareup.kotlinpoet.ANY
-import godot.tools.common.constants.GodotTypes
-import godot.tools.common.extensions.convertToCamelCase
-import godot.codegen.extensions.getTypeClassName
 import godot.codegen.extensions.isObjectSubClass
-import godot.codegen.workarounds.sanitizeApiType
 import godot.codegen.models.Argument
 import godot.codegen.models.Property
 import godot.codegen.traits.CallableTrait
 import godot.codegen.traits.CastableTrait
 import godot.codegen.traits.IDocumented
 import godot.codegen.traits.NullableTrait
+import godot.codegen.workarounds.sanitizeApiType
+import godot.tools.common.constants.GodotTypes
+import godot.tools.common.extensions.convertToCamelCase
 
 class EnrichedProperty(val internal: Property) : CastableTrait, NullableTrait, IDocumented {
     val name = internal.name.replace("/", "_").convertToCamelCase()
@@ -38,7 +36,7 @@ class EnrichedProperty(val internal: Property) : CastableTrait, NullableTrait, I
         get() = getterMethod?.type ?: internal.type
 
     override val type: String
-        get() = if (internal.type.indexOf(",") != -1) {
+        get() = if (internalType.indexOf(",") != -1) {
             // There are property with multiple types, and it's all Materials, so
             // Godot's developer should make more strict API
             "Material"

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/AStarGrid2D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/AStarGrid2D.kt
@@ -615,7 +615,7 @@ public open class AStarGrid2D : RefCounted() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): CellShape = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimationMixer.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/AnimationMixer.kt
@@ -688,7 +688,8 @@ public open class AnimationMixer internal constructor() : Node() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): AnimationCallbackModeDiscrete =
+          entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/AudioServer.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/AudioServer.kt
@@ -549,7 +549,7 @@ public object AudioServer : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): PlaybackType = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/AudioStreamInteractive.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/AudioStreamInteractive.kt
@@ -289,7 +289,7 @@ public open class AudioStreamInteractive : AudioStream() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): TransitionFromTime = entries.single { it.id == `value` }
     }
   }
 
@@ -313,7 +313,7 @@ public open class AudioStreamInteractive : AudioStream() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): TransitionToTime = entries.single { it.id == `value` }
     }
   }
 
@@ -350,7 +350,7 @@ public open class AudioStreamInteractive : AudioStream() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): FadeMode = entries.single { it.id == `value` }
     }
   }
 
@@ -378,7 +378,7 @@ public open class AudioStreamInteractive : AudioStream() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): AutoAdvanceMode = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Camera3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Camera3D.kt
@@ -104,11 +104,11 @@ public open class Camera3D : Node3D() {
   /**
    * The [CameraAttributes] to use for this camera.
    */
-  public var attributes: Material?
+  public var attributes: CameraAttributes?
     get() {
       TransferContext.writeArguments()
       TransferContext.callMethod(rawPtr, MethodBindings.getAttributesPtr, OBJECT)
-      return (TransferContext.readReturnValue(OBJECT, true) as Material?)
+      return (TransferContext.readReturnValue(OBJECT, true) as CameraAttributes?)
     }
     set(`value`) {
       TransferContext.writeArguments(OBJECT to value)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/CompositorEffect.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/CompositorEffect.kt
@@ -204,7 +204,7 @@ public open class CompositorEffect : Resource() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): EffectCallbackType = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Environment.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Environment.kt
@@ -1524,11 +1524,11 @@ public open class Environment : Resource() {
    * grading. Can use a [GradientTexture1D] for a 1-dimensional LUT, or a [Texture3D] for a more
    * complex LUT. Effective only if [adjustmentEnabled] is `true`.
    */
-  public var adjustmentColorCorrection: Material?
+  public var adjustmentColorCorrection: Texture?
     get() {
       TransferContext.writeArguments()
       TransferContext.callMethod(rawPtr, MethodBindings.getAdjustmentColorCorrectionPtr, OBJECT)
-      return (TransferContext.readReturnValue(OBJECT, true) as Material?)
+      return (TransferContext.readReturnValue(OBJECT, true) as Texture?)
     }
     set(`value`) {
       TransferContext.writeArguments(OBJECT to value)
@@ -1916,7 +1916,7 @@ public open class Environment : Resource() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): FogMode = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/FlowContainer.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/FlowContainer.kt
@@ -162,7 +162,7 @@ public open class FlowContainer : Container() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): LastWrapAlignmentMode = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/GLTFAccessor.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/GLTFAccessor.kt
@@ -300,7 +300,7 @@ public open class GLTFAccessor : Resource() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): GLTFAccessorType = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/GraphEdit.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/GraphEdit.kt
@@ -952,7 +952,7 @@ public open class GraphEdit : Control() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): GridPattern = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/KeyLocation.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/KeyLocation.kt
@@ -29,6 +29,6 @@ public enum class KeyLocation(
   }
 
   public companion object {
-    public fun from(`value`: Long) = entries.single { it.id == `value` }
+    public fun from(`value`: Long): KeyLocation = entries.single { it.id == `value` }
   }
 }

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/LightmapGI.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/LightmapGI.kt
@@ -322,11 +322,11 @@ public open class LightmapGI : VisualInstance3D() {
    * range present when baking. If exposure is too high, the [LightmapGI] will have banding artifacts
    * or may have over-exposure artifacts.
    */
-  public var cameraAttributes: Material?
+  public var cameraAttributes: CameraAttributes?
     get() {
       TransferContext.writeArguments()
       TransferContext.callMethod(rawPtr, MethodBindings.getCameraAttributesPtr, OBJECT)
-      return (TransferContext.readReturnValue(OBJECT, true) as Material?)
+      return (TransferContext.readReturnValue(OBJECT, true) as CameraAttributes?)
     }
     set(`value`) {
       TransferContext.writeArguments(OBJECT to value)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/NativeMenu.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/NativeMenu.kt
@@ -995,7 +995,7 @@ public object NativeMenu : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): Feature = entries.single { it.id == `value` }
     }
   }
 
@@ -1036,7 +1036,7 @@ public object NativeMenu : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): SystemMenus = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Node.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Node.kt
@@ -2217,7 +2217,7 @@ public open class Node : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): PhysicsInterpolationMode = entries.single { it.id == `value` }
     }
   }
 
@@ -2309,7 +2309,7 @@ public open class Node : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): AutoTranslateMode = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/OpenXRAPIExtension.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/OpenXRAPIExtension.kt
@@ -245,7 +245,8 @@ public open class OpenXRAPIExtension : RefCounted() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): OpenXRAlphaBlendModeSupport =
+          entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/OpenXRHand.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/OpenXRHand.kt
@@ -186,7 +186,7 @@ public open class OpenXRHand : Node3D() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): SkeletonRig = entries.single { it.id == `value` }
     }
   }
 
@@ -214,7 +214,7 @@ public open class OpenXRHand : Node3D() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): BoneUpdate = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/OpenXRInterface.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/OpenXRInterface.kt
@@ -438,7 +438,7 @@ public open class OpenXRInterface : XRInterface() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): HandTrackedSource = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/ParticleProcessMaterial.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/ParticleProcessMaterial.kt
@@ -652,11 +652,11 @@ public open class ParticleProcessMaterial : Material() {
    * **Note:** Animated velocities will not be affected by damping, use [velocityLimitCurve]
    * instead.
    */
-  public var orbitVelocityCurve: Material?
+  public var orbitVelocityCurve: Texture2D?
     get() {
       TransferContext.writeArguments(LONG to 2L)
       TransferContext.callMethod(rawPtr, MethodBindings.getParamTexturePtr, OBJECT)
-      return (TransferContext.readReturnValue(OBJECT, true) as Material?)
+      return (TransferContext.readReturnValue(OBJECT, true) as Texture2D?)
     }
     set(`value`) {
       TransferContext.writeArguments(LONG to 2L, OBJECT to value)
@@ -1033,11 +1033,11 @@ public open class ParticleProcessMaterial : Material() {
    * Each particle's scale will vary along this [CurveTexture] over its lifetime. If a
    * [CurveXYZTexture] is supplied instead, the scale will be separated per-axis.
    */
-  public var scaleCurve: Material?
+  public var scaleCurve: Texture2D?
     get() {
       TransferContext.writeArguments(LONG to 8L)
       TransferContext.callMethod(rawPtr, MethodBindings.getParamTexturePtr, OBJECT)
-      return (TransferContext.readReturnValue(OBJECT, true) as Material?)
+      return (TransferContext.readReturnValue(OBJECT, true) as Texture2D?)
     }
     set(`value`) {
       TransferContext.writeArguments(LONG to 8L, OBJECT to value)
@@ -1091,11 +1091,11 @@ public open class ParticleProcessMaterial : Material() {
   /**
    * Either a [CurveTexture] or a [CurveXYZTexture] that scales each particle based on its velocity.
    */
-  public var scaleOverVelocityCurve: Material?
+  public var scaleOverVelocityCurve: Texture2D?
     get() {
       TransferContext.writeArguments(LONG to 17L)
       TransferContext.callMethod(rawPtr, MethodBindings.getParamTexturePtr, OBJECT)
-      return (TransferContext.readReturnValue(OBJECT, true) as Material?)
+      return (TransferContext.readReturnValue(OBJECT, true) as Texture2D?)
     }
     set(`value`) {
       TransferContext.writeArguments(LONG to 17L, OBJECT to value)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/RenderingServer.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/RenderingServer.kt
@@ -7311,7 +7311,7 @@ public object RenderingServer : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): ViewportVRSUpdateMode = entries.single { it.id == `value` }
     }
   }
 
@@ -7393,7 +7393,7 @@ public object RenderingServer : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): CompositorEffectFlags = entries.single { it.id == `value` }
     }
   }
 
@@ -7433,7 +7433,8 @@ public object RenderingServer : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): CompositorEffectCallbackType =
+          entries.single { it.id == `value` }
     }
   }
 
@@ -7600,7 +7601,7 @@ public object RenderingServer : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): EnvironmentFogMode = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/RichTextLabel.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/RichTextLabel.kt
@@ -1335,7 +1335,7 @@ public open class RichTextLabel : Control() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): MetaUnderline = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/ScriptLanguage.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/ScriptLanguage.kt
@@ -34,7 +34,7 @@ public open class ScriptLanguage internal constructor() : Object() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): ScriptNameCasing = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Skeleton3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Skeleton3D.kt
@@ -586,7 +586,8 @@ public open class Skeleton3D : Node3D() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): ModifierCallbackModeProcess =
+          entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/TabContainer.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/TabContainer.kt
@@ -517,7 +517,7 @@ public open class TabContainer : Container() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): TabPosition = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/TileMapLayer.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/TileMapLayer.kt
@@ -601,7 +601,7 @@ public open class TileMapLayer : Node2D() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): DebugVisibilityMode = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/Viewport.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/Viewport.kt
@@ -1796,7 +1796,7 @@ public open class Viewport internal constructor() : Node() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): VRSUpdateMode = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/VoxelGI.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/VoxelGI.kt
@@ -91,11 +91,11 @@ public open class VoxelGI : VisualInstance3D() {
    * range present when baking. If exposure is too high, the [VoxelGI] will have banding artifacts or
    * may have over-exposure artifacts.
    */
-  public var cameraAttributes: Material?
+  public var cameraAttributes: CameraAttributes?
     get() {
       TransferContext.writeArguments()
       TransferContext.callMethod(rawPtr, MethodBindings.getCameraAttributesPtr, OBJECT)
-      return (TransferContext.readReturnValue(OBJECT, true) as Material?)
+      return (TransferContext.readReturnValue(OBJECT, true) as CameraAttributes?)
     }
     set(`value`) {
       TransferContext.writeArguments(OBJECT to value)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/World3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/World3D.kt
@@ -55,11 +55,11 @@ public open class World3D : Resource() {
   /**
    * The default [CameraAttributes] resource to use if none set on the [Camera3D].
    */
-  public var cameraAttributes: Material?
+  public var cameraAttributes: CameraAttributes?
     get() {
       TransferContext.writeArguments()
       TransferContext.callMethod(rawPtr, MethodBindings.getCameraAttributesPtr, OBJECT)
-      return (TransferContext.readReturnValue(OBJECT, true) as Material?)
+      return (TransferContext.readReturnValue(OBJECT, true) as CameraAttributes?)
     }
     set(`value`) {
       TransferContext.writeArguments(OBJECT to value)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/WorldEnvironment.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/WorldEnvironment.kt
@@ -45,11 +45,11 @@ public open class WorldEnvironment : Node() {
   /**
    * The default [CameraAttributes] resource to use if none set on the [Camera3D].
    */
-  public var cameraAttributes: Material?
+  public var cameraAttributes: CameraAttributes?
     get() {
       TransferContext.writeArguments()
       TransferContext.callMethod(rawPtr, MethodBindings.getCameraAttributesPtr, OBJECT)
-      return (TransferContext.readReturnValue(OBJECT, true) as Material?)
+      return (TransferContext.readReturnValue(OBJECT, true) as CameraAttributes?)
     }
     set(`value`) {
       TransferContext.writeArguments(OBJECT to value)

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/XRBodyModifier3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/XRBodyModifier3D.kt
@@ -165,7 +165,7 @@ public open class XRBodyModifier3D : SkeletonModifier3D() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): BoneUpdate = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/XRBodyTracker.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/XRBodyTracker.kt
@@ -478,7 +478,7 @@ public open class XRBodyTracker : XRPositionalTracker() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): Joint = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/XRFaceTracker.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/XRFaceTracker.kt
@@ -659,7 +659,7 @@ public open class XRFaceTracker : XRTracker() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): BlendShapeEntry = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/XRHandModifier3D.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/XRHandModifier3D.kt
@@ -87,7 +87,7 @@ public open class XRHandModifier3D : SkeletonModifier3D() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): BoneUpdate = entries.single { it.id == `value` }
     }
   }
 

--- a/kt/godot-library/src/main/kotlin/godot/gen/godot/XRHandTracker.kt
+++ b/kt/godot-library/src/main/kotlin/godot/gen/godot/XRHandTracker.kt
@@ -183,7 +183,7 @@ public open class XRHandTracker : XRPositionalTracker() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): HandTrackingSource = entries.single { it.id == `value` }
     }
   }
 
@@ -306,7 +306,7 @@ public open class XRHandTracker : XRPositionalTracker() {
     }
 
     public companion object {
-      public fun from(`value`: Long) = entries.single { it.id == `value` }
+      public fun from(`value`: Long): HandJoint = entries.single { it.id == `value` }
     }
   }
 


### PR DESCRIPTION
Fix #655.

Also somehow added an explicit return type to some methods, but shouldn't have any effect.
Look at the change to ParticleProcessMaterial to see the relevant part.

Explanation: The Godot api.json got many errors when it comes to the type of properties. We usually fallback to the type of the getter method it uses. There was a mistake in the code that didn't make use of that fallback.