### PR TITLE
Fix template usage

### DIFF
--- a/.github/workflows/assemble_export_templates.yml
+++ b/.github/workflows/assemble_export_templates.yml
@@ -6,6 +6,8 @@ on:
         type: string
       godot-version:
         type: string
+      build-version:
+          type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-export_templates_assemble
@@ -51,7 +53,7 @@ jobs:
 
       - name: Move linux x86_64 debug export template
         shell: sh
-        run: mv godot.linuxbsd.template_debug.x86_64 templates/linux_debug.x86_64
+        run: mv godot.linuxbsd.template_debug.x86_64.jvm.${{ inputs.build-version }} templates/linux_debug.x86_64
 
       - name: Download linux x86_64 release export template
         uses: actions/download-artifact@v4
@@ -61,7 +63,7 @@ jobs:
 
       - name: Move linux x86_64 release export template
         shell: sh
-        run: mv godot.linuxbsd.template_release.x86_64 templates/linux_release.x86_64
+        run: mv godot.linuxbsd.template_release.x86_64.jvm.${{ inputs.build-version }} templates/linux_release.x86_64
 
       - name: Download windows x86_64 debug export template
         uses: actions/download-artifact@v4
@@ -71,7 +73,7 @@ jobs:
 
       - name: Move windows x86_64 debug export template
         shell: sh
-        run: mv godot.windows.template_debug.x86_64.exe templates/windows_debug_x86_64.exe
+        run: mv godot.windows.template_debug.x86_64.jvm.${{ inputs.build-version }}.exe templates/windows_debug_x86_64.exe
 
       - name: Download windows x86_64 release export template
         uses: actions/download-artifact@v4
@@ -81,7 +83,7 @@ jobs:
 
       - name: Move windows x86_64 release export template
         shell: sh
-        run: mv godot.windows.template_release.x86_64.exe templates/windows_release_x86_64.exe
+        run: mv godot.windows.template_release.x86_64.jvm.${{ inputs.build-version }}.exe.jvm templates/windows_release_x86_64.exe
 
       - name: Download macos debug export template
         uses: actions/download-artifact@v4
@@ -95,7 +97,7 @@ jobs:
 
       - name: Create version.txt
         run: |
-          refVersion=${{ inputs.godot-version }}.jvm.${{ inputs.build-version }}
+          refVersion=${{ inputs.godot-version }}jvm-${{ inputs.build-version }}
           templatesVersion=${refVersion//-/.} #replace `-` with `.` in templates version
           echo "$templatesVersion" > templates/version.txt
         shell: bash

--- a/.github/workflows/assemble_export_templates.yml
+++ b/.github/workflows/assemble_export_templates.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Create version.txt
         run: |
-          refVersion=godot-kotlin-jvm-${{ inputs.godot-kotlin-jvm-version }}
+          refVersion=${{ inputs.godot-version }}.jvm.${{ inputs.build-version }}
           templatesVersion=${refVersion//-/.} #replace `-` with `.` in templates version
           echo "$templatesVersion" > templates/version.txt
         shell: bash

--- a/.github/workflows/assemble_export_templates.yml
+++ b/.github/workflows/assemble_export_templates.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Move windows x86_64 release export template
         shell: sh
-        run: mv godot.windows.template_release.x86_64.jvm.${{ inputs.build-version }}.exe.jvm templates/windows_release_x86_64.exe
+        run: mv godot.windows.template_release.x86_64.jvm.${{ inputs.build-version }}.exe templates/windows_release_x86_64.exe
 
       - name: Download macos debug export template
         uses: actions/download-artifact@v4

--- a/.github/workflows/assemble_ios.yml
+++ b/.github/workflows/assemble_ios.yml
@@ -6,6 +6,8 @@ on:
         type: string
       godot-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-ios_assemble

--- a/.github/workflows/assemble_linux.yml
+++ b/.github/workflows/assemble_linux.yml
@@ -6,6 +6,8 @@ on:
         type: string
       godot-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux_assemble

--- a/.github/workflows/assemble_macos.yml
+++ b/.github/workflows/assemble_macos.yml
@@ -6,6 +6,8 @@ on:
         type: string
       godot-version:
         type: string
+      build-version:
+          type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos_assemble
@@ -49,8 +51,8 @@ jobs:
       - name: Create ${{ matrix.target }} OSX universal binary
         uses: ./.github/actions/create-macos-universal-binary
         with:
-          amd-64-binary: godot.macos.editor${{ matrix.editor-target-insert }}.x86_64
-          arm-64-binary: godot.macos.editor${{ matrix.editor-target-insert }}.arm64
+          amd-64-binary: godot.macos.editor${{ matrix.editor-target-insert }}.x86_64.jvm.${{ inputs.build-version }}
+          arm-64-binary: godot.macos.editor${{ matrix.editor-target-insert }}.arm64.jvm.${{ inputs.build-version }}
           universal-output-binary: godot.macos.editor.${{ matrix.target }}.universal
 
       - name: Upload ${{ matrix.target }} macos universal artifact
@@ -142,8 +144,8 @@ jobs:
       - name: Create macos universal binary
         uses: ./.github/actions/create-macos-universal-binary
         with:
-          amd-64-binary: godot.macos.template_${{ matrix.target }}.x86_64
-          arm-64-binary: godot.macos.template_${{ matrix.target }}.arm64
+          amd-64-binary: godot.macos.template_${{ matrix.target }}.x86_64.jvm.${{ inputs.build-version }}
+          arm-64-binary: godot.macos.template_${{ matrix.target }}.arm64.jvm.${{ inputs.build-version }}
           universal-output-binary: godot.macos.template_${{ matrix.target }}.universal
 
       - name: Upload ${{ matrix.target }} macos universal artifact

--- a/.github/workflows/assemble_windows.yml
+++ b/.github/workflows/assemble_windows.yml
@@ -6,6 +6,8 @@ on:
         type: string
       godot-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-windows_assemble
@@ -32,7 +34,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: editor_${{ matrix.target }}_windows_${{ matrix.arch }}
-          path: godot-kotlin-jvm_editor_windows_${{ matrix.arch }}_${{ matrix.target }}_${{ inputs.godot-kotlin-jvm-version }}
+          path: godot-kotlin-jvm_editor_windows_${{ matrix.arch }}_${{ matrix.target }}_${{ inputs.godot-kotlin-jvm-version }}.jvm.${{ inputs.build-version }}
 
       - name: Download ${{ matrix.target }} bootstrap jar
         uses: actions/download-artifact@v4

--- a/.github/workflows/build_android.yml
+++ b/.github/workflows/build_android.yml
@@ -6,6 +6,8 @@ on:
         type: string
       jvm-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-android_build

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,6 +1,5 @@
 name: Deploy docs
 
-
 on:
   workflow_call:
 

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -6,6 +6,8 @@ on:
         type: string
       jvm-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux_tests

--- a/.github/workflows/test_linux_exports.yml
+++ b/.github/workflows/test_linux_exports.yml
@@ -61,7 +61,7 @@ jobs:
         run: |
           chmod +x harness/tests/bin/godot.*
           mkdir -p harness/tests/export
-          mv godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64 harness/tests/godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64
+          mv godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }} harness/tests/godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }}
 
       - name: Build tests project
         run: |

--- a/.github/workflows/test_linux_exports.yml
+++ b/.github/workflows/test_linux_exports.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           chmod +x harness/tests/bin/godot.*
           mkdir -p harness/tests/export
-          mv godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }} harness/tests/godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }}
+          mv godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }} harness/tests/godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64
 
       - name: Build tests project
         run: |

--- a/.github/workflows/test_linux_exports.yml
+++ b/.github/workflows/test_linux_exports.yml
@@ -6,6 +6,8 @@ on:
         type: string
       jvm-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-linux_exports_tests

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -6,6 +6,8 @@ on:
         type: string
       jvm-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos_tests

--- a/.github/workflows/test_macos_exports.yml
+++ b/.github/workflows/test_macos_exports.yml
@@ -6,6 +6,8 @@ on:
         type: string
       jvm-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-macos_exports_tests

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -6,6 +6,8 @@ on:
         type: string
       jvm-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-windows_tests

--- a/.github/workflows/test_windows_exports.yml
+++ b/.github/workflows/test_windows_exports.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Prepare export
         run: |
           mkdir -p harness/tests/export
-          mv godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }}.exe harness/tests/godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }}.exe
+          mv godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }}.exe harness/tests/godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.exe
 
       - name: Build tests project
         run: |

--- a/.github/workflows/test_windows_exports.yml
+++ b/.github/workflows/test_windows_exports.yml
@@ -6,6 +6,8 @@ on:
         type: string
       jvm-version:
         type: string
+      build-version:
+        type: string
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-windows_exports_tests

--- a/.github/workflows/test_windows_exports.yml
+++ b/.github/workflows/test_windows_exports.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Prepare export
         run: |
           mkdir -p harness/tests/export
-          mv godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.exe harness/tests/godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.exe
+          mv godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }}.exe harness/tests/godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }}.exe
 
       - name: Build tests project
         run: |

--- a/.github/workflows/trigger_dev.yml
+++ b/.github/workflows/trigger_dev.yml
@@ -66,7 +66,9 @@ jobs:
       - run: |
           echo "Setup done"
     outputs: # defined here explicitly, so it only needs to be defined here. All other workflows can just reference it
+      godot-kotlin-jvm-version: "0.11.0-4.3"
       godot-version: "4.3-stable"
+      build-version: "0.11.0"
       jvm-version: "17"
 
   build-jvm:

--- a/.github/workflows/trigger_on_pull_request.yml
+++ b/.github/workflows/trigger_on_pull_request.yml
@@ -14,8 +14,9 @@ jobs:
       - run: |
           echo "Setup done"
     outputs: # defined here explicitly, so it only needs to be defined here. All other workflows can just reference it
-      godot-kotlin-jvm-version: "0.10.0-4.3.0"
+      godot-kotlin-jvm-version: "0.11.0-4.3"
       godot-version: "4.3-stable"
+      build-version: "0.11.0"
       jvm-version: "17"
 
   build-jvm:

--- a/.github/workflows/trigger_on_pull_request.yml
+++ b/.github/workflows/trigger_on_pull_request.yml
@@ -36,6 +36,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   build-ios:
     name: 🍏 Build iOS
@@ -79,6 +80,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-ios:
     name: 🍏 Assemble ios
@@ -89,6 +91,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-linux:
     name: 🐧 Assemble linux
@@ -100,6 +103,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-windows:
     name: 🪟 Assemble windows
@@ -111,6 +115,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-export-templates:
     name: 🤖+🍏+🐧+🍎+🪟 Assemble export templates
@@ -125,6 +130,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   test-linux:
     name: 🐧 Test Linux

--- a/.github/workflows/trigger_on_pull_request.yml
+++ b/.github/workflows/trigger_on_pull_request.yml
@@ -142,6 +142,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   test-macos:
     name: 🍎 Test Macos
@@ -153,6 +154,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   test-windows:
     name: 🪟 Test Windows
@@ -164,6 +166,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   test-linux-exports:
     name: 🐧 Test Linux Exports
@@ -175,6 +178,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   test-macos-exports:
     name: 🍎 Test Macos Exports
@@ -186,6 +190,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   test-windows-exports:
     name: 🪟 Test Windows Exports
@@ -197,3 +202,4 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}

--- a/.github/workflows/trigger_on_push_master.yml
+++ b/.github/workflows/trigger_on_push_master.yml
@@ -19,8 +19,9 @@ jobs:
       - run: |
           echo "Setup done"
     outputs: # defined here explicitly, so it only needs to be defined here. All other workflows can just reference it
-      godot-kotlin-jvm-version: "0.10.0-4.3.0"
+      godot-kotlin-jvm-version: "0.11.0-4.3"
       godot-version: "4.3-stable"
+      build-version: "0.11.0"
       jvm-version: "17"
 
   build-jvm:

--- a/.github/workflows/trigger_on_push_master.yml
+++ b/.github/workflows/trigger_on_push_master.yml
@@ -41,6 +41,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   build-ios:
     name: 🍏 Build iOS
@@ -84,6 +85,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-ios:
     name: 🍏 Assemble ios
@@ -94,6 +96,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-linux:
     name: 🐧 Assemble linux
@@ -105,6 +108,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-windows:
     name: 🪟 Assemble windows
@@ -116,6 +120,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-export-templates:
     name: 🤖+🍏+🐧+🍎+🪟 Assemble export templates
@@ -130,3 +135,4 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}

--- a/.github/workflows/trigger_on_tag.yml
+++ b/.github/workflows/trigger_on_tag.yml
@@ -2,7 +2,9 @@ name: Deploy release
 on:
   push:
     tags:
+      - '\d+.\d+.\d+-\d+.\d+-SNAPSHOT'
       - '\d+.\d+.\d+-\d+.\d+.\d+-SNAPSHOT'
+      - '\d+.\d+.\d+-\d+.\d+'
       - '\d+.\d+.\d+-\d+.\d+.\d+'
 
 concurrency:

--- a/.github/workflows/trigger_on_tag.yml
+++ b/.github/workflows/trigger_on_tag.yml
@@ -48,6 +48,7 @@ jobs:
     with:
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
       jvm-version: ${{ needs.setup-build-variables.outputs['jvm-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   build-ios:
     name: 🍏 Build iOS
@@ -91,6 +92,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-ios:
     name: 🍏 Assemble ios
@@ -101,6 +103,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-linux:
     name: 🐧 Assemble linux
@@ -112,6 +115,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-windows:
     name: 🪟 Assemble windows
@@ -123,6 +127,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   assemble-export-templates:
     name: 🤖+🍏+🐧+🍎+🪟 Assemble export templates
@@ -137,6 +142,7 @@ jobs:
     with:
       godot-kotlin-jvm-version: ${{ needs.setup-build-variables.outputs['godot-kotlin-jvm-version'] }}
       godot-version: ${{ needs.setup-build-variables.outputs['godot-version'] }}
+      build-version: ${{ needs.setup-build-variables.outputs['build-version'] }}
 
   deploy-godot:
     name: 🚀 Deploy godot artifacts to Github

--- a/.github/workflows/trigger_on_tag.yml
+++ b/.github/workflows/trigger_on_tag.yml
@@ -24,8 +24,9 @@ jobs:
       - run: |
           echo "Setup done"
     outputs: # defined here explicitly, so it only needs to be defined here. All other workflows can just reference it
-      godot-kotlin-jvm-version: "0.10.0-4.3.0"
+      godot-kotlin-jvm-version: "0.11.0-4.3"
       godot-version: "4.3-stable"
+      build-version: "0.11.0"
       jvm-version: "17"
 
   build-jvm:

--- a/config.py
+++ b/config.py
@@ -2,4 +2,4 @@ def can_build(env, platform):
     return True
 
 def configure(env):
-    pass
+    env.add_module_version_string("jvm.0.11.0")

--- a/docs/src/doc/user-guide/exporting.md
+++ b/docs/src/doc/user-guide/exporting.md
@@ -14,7 +14,7 @@ On desktop platforms, this also copies the JRE folder of your project in the exp
 !!!warning
     The official export templates from Godot will not work! You have to use our export templates or build your own!
     Note that because this is not an official build, the template manager will fail to find a link to our templates and display a warning.
-    Downloading our templates from the Godot editor is currently not possible, we opened a [proposal](godotengine/godot-proposals#10894) for it.
+    You can simply ignore it. Downloading our templates from the Godot editor is currently not possible, we opened a [proposal](godotengine/godot-proposals#10894) for it.
 
 
 ## Requirements

--- a/docs/src/doc/user-guide/exporting.md
+++ b/docs/src/doc/user-guide/exporting.md
@@ -11,8 +11,10 @@ To export your game, you need to add our export templates to Godot. After you've
 After the export templates have been added, you can export your game. Your game `jar` will be included in `pck`.
 On desktop platforms, this also copies the JRE folder of your project in the exported game folder.
 
-!!!danger
-    The official export templates from Godot will not work! You have to use our export templates or build your own! Therefore, you cannot just hit the "Download and Install" button in the export template manager!
+!!!warning
+    The official export templates from Godot will not work! You have to use our export templates or build your own!
+    Note that because this is not an official build, the template manager will fail to find a link to our templates and display a warning.
+    Downloading our templates from the Godot editor is currently not possible, we opened a [proposal](godotengine/godot-proposals#10894) for it.
 
 
 ## Requirements

--- a/kt/gradle/libs.versions.toml
+++ b/kt/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 
-godotKotlinJvm = "0.10.0"
+godotKotlinJvm = "0.11.0"
 kotlin = "2.0.20" # https://kotlinlang.org/docs/releases.html#release-details
 kotlinCoroutine = "1.8.1"
-godot = "4.3.0"
+godot = "4.3"
 ideaPluginDefaultIntellijVersion = "2024.2"
 
 shadowJar = "8.3.0" # https://github.com/johnrengelman/shadow/releases

--- a/src/version.h
+++ b/src/version.h
@@ -1,6 +1,6 @@
 #ifndef GODOT_JVM_VERSION_H
 #define GODOT_JVM_VERSION_H
 
-constexpr const char* GODOT_KOTLIN_VERSION = "0.10.0-4.3.0";
+constexpr const char* GODOT_KOTLIN_VERSION = "0.11.0-4.3";
 
 #endif// GODOT_JVM_VERSION_H

--- a/versionBumpGuide.txt
+++ b/versionBumpGuide.txt
@@ -2,7 +2,7 @@ When updating this project version, here the list of strings to changes:
 - src/version.h: GODOT_KOTLIN_VERSION.
 - kt/gradle/libs.versions.toml: godotKotlinJvm, kotlin and godot variables.
 - docs/src/index.md: kotlin version, Full version, Module Version and Supported Godot Version fields in "Versioning" block.
-- docs/src/user-guide/versioning.md:
+- config.py: Change the String to "jvm-x.x.x".
 
 If you've updated the kotlin version, ensure to check if the R8 version is compatible with the chosen kotlin version! Then update the required minimum build tool versions by doing a search and replace on the following strings:
 - `android-35`


### PR DESCRIPTION
Currently, the editor is not able to automatically use our templates because there is a mismatch between its name and the name of the template. We have so far build our custom editor using the same "name" as the official godot, which creates a conflict.

I made the changes so that the next release is going to use the name `4.3.stable.jvm.0.11.0`.
We can't change the prefix `4.3-stable` unless we directly Godot files, but we can append anything we want to it, so I picked `jvm.ourcurrentversion`

Without that change, users can't properly export without manually setting a release and a debug export template in their export preset.
This issue didn't happened before because we were using the same name as the official template for ours. I changed last before the last release so people could have both the official and the koltin versions of a template without name conflict. I just didn't realise that the editor name had to exactly the template to work..

So it's either this change or we revert all names to the same as the official release, preventing users to use both Kotlin and non kotlin versions of the templates.

Note that because, this PR changes the names of the build, opening the template manager create this warning:
![image](https://github.com/user-attachments/assets/bbd30add-6985-4c1b-a298-7522f16c4b48)
It doesn't prevent anything, it's just an annoying warning because the editor is hardcoded to search the official godot website.

I created a proposal that would allow us to set a link to our GitHub, so users can download templates directly from there:
https://github.com/godotengine/godot-proposals/issues/10894