### PR TITLE
Fix default value retrieval for resources and node paths

### DIFF
--- a/src/script/jvm_script.cpp
+++ b/src/script/jvm_script.cpp
@@ -231,10 +231,12 @@ void JvmScript::update_script() {
     get_script_exported_property_list(&exported_properties);
 
     for (auto& exported_property : exported_properties) {
-        if(exported_property.type == Variant::OBJECT) { continue;}
         Variant default_value;
         const String& property_name {exported_property.name};
-        kotlin_script_instance->get_or_default(property_name, default_value);
+
+        if(exported_property.type != Variant::OBJECT) {
+            kotlin_script_instance->get_or_default(property_name, default_value);
+        }
         exported_members_default_value_cache[property_name] = default_value;
     }
 


### PR DESCRIPTION
Resources should still gather default values.
For node types (which are treated as node paths in the inspector) we return an empty variant so we can set them.

@CedNaru please look at this carefully. I'm very unsure if this is the proper way of dealing with this, but it works