### PR TITLE
Fix closing of module

### DIFF
--- a/register_types.cpp
+++ b/register_types.cpp
@@ -70,7 +70,7 @@ void uninitialize_kotlin_jvm_module(ModuleInitializationLevel p_level) {
     if (Engine::get_singleton()->is_project_manager_hint()) { return; }
 #endif
 
-    if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) { return; }
+    if (p_level != MODULE_INITIALIZATION_LEVEL_CORE) { return; }
 
     ResourceLoader::remove_resource_format_loader((resource_format_loader));
     ResourceSaver::remove_resource_format_saver(resource_format_saver);


### PR DESCRIPTION
This should delay the cleanup of our module, giving godot time to call all `_instance_binding_free_callback` necessary before we close.

Again @CedNaru Please have a close look at this. Maybe i understood these levels wrong.

Should fix the following error:
```
Godot-JVM: Cleaning JVM Memory...
Godot-JVM: JVM Memory cleaned!
Godot-JVM: Shutting down JVM ...
XR: Removed interface "Native mobile"
XR: Removed interface "OpenXR"
ERROR: Godot-JVM: godot.core.memory.MemoryManager singleton is not initialized.
   at: get_instance (modules/kotlin_jvm/src/jvm_wrapper/jvm_singleton_wrapper.h:69)
```

caused in: 
```cpp
void KotlinBindingManager::_instance_binding_free_callback(void* p_token, void* p_instance, void* p_binding) {
    // Called in the destructor of the Object.
    //  It's the very last action done in the destructor so assume variables local to the Object have been cleaned (including script and extension).
    // There are 2 cases, either an Object has been freed, and we have to release its reference OR it's a RefCounted and the JVM instance is already dead.

    memdelete(reinterpret_cast<KotlinBinding*>(p_binding));

    Object* object = reinterpret_cast<Object*>(p_instance);
    if (!object->is_ref_counted()) { MemoryManager::get_instance().queue_dead_object(object); } // <-- here
}
```