### PR TITLE
Fix custom classes hint string

### DIFF
--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/NodeTypeHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/NodeTypeHintStringGenerator.kt
@@ -8,6 +8,8 @@ class NodeTypeHintStringGenerator(
     registeredProperty: RegisteredProperty
 ) : PropertyHintStringGenerator<PropertyHintAnnotation>(registeredProperty) {
     override fun getHintString(): String {
-        return registeredProperty.type.baseGodotType()?.fqName?.substringAfterLast(".") ?: ""
+        // we first try to use the registered class name in case it's a user type extending a godot type
+        // if that is not the case (null) we get the simple name instead
+        return registeredProperty.type.registeredName() ?: registeredProperty.type.baseGodotType()?.fqName?.substringAfterLast(".") ?: ""
     }
 }

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/ResourceHintStringGenerator.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/generator/hintstring/ResourceHintStringGenerator.kt
@@ -1,5 +1,7 @@
 package godot.entrygenerator.generator.hintstring
 
+import godot.entrygenerator.EntryGenerator
+import godot.entrygenerator.ext.baseGodotType
 import godot.entrygenerator.model.PropertyHintAnnotation
 import godot.entrygenerator.model.RegisteredProperty
 
@@ -7,5 +9,9 @@ class ResourceHintStringGenerator(
     registeredProperty: RegisteredProperty
 ) : PropertyHintStringGenerator<PropertyHintAnnotation>(registeredProperty) {
 
-    override fun getHintString(): String = registeredProperty.type.fqName.substringAfterLast(".")
+    override fun getHintString(): String {
+        // we first try to use the registered class name in case it's a user type extending a godot type
+        // if that is not the case (null) we get the simple name instead
+        return registeredProperty.type.registeredName() ?: registeredProperty.type.fqName.substringAfterLast(".")
+    }
 }


### PR DESCRIPTION
Resolves https://github.com/utopia-rise/godot-kotlin-jvm/issues/658

This fixes the generated type hint for custom classes extending resource types and node types.

With normal registration this did not cause any issues but with fqdn registration it did as not the fqdn name was used as a hint string but the simple name.

**Important:** this does NOT solve the same issue for libraries! If a library registeres a custom resource with fqdn registration enabled but the users project uses normal registration, it uses normal registration. The users project config always overrides the config of any library used. This issue is not as easy solveable atm and i first need to think of a proper solution. This PR fixes the issue at hand though. I created a follow up issue here: #677