### PR TITLE
Update exporting.md

### DIFF
--- a/docs/src/doc/user-guide/exporting.md
+++ b/docs/src/doc/user-guide/exporting.md
@@ -12,7 +12,7 @@ After the export templates have been added, you can export your game. Your game 
 On desktop platforms, this also copies the JRE folder of your project in the exported game folder.
 
 !!!danger
-    The official export templates from Godot will not work! You have to use our export templates or build your own! Therefore, you cannot just hit the "Download and Install" button in the export template manager!
+    The official export templates from Godot will not work! You have to use our export templates or build your own! Therefore, you cannot just hit the "Download and Install" button in the export template manager! If you have both our export templates and the official ones installed, you must set the "Custom Template" in the export settings window to ours, or the official ones will be used and your exported game will fail to load any scene with Kotlin/Java code.
 
 
 ## Requirements


### PR DESCRIPTION
Document conflict with official export templates

If you attempt to export with both the official Godot export templates and the godot-kotlin-jvm export templates installed, Godot will default to using its own and the exported game will not be able to load any scene with Kotlin/Java code. This is avoided by setting the "Custom Template" fields in the export window.