### PR TITLE
Make VariantArray and Dictionary constructors visible to Java

### DIFF
--- a/harness/tests/src/main/java/godot/tests/JavaTestClass.java
+++ b/harness/tests/src/main/java/godot/tests/JavaTestClass.java
@@ -3,13 +3,13 @@ package godot.tests;
 import godot.Button;
 import godot.Node;
 import godot.annotation.*;
-import godot.core.Dictionary;
-import godot.core.NativeCallable;
-import godot.core.StringNameUtils;
-import godot.core.VariantArray;
+import godot.core.*;
 import godot.signals.Signal;
 import godot.signals.Signal2;
 import godot.signals.SignalProvider;
+import kotlin.Unit;
+import kotlin.jvm.functions.Function2;
+import org.jetbrains.annotations.NotNull;
 
 @RegisterClass
 public class JavaTestClass extends Node {
@@ -68,11 +68,11 @@ public class JavaTestClass extends Node {
     @RegisterProperty
     public boolean signalEmitted = false;
 
-    @RegisterConstructor
-    public JavaTestClass() {
-        VariantArray<Integer> arr = new VariantArray<>(Integer.class);
-        Dictionary<Float, String> dict = new Dictionary<>(Float.class, String.class);
-    }
+    @RegisterProperty
+    public VariantArray<Integer> variantArray = new VariantArray<>(Integer.class);
+
+    @RegisterProperty
+    public Dictionary<Float, String> dictionary = new Dictionary<>(Float.class, String.class);
 
     @RegisterFunction
     public void connectAndTriggerSignal() {
@@ -82,6 +82,17 @@ public class JavaTestClass extends Node {
                 (int) ConnectFlags.CONNECT_ONE_SHOT.getId()
         );
         emitSignal(StringNameUtils.asStringName("test_signal"));
+    }
+
+    @NotNull
+    @Override
+    public GodotNotification _notification() {
+        return godotNotification(
+                this, (myself, notification) -> {
+                    System.out.println(notification);
+                    return null;
+                }
+        );
     }
 
     @RegisterFunction

--- a/harness/tests/src/main/java/godot/tests/JavaTestClass.java
+++ b/harness/tests/src/main/java/godot/tests/JavaTestClass.java
@@ -3,8 +3,10 @@ package godot.tests;
 import godot.Button;
 import godot.Node;
 import godot.annotation.*;
+import godot.core.Dictionary;
 import godot.core.NativeCallable;
 import godot.core.StringNameUtils;
+import godot.core.VariantArray;
 import godot.signals.Signal;
 import godot.signals.Signal2;
 import godot.signals.SignalProvider;
@@ -65,6 +67,12 @@ public class JavaTestClass extends Node {
 
     @RegisterProperty
     public boolean signalEmitted = false;
+
+    @RegisterConstructor
+    public JavaTestClass() {
+        VariantArray<Integer> arr = new VariantArray<>(Integer.class);
+        Dictionary<Float, String> dict = new Dictionary<>(Float.class, String.class);
+    }
 
     @RegisterFunction
     public void connectAndTriggerSignal() {

--- a/kt/godot-library/src/main/kotlin/godot/core/KtObject.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/KtObject.kt
@@ -8,8 +8,7 @@ import godot.util.nullObjectID
 import godot.util.nullptr
 import kotlincompile.definitions.GodotJvmBuildConfig
 
-@JvmInline
-value class GodotNotification internal constructor(val block: Any.(Int) -> Unit)
+class GodotNotification internal constructor(val block: Any.(Int) -> Unit)
 
 @Suppress("LeakingThis")
 abstract class KtObject {
@@ -92,7 +91,11 @@ abstract class KtObject {
     open fun _notification(): GodotNotification = godotNotification {}
 
     @Suppress("UNCHECKED_CAST")
+    @JvmName("kotlinNotification")
     protected fun <T : KtObject> T.godotNotification(block: T.(Int) -> Unit): GodotNotification = GodotNotification(block as Any.(Int) -> Unit)
+
+    @JvmName("godotNotification")
+    protected fun <T : KtObject> javaGodotNotification(obj: T, block: T.(Int) -> Unit) = obj.godotNotification(block)
 
     @Suppress("FunctionName")
     /**


### PR DESCRIPTION
I just discovered from a Discord conversation that it was not possible to create a new VariantArray and Dictionary from Java.
They both require a KClass which is a Kotlin STD object and the fake constructor we use for it is inlined when the actual one is internal. Inline functions are not visible from Java.

I created a new public constructor that directly take Java classes as arguments. Boilerplate to use, but we have no choice.