### PR TITLE
Fix coroutines gradle flag name

### DIFF
--- a/harness/tests/build.gradle.kts
+++ b/harness/tests/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 godot {
     registrationFileBaseDir.set(projectDir.resolve("scripts").also { it.mkdirs() })
     isRegistrationFileHierarchyEnabled.set(true)
-    enableGodotCoroutines.set(true)
+    isGodotCoroutinesEnabled.set(true)
 
     //uncomment to test android
 //    isAndroidExportEnabled.set(true)

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotExtension.kt
@@ -171,7 +171,7 @@ open class GodotExtension(objects: ObjectFactory) {
      *
      * If set to true, import godot-coroutine-library
      */
-    val enableGodotCoroutines: Property<Boolean> = objects.property(Boolean::class.java)
+    val isGodotCoroutinesEnabled: Property<Boolean> = objects.property(Boolean::class.java)
 
     internal fun configureExtensionDefaults(target: Project) {
         val androidSdkRoot = System.getenv("ANDROID_SDK_ROOT")?.let { androidSdkRoot ->
@@ -226,7 +226,7 @@ open class GodotExtension(objects: ObjectFactory) {
         additionalGraalResourceConfigurationFiles.set(arrayOf())
         isGraalVmNativeImageGenerationVerbose.set(false)
 
-        enableGodotCoroutines.set(false)
+        isGodotCoroutinesEnabled.set(false)
 
         System.getenv("VC_VARS_PATH")?.let {
             windowsDeveloperVCVarsPath.set(File(it))

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotPlugin.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/GodotPlugin.kt
@@ -34,7 +34,7 @@ abstract class GodotPlugin : Plugin<Project> {
 
         // registers the tooling model builder, so it can be used by the ide plugin
         afterEvaluate {
-            if (godotJvmExtension.enableGodotCoroutines.get()) {
+            if (godotJvmExtension.isGodotCoroutinesEnabled.get()) {
                 dependencies.add(
                     "implementation",
                     dependencies.create("com.utopia-rise:${godotCoroutineLibraryArtifactName}:${GodotBuildProperties.assembledGodotKotlinJvmVersion}")


### PR DESCRIPTION
This aligns the naming of the coroutine flag to the ones we already have and to what gradle and kotlin are doing in their plugins