### PR TITLE
Add/Fix missing GD singleton methods.

### DIFF
--- a/kt/godot-library/src/main/kotlin/godot/global/GDMath.kt
+++ b/kt/godot-library/src/main/kotlin/godot/global/GDMath.kt
@@ -13,7 +13,6 @@ import godot.util.isEqualApprox
 import godot.util.isZeroApprox
 import godot.util.toRealT
 import kotlin.math.pow
-import kotlin.math.abs
 import kotlin.math.sign
 
 //Necessary for stepDecimal function
@@ -209,7 +208,7 @@ internal interface GDMath {
 
     /** Returns the floating-point modulus of a/b that wraps equally in positive and negative. */
     fun fposmod(a: Double, b: Double): Double {
-        return a.toRealT().fposmod(b.toRealT()).toDouble()
+        return a.toRealT().fposmod(b.toRealT())
     }
 
     /** Returns a normalized value considering the given range. This is the opposite of lerp. */
@@ -384,10 +383,10 @@ internal interface GDMath {
     }
 
     /** Converts a 2D point expressed in the polar coordinate system (a distance from the origin r and an angle th) to the cartesian coordinate system (X and Y axis). */
-    fun polar2cartesian(r: Float, th: Float) = polar2cartesian(r.toDouble(), th.toDouble())
+    fun polarToCartesian(r: Float, th: Float) = polarToCartesian(r.toDouble(), th.toDouble())
 
     /** Converts a 2D point expressed in the polar coordinate system (a distance from the origin r and an angle th) to the cartesian coordinate system (X and Y axis). */
-    fun polar2cartesian(r: Double, th: Double) = Vector2(r * kotlin.math.sin(th), r * kotlin.math.cos(th))
+    fun polarToCartesian(r: Double, th: Double) = Vector2(r * kotlin.math.sin(th), r * kotlin.math.cos(th))
 
 
     /** Returns the floating-point modulus of a/b that wraps equally in positive and negative. */
@@ -423,12 +422,20 @@ internal interface GDMath {
     fun radToDeg(rad: Double) = rad * 360 / TAU
 
 
-    /** Maps a value from range [istart, istop] to [ostart, ostop]. */
-    fun rangeLerp(value: Float, istart: Float, istop: Float, ostart: Float, ostop: Float) =
+    /** Maps a value from range [istart, istop] to [ostart, ostop]. See also lerp and inverse_lerp.
+     * If value is outside [istart, istop], then the resulting value will also be outside [ostart, ostop].
+     * If this is not desired, use clamp on the result of this function.
+     * For complex use cases where multiple ranges are needed, consider using Curve or Gradient instead.
+     * Note: If istart == istop, the return value is undefined (most likely NaN, INF, or -INF).*/
+    fun remap(value: Float, istart: Float, istop: Float, ostart: Float, ostop: Float) =
         lerp(ostart, ostop, inverseLerp(istart, istop, value))
 
-    /** Maps a value from range [istart, istop] to [ostart, ostop]. */
-    fun rangeLerp(value: Double, istart: Double, istop: Double, ostart: Double, ostop: Double) =
+    /** Maps a value from range [istart, istop] to [ostart, ostop]. See also lerp and inverse_lerp.
+     * If value is outside [istart, istop], then the resulting value will also be outside [ostart, ostop].
+     * If this is not desired, use clamp on the result of this function.
+     * For complex use cases where multiple ranges are needed, consider using Curve or Gradient instead.
+     * Note: If istart == istop, the return value is undefined (most likely NaN, INF, or -INF).*/
+    fun remap(value: Double, istart: Double, istop: Double, ostart: Double, ostop: Double) =
         lerp(ostart, ostop, inverseLerp(istart, istop, value))
 
     /** Returns the integral value that is nearest to s, with halfway cases rounded away from zero. */

--- a/kt/godot-library/src/main/kotlin/godot/global/GDPrint.kt
+++ b/kt/godot-library/src/main/kotlin/godot/global/GDPrint.kt
@@ -1,7 +1,7 @@
 package godot.global
 
-import godot.core.memory.TransferContext
 import godot.core.VariantType
+import godot.core.memory.TransferContext
 
 
 internal interface GDPrint {
@@ -10,6 +10,36 @@ internal interface GDPrint {
     fun print(vararg args: Any?) {
         TransferContext.writeArguments(VariantType.STRING to args.joinToString(""))
         Bridge.print()
+    }
+
+    /**
+     * Converts one or more arguments of any type to string in the best way possible and prints them to the console.
+     *
+     * The following BBCode tags are supported: b, i, u, s, indent, code, url, center, right, color, bgcolor, fgcolor.
+     *
+     * Color tags only support the following named colors: black, red, green, yellow, blue, magenta, pink, purple, cyan, white, orange, gray. Hexadecimal color codes are not supported.
+     *
+     * URL tags only support URLs wrapped by a URL tag, not URLs with a different title.
+     *
+     * When printing to standard output, the supported subset of BBCode is converted to ANSI escape codes for the terminal emulator to display. Support for ANSI escape codes varies across terminal emulators, especially for italic and strikethrough. In standard output, code is represented with faint text but without any font change. Unsupported tags are left as-is in standard output.
+     *
+     * `printRich("[color=green][b]Hello world![/b][/color]")`
+     *
+     * Note: Consider using [pushError] and [pushWarning] to print error and warning messages instead of print or print_rich. This distinguishes them from print messages used for debugging purposes, while also displaying a stack trace when an error or warning is printed.
+     *
+     * Note: On Windows, only Windows 10 and later correctly displays ANSI escape codes in standard output.
+     *
+     * Note: Output displayed in the editor supports clickable [url=address]text[/url] tags. The [url] tag's address value is handled by OS.shell_open when clicked.
+     * **/
+    fun printRich(vararg args: Any?) {
+        TransferContext.writeArguments(VariantType.STRING to args.joinToString(""))
+        Bridge.printRich()
+    }
+
+    /** If verbose mode is enabled (OS.is_stdout_verbose returning true), converts one or more arguments of any type to string in the best way possible and prints them to the console.**/
+    fun printVerbose(vararg args: Any?) {
+        TransferContext.writeArguments(VariantType.STRING to args.joinToString(""))
+        Bridge.printVerbose()
     }
 
     /** Converts one or more arguments to strings in the best way possible and prints them as error to the console.**/
@@ -30,11 +60,30 @@ internal interface GDPrint {
     /** Converts one or more arguments to strings in the best way possible and prints them to the console.**/
     fun printt(vararg args: Any?) = print(args.joinToString("\t"))
 
-    fun printStack() = print(Thread.currentThread().stackTrace.joinToString("\n"))
+    /** Pushes an error message to Godot's built-in debugger and to the OS terminal.**/
+    fun pushError(vararg args: Any?) {
+        TransferContext.writeArguments(VariantType.STRING to args.joinToString(""))
+        Bridge.pushError()
+    }
+
+    /** Pushes a warning message to Godot's built-in debugger and to the OS terminal.**/
+    fun pushWarning(vararg args: Any?) {
+        TransferContext.writeArguments(VariantType.STRING to args.joinToString(""))
+        Bridge.pushWarning()
+    }
+
+    fun printStacktrace() = print(Thread.currentThread().stackTrace.joinToString("\n"))
 
     private object Bridge {
+        fun getStacktrace() = Thread.currentThread().stackTrace.joinToString("\n")
+
         external fun print()
+        external fun printRich()
+        external fun printVerbose()
         external fun printErr()
         external fun printRaw()
+        external fun pushError()
+        external fun pushWarning()
+
     }
 }

--- a/kt/godot-library/src/main/kotlin/godot/global/GDRandom.kt
+++ b/kt/godot-library/src/main/kotlin/godot/global/GDRandom.kt
@@ -3,52 +3,37 @@ package godot.global
 import godot.RandomNumberGenerator
 
 internal interface GDRandom {
-    /** Global RandomNumberGenerator for all the rand functions, it should have the same behaviour than GdScript.*/
+    /** Global RandomNumberGenerator for all the rand functions, it should have the same behaviour as GdScript.*/
     /** Must be a nullable because we have to set it to null to have the reference collected when the JVM is closing*/
-    var rng: RandomNumberGenerator
+    val rng: RandomNumberGenerator
 
-    /** Random range, any floating point value between from and to. */
-    fun randdRange(from: Double, to: Double) = randfRange(from.toFloat(), to.toFloat()).toDouble()
+    /** Returns a random floating-point value between 0.0 and 1.0 (inclusive). */
+    fun randf() = rng.randf()
+
+    /**
+     * Returns a [normally-distributed](https://en.wikipedia.org/wiki/Normal_distribution) pseudo-random number, using Box-Muller transform with the specified [mean] and a standard [deviation]. This is also called Gaussian distribution.
+     */
+    fun randfn(mean: Float = 0.0f, deviation: Float = 1.0f) = rng.randfn(mean, deviation)
 
     /** Random range, any floating point value between from and to. */
     fun randfRange(from: Float, to: Float) = rng.randfRange(from, to)
 
+    /** Returns a random unsigned 32-bit integer. Use remainder to obtain a random value in the interval [0, N - 1] (where N is smaller than 2^32). */
+    fun randi() = rng.randi()
+
     /** Random range, any integer value between from and to. */
     fun randiRange(from: Int, to: Int) = rng.randiRange(from, to)
 
-    /** Random range, any long value between from and to. */
-    fun randlRange(from: Long, to: Long) = rng.randiRange(from.toInt(), to.toInt()).toLong()
-
-    /** Random from seed: pass a seed, and an array with both number and new seed is returned. "Seed" here refers to the internal state of the pseudo random number generator.
-     * The internal state of the current implementation is 64 bits. */
-    fun randSeed(seed: Long): Pair<Long, Long> {
+    /**
+     * Given a seed, returns a PackedInt64Array of size 2, where its first element is the randomized int value, and the second element is the same as seed. Passing the same seed consistently returns the same array.
+     * Note: "Seed" here refers to the internal state of the pseudo random number generator, currently implemented as a 64 bit integer.
+     */
+    fun randFromSeed(seed: Long): Pair<Long, Long> {
         rng.seed = seed
         //Call to randi() should change the value of the seed, that's why we retrieve it again in the return statement
         val randomValue = rng.randi()
-        return Pair(rng.seed, randomValue)
+        return Pair(randomValue, rng.seed)
     }
-
-    /** Returns a random floating point value on the interval [0, 1]. */
-    fun randf() = rng.randf()
-
-    /** Returns a random floating point value on the interval [0, 1]. */
-    fun randd() = rng.randf().toDouble()
-
-    /** Returns a random signed 32 bit integer. */
-    fun randi() = rng.randi().toInt()
-
-    /** Returns a random long. */
-    fun randl() = rng.randi()
-
-    /**
-     * Returns a [normally-distributed](https://en.wikipedia.org/wiki/Normal_distribution) pseudo-random number, using Box-Muller transform with the specified [mean] and a standard [deviation]. This is also called Gaussian distribution.
-     */
-    fun randfn(mean: Float = 0.0f, deviation: Float = 1.0f)  = rng.randfn(mean, deviation)
-
-    /**
-     * Returns a [normally-distributed](https://en.wikipedia.org/wiki/Normal_distribution) pseudo-random number, using Box-Muller transform with the specified [mean] and a standard [deviation]. This is also called Gaussian distribution.
-     */
-    fun randdn(mean: Double = 0.0, deviation: Double = 1.0)  = rng.randfn(mean.toFloat(), deviation.toFloat()).toDouble()
 
     /** Randomizes the seed (or the internal state) of the random number generator. Current implementation reseeds using a number based on time. */
     fun randomize() = rng.randomize()

--- a/kt/plugins/godot-gradle-plugin/src/main/resources/godot/gradle/godot-kotlin-graal-jni-config.json
+++ b/kt/plugins/godot-gradle-plugin/src/main/resources/godot/gradle/godot-kotlin-graal-jni-config.json
@@ -106,9 +106,14 @@
       { "name" : "INSTANCE" }
     ],
     "methods" : [
+      { "name" : "getStacktrace", "parameterTypes" : ["java.lang.String"] },
       { "name" : "print", "parameterTypes" : [] },
+      { "name" : "printRich", "parameterTypes" : [] },
+      { "name" : "printVerbose", "parameterTypes" : [] },
       { "name" : "printErr", "parameterTypes" : [] },
-      { "name" : "printRaw", "parameterTypes" : [] }
+      { "name" : "printRaw", "parameterTypes" : [] },
+      { "name" : "pushError", "parameterTypes" : [] },
+      { "name" : "pushWarning", "parameterTypes" : [] }
     ]
   },
   {

--- a/src/jvm_wrapper/bridge/gd_print_bridge.cpp
+++ b/src/jvm_wrapper/bridge/gd_print_bridge.cpp
@@ -11,6 +11,20 @@ void GDPrintBridge::print(JNIEnv* p_raw_env, jobject p_instance) {
     print_line(args[0].operator String());
 }
 
+void GDPrintBridge::print_rich(JNIEnv* p_raw_env, jobject p_instance) {
+    jni::Env env {p_raw_env};
+    Variant args[1] = {};
+    TransferContext::get_instance().read_args(env, args);
+    print_line_rich(args[0].operator String());
+}
+
+void GDPrintBridge::print_verbose2(JNIEnv* p_raw_env, jobject p_instance) {
+    jni::Env env {p_raw_env};
+    Variant args[1] = {};
+    TransferContext::get_instance().read_args(env, args);
+    print_verbose(args[0].operator String());
+}
+
 void GDPrintBridge::print_err(JNIEnv* p_raw_env, jobject p_instance) {
     jni::Env env {p_raw_env};
     Variant args[1] = {};
@@ -23,6 +37,27 @@ void GDPrintBridge::print_raw(JNIEnv* p_raw_env, jobject p_instance) {
     Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
     OS::get_singleton()->print("%s", (args[0].operator String()).utf8().get_data());
+}
+
+void GDPrintBridge::push_error(JNIEnv* p_raw_env, jobject p_instance) {
+    jni::Env env {p_raw_env};
+    Variant args[1] = {};
+    TransferContext::get_instance().read_args(env, args);
+    ERR_PRINT(args[0].operator String());
+}
+
+void GDPrintBridge::push_warning(JNIEnv* p_raw_env, jobject p_instance) {
+    jni::Env env {p_raw_env};
+    Variant args[1] = {};
+    TransferContext::get_instance().read_args(env, args);
+    WARN_PRINT(args[0].operator String());
+}
+
+String GDPrintBridge::get_jvm_stacktrace(jni::Env& p_env) {
+    jni::JString str {wrapped.call_object_method(p_env, PRINT_STACKTRACE)};
+    String ret {p_env.from_jstring(str)};
+    str.delete_local_ref(p_env);
+    return ret;
 }
 
 GDPrintBridge::~GDPrintBridge() = default;

--- a/src/jvm_wrapper/bridge/gd_print_bridge.h
+++ b/src/jvm_wrapper/bridge/gd_print_bridge.h
@@ -9,17 +9,31 @@ namespace bridges {
         SINGLETON_CLASS(GDPrintBridge)
 
         // clang-format off
+        JNI_METHOD(PRINT_STACKTRACE)
+
         INIT_JNI_BINDINGS(
+            INIT_JNI_METHOD(PRINT_STACKTRACE, "getStacktrace", "()[Ljava/lang/String;")
             INIT_NATIVE_METHOD("print", "()V", GDPrintBridge::print)
+            INIT_NATIVE_METHOD("printRich", "()V", GDPrintBridge::print_rich)
+            INIT_NATIVE_METHOD("printVerbose", "()V", GDPrintBridge::print_verbose2)
             INIT_NATIVE_METHOD("printErr", "()V", GDPrintBridge::print_err)
             INIT_NATIVE_METHOD("printRaw", "()V", GDPrintBridge::print_raw)
+            INIT_NATIVE_METHOD("pushError", "()V", GDPrintBridge::push_error)
+            INIT_NATIVE_METHOD("pushWarning", "()V", GDPrintBridge::push_warning)
           )
         // clang-format on
 
     public:
         static void print(JNIEnv* p_raw_env, jobject p_instance);
+        static void print_rich(JNIEnv* p_raw_env, jobject p_instance);
+        static void print_verbose2(JNIEnv* p_raw_env, jobject p_instance); // Can't be named normally this because a godot macro of the same name is already included.
         static void print_err(JNIEnv* p_raw_env, jobject p_instance);
         static void print_raw(JNIEnv* p_raw_env, jobject p_instance);
+        static void push_error(JNIEnv* p_raw_env, jobject p_instance);
+        static void push_warning(JNIEnv* p_raw_env, jobject p_instance);
+
+        // TODO: Use this method to get the JVM stacktrace when Godot will add the features to script https://github.com/godotengine/godot/pull/91006
+        String get_jvm_stacktrace(jni::Env& p_env);
     };
 
 }// namespace bridge

--- a/src/jvm_wrapper/bridge/gd_print_bridge.h
+++ b/src/jvm_wrapper/bridge/gd_print_bridge.h
@@ -12,7 +12,7 @@ namespace bridges {
         JNI_METHOD(PRINT_STACKTRACE)
 
         INIT_JNI_BINDINGS(
-            INIT_JNI_METHOD(PRINT_STACKTRACE, "getStacktrace", "()[Ljava/lang/String;")
+            INIT_JNI_METHOD(PRINT_STACKTRACE, "getStacktrace", "()Ljava/lang/String;")
             INIT_NATIVE_METHOD("print", "()V", GDPrintBridge::print)
             INIT_NATIVE_METHOD("printRich", "()V", GDPrintBridge::print_rich)
             INIT_NATIVE_METHOD("printVerbose", "()V", GDPrintBridge::print_verbose2)


### PR DESCRIPTION
Resolves #590 and #543

I decided to remove the alternative Long/Double version of the random methods to remove confusion. Those helpers parameters were internally downsized and the return value were never able to use the extended size of the type. 
Some of the results were actually inacurate because casting a Long to an Int when it's bigger than its maximal value can result in a negative number.