### PR TITLE
fix(graal): set right signature for GDPrint$Bridge::getStacktrace in graal jni config

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/resources/godot/gradle/godot-kotlin-graal-jni-config.json
+++ b/kt/plugins/godot-gradle-plugin/src/main/resources/godot/gradle/godot-kotlin-graal-jni-config.json
@@ -94,7 +94,7 @@
       { "name" : "INSTANCE" }
     ],
     "methods" : [
-      { "name" : "getStacktrace", "parameterTypes" : ["java.lang.String"] },
+      { "name" : "getStacktrace", "parameterTypes" : [] },
       { "name" : "print", "parameterTypes" : [] },
       { "name" : "printRich", "parameterTypes" : [] },
       { "name" : "printVerbose", "parameterTypes" : [] },


### PR DESCRIPTION
This fixes GDPrint$Bridge::getStacktrace jni signature for graalvm native-image.