### PR TITLE
Fix jvm publications

### DIFF
--- a/.github/workflows/deploy_jvm.yml
+++ b/.github/workflows/deploy_jvm.yml
@@ -55,44 +55,44 @@ jobs:
       - name: Publish godot-build-props
         shell: sh
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-build-props:publish publish
+          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-build-props:publish
 
       - name: Publish godot-entry-generator
         shell: sh
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-entry-generator:publish publish
+          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-entry-generator:publish
 
       - name: Publish godot-kotlin-symbol-processor
         shell: sh
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-kotlin-symbol-processor:publish publish
+          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-kotlin-symbol-processor:publish
 
       - name: Publish godot-library debug
         shell: sh
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-library:publish publish -Pdebug
+          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-library:publish -Pdebug
 
       - name: Publish godot-library release
         shell: sh
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-library:publish publish -Prelease
+          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-library:publish -Prelease
 
       - name: Publish godot-coroutine-library debug
         shell: sh
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-coroutine-library:publish publish -Pdebug
+          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-coroutine-library:publish -Pdebug
 
       - name: Publish godot-coroutine-library release
         shell: sh
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-coroutine-library:publish publish -Prelease
+          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-coroutine-library:publish -Prelease
 
       - name: Publish godot-plugins-common
         shell: sh
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-plugins-common:publish publish
+          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-plugins-common:publish
 
-      - name: Publish godot-plugins-common
+      - name: Publish godot plugins
         shell: sh
         run: |
           modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-gradle-plugin:publish :godot-gradle-plugin:publishPlugins -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET

--- a/kt/plugins/godot-intellij-plugin/build.gradle.kts
+++ b/kt/plugins/godot-intellij-plugin/build.gradle.kts
@@ -25,7 +25,7 @@ val buildMatrix: Map<String, BuildConfig> = mapOf(
         sdk = "232.8660.185",
         prefix = "IJ2023.2",
         extraSource = "",
-        version = VersionRange("232.1", "999.*"),
+        version = VersionRange("232.1", ""), // empty is the same as 999.* was before
         ideVersionsForVerifierTask = listOf("2023.2"),
         deps = listOf(
             "java",


### PR DESCRIPTION
This fixes the verification error in the idea plugin. An empty string now basically means the same as `999.*` previously.
This also fixes the jvm publications as by accident after every publish, we tried to publish everything a second time.

I tested this locally with mavenLocal and it worked but definitely needs to be tested from the maven snapshot repo before moving that to the prod repo @piiertho 