### PR TITLE
Rework Variant.h

### DIFF
--- a/src/jvm_wrapper/memory/transfer_context.h
+++ b/src/jvm_wrapper/memory/transfer_context.h
@@ -36,7 +36,7 @@ private:
 
     _FORCE_INLINE_ static void read_args_to_array(SharedBuffer* buffer, Variant* p_args, uint32_t args_size) {
         for (uint32_t i = 0; i < args_size; ++i) {
-            ktvariant::get_variant_from_buffer(buffer, p_args[i]);
+            BufferToVariant::read_variant(buffer, p_args[i]);
         }
     }
 };

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -12,23 +12,46 @@
 #include <core/os/os.h>
 #include <core/variant/variant.h>
 
-namespace ktvariant {
+constexpr const int BOOL_SIZE = 4;
+constexpr const int PTR_SIZE = 8;
+constexpr const int INT_SIZE = 4;
 
-    constexpr const int BOOL_SIZE = 4;
+class VariantToBuffer {
+    template<Variant::Type variantType, class T>
+    static void write_core_type(SharedBuffer* des, const Variant& src) {
+        set_variant_type(des, variantType);
 
-    constexpr const int PTR_SIZE = 8;
+        *reinterpret_cast<T*>(des->get_cursor()) = src;
+        des->increment_position(sizeof(T));
+    }
 
-    constexpr const int INT_SIZE = 4;
+    template<class TNativeCoreType>
+    inline static void write_pointer(SharedBuffer* des, TNativeCoreType native_core_type) {
+        des->increment_position(
+          encode_uint64(reinterpret_cast<uintptr_t>(memnew(TNativeCoreType(native_core_type))), des->get_cursor())
+        );
+    }
+
+    template<Variant::Type variantType, class TNativeCoreType, TNativeCoreType (Variant::* converter)() const>
+    static void write_native_core_type(SharedBuffer* des, const Variant& src) {
+        set_variant_type(des, variantType);
+        write_pointer(des, (src.*converter)());
+    }
 
     static void set_variant_type(SharedBuffer* des, Variant::Type variant_type) {
         des->increment_position(encode_uint32(variant_type, des->get_cursor()));
     }
 
-    static void to_kvariant_fromNIL(SharedBuffer* des, const Variant& src) {
+    static void write_nil(SharedBuffer* des, const Variant& src) {
         set_variant_type(des, Variant::Type::NIL);
     }
 
-    static void to_kvariant_fromSTRING(SharedBuffer* des, const Variant& src) {
+    static void write_bool(SharedBuffer* des, const Variant& src) {
+        set_variant_type(des, Variant::Type::BOOL);
+        des->increment_position(encode_uint32(src.operator bool(), des->get_cursor()));
+    }
+
+    static void write_string(SharedBuffer* des, const Variant& src) {
         String str {src};
         const CharString& char_string {str.utf8()};
         set_variant_type(des, Variant::Type::STRING);
@@ -44,33 +67,7 @@ namespace ktvariant {
         }
     }
 
-    static void to_kvariant_fromBOOL(SharedBuffer* des, const Variant& src) {
-        set_variant_type(des, Variant::Type::BOOL);
-        des->increment_position(encode_uint32(src.operator bool(), des->get_cursor()));
-    }
-
-    template<Variant::Type variantType, class T>
-    static void to_kvariant_fromCORETYPE(SharedBuffer* des, const Variant& src) {
-        set_variant_type(des, variantType);
-
-        *reinterpret_cast<T*>(des->get_cursor()) = src;
-        des->increment_position(sizeof(T));
-    }
-
-    template<class TNativeCoreType>
-    inline static void append_nativecoretype(SharedBuffer* des, TNativeCoreType native_core_type) {
-        des->increment_position(
-          encode_uint64(reinterpret_cast<uintptr_t>(memnew(TNativeCoreType(native_core_type))), des->get_cursor())
-        );
-    }
-
-    template<Variant::Type variantType, class TNativeCoreType, TNativeCoreType (Variant::* converter)() const>
-    static void to_kvariant_fromNATIVECORETYPE(SharedBuffer* des, const Variant& src) {
-        set_variant_type(des, variantType);
-        append_nativecoretype(des, (src.*converter)());
-    }
-
-    static void to_kvariant_fromARRAY(SharedBuffer* des, const Variant& src) {
+    static void write_array(SharedBuffer* des, const Variant& src) {
         Array arr = src.operator Array();
         uint64_t type = arr.get_typed_builtin();
         set_variant_type(des, Variant::Type::ARRAY);
@@ -95,84 +92,110 @@ namespace ktvariant {
         des->increment_position(encode_uint64(ptr->get_instance_id(), des->get_cursor()));
     }
 
-    static void to_kvariant_fromSIGNAL(SharedBuffer* des, const Variant& src) {
-        Signal signal {src.operator Signal()};
-        set_variant_type(des, Variant::Type::SIGNAL);
-        append_object(des, signal.get_object());
-        append_nativecoretype<StringName>(des, signal.get_name());
-    }
-
-    static void to_kvariant_fromOBJECT(SharedBuffer* des, const Variant& src) {
+    static void write_object(SharedBuffer* des, const Variant& src) {
         set_variant_type(des, Variant::Type::OBJECT);
         append_object(des, src);
     }
 
-    static void init_to_kt_methods(void (*to_kt_array[Variant::Type::VARIANT_MAX])(SharedBuffer*, const Variant&)) {
-        to_kt_array[Variant::NIL] = to_kvariant_fromNIL;
-        to_kt_array[Variant::BOOL] = to_kvariant_fromBOOL;
-        to_kt_array[Variant::INT] = to_kvariant_fromCORETYPE<Variant::INT, uint64_t>;
-        to_kt_array[Variant::FLOAT] = to_kvariant_fromCORETYPE<Variant::FLOAT, double>;
-        to_kt_array[Variant::STRING] = to_kvariant_fromSTRING;
-        to_kt_array[Variant::VECTOR2] = to_kvariant_fromCORETYPE<Variant::VECTOR2, Vector2>;
-        to_kt_array[Variant::VECTOR2I] = to_kvariant_fromCORETYPE<Variant::VECTOR2I, Vector2i>;
-        to_kt_array[Variant::RECT2] = to_kvariant_fromCORETYPE<Variant::RECT2, Rect2>;
-        to_kt_array[Variant::RECT2I] = to_kvariant_fromCORETYPE<Variant::RECT2I, Rect2i>;
-        to_kt_array[Variant::VECTOR3] = to_kvariant_fromCORETYPE<Variant::VECTOR3, Vector3>;
-        to_kt_array[Variant::VECTOR3I] = to_kvariant_fromCORETYPE<Variant::VECTOR3I, Vector3i>;
-        to_kt_array[Variant::TRANSFORM2D] = to_kvariant_fromCORETYPE<Variant::TRANSFORM2D, Transform2D>;
-        to_kt_array[Variant::VECTOR4] = to_kvariant_fromCORETYPE<Variant::VECTOR4, Vector4>;
-        to_kt_array[Variant::VECTOR4I] = to_kvariant_fromCORETYPE<Variant::VECTOR4I, Vector4i>;
-        to_kt_array[Variant::PLANE] = to_kvariant_fromCORETYPE<Variant::PLANE, Plane>;
-        to_kt_array[Variant::QUATERNION] = to_kvariant_fromCORETYPE<Variant::QUATERNION, Quaternion>;
-        to_kt_array[Variant::AABB] = to_kvariant_fromCORETYPE<Variant::AABB, AABB>;
-        to_kt_array[Variant::BASIS] = to_kvariant_fromCORETYPE<Variant::BASIS, Basis>;
-        to_kt_array[Variant::TRANSFORM3D] = to_kvariant_fromCORETYPE<Variant::TRANSFORM3D, Transform3D>;
-        to_kt_array[Variant::PROJECTION] = to_kvariant_fromCORETYPE<Variant::PROJECTION, Projection>;
-        to_kt_array[Variant::COLOR] = to_kvariant_fromCORETYPE<Variant::COLOR, Color>;
-        to_kt_array[Variant::CALLABLE] = to_kvariant_fromNATIVECORETYPE < Variant::CALLABLE, Callable, &Variant::operator Callable>;
-        to_kt_array[Variant::SIGNAL] = to_kvariant_fromSIGNAL;
-        to_kt_array[Variant::DICTIONARY] = to_kvariant_fromNATIVECORETYPE < Variant::DICTIONARY, Dictionary,
-        &Variant::operator Dictionary>;
-        to_kt_array[Variant::ARRAY] = to_kvariant_fromARRAY;
-        to_kt_array[Variant::STRING_NAME] = to_kvariant_fromNATIVECORETYPE < Variant::STRING_NAME, StringName,
-        &Variant::operator StringName>;
-        to_kt_array[Variant::NODE_PATH] = to_kvariant_fromNATIVECORETYPE < Variant::NODE_PATH, NodePath,
-        &Variant::operator NodePath>;
-        to_kt_array[Variant::RID] = to_kvariant_fromCORETYPE<Variant::RID, RID>;
-        to_kt_array[Variant::PACKED_BYTE_ARRAY] = to_kvariant_fromNATIVECORETYPE < Variant::PACKED_BYTE_ARRAY,
-        PackedByteArray, &Variant::operator PackedByteArray>;
-        to_kt_array[Variant::PACKED_INT32_ARRAY] = to_kvariant_fromNATIVECORETYPE < Variant::PACKED_INT32_ARRAY,
-        PackedInt32Array, &Variant::operator PackedInt32Array>;
-        to_kt_array[Variant::PACKED_INT64_ARRAY] = to_kvariant_fromNATIVECORETYPE < Variant::PACKED_INT64_ARRAY,
-        PackedInt64Array, &Variant::operator PackedInt64Array>;
-        to_kt_array[Variant::PACKED_FLOAT32_ARRAY] = to_kvariant_fromNATIVECORETYPE < Variant::PACKED_FLOAT32_ARRAY,
-        PackedFloat32Array, &Variant::operator PackedFloat32Array>;
-        to_kt_array[Variant::PACKED_FLOAT64_ARRAY] = to_kvariant_fromNATIVECORETYPE < Variant::PACKED_FLOAT64_ARRAY,
-        PackedFloat64Array, &Variant::operator PackedFloat64Array>;
-        to_kt_array[Variant::PACKED_STRING_ARRAY] = to_kvariant_fromNATIVECORETYPE < Variant::PACKED_STRING_ARRAY,
-        PackedStringArray, &Variant::operator PackedStringArray>;
-        to_kt_array[Variant::PACKED_VECTOR2_ARRAY] = to_kvariant_fromNATIVECORETYPE < Variant::PACKED_VECTOR2_ARRAY,
-        PackedVector2Array, &Variant::operator PackedVector2Array>;
-        to_kt_array[Variant::PACKED_VECTOR3_ARRAY] = to_kvariant_fromNATIVECORETYPE < Variant::PACKED_VECTOR3_ARRAY,
-        PackedVector3Array, &Variant::operator PackedVector3Array>;
-        to_kt_array[Variant::PACKED_COLOR_ARRAY] = to_kvariant_fromNATIVECORETYPE < Variant::PACKED_COLOR_ARRAY,
-        PackedColorArray, &Variant::operator PackedColorArray>;
-        to_kt_array[Variant::OBJECT] = to_kvariant_fromOBJECT;
+
+    static void write_signal(SharedBuffer* des, const Variant& src) {
+        Signal signal {src.operator Signal()};
+        set_variant_type(des, Variant::Type::SIGNAL);
+        append_object(des, signal.get_object());
+        write_pointer<StringName>(des, signal.get_name());
     }
 
-    static void send_variant_to_buffer(const Variant& variant, SharedBuffer* byte_buffer) {
+public:
+
+    static void write_variant(const Variant& variant, SharedBuffer* byte_buffer) {
         // must match the value order of godot_variant_type
-        static void (*TO_KT_VARIANT_FROM[Variant::Type::VARIANT_MAX])(SharedBuffer*, const Variant&);
-        if (unlikely(!TO_KT_VARIANT_FROM[0])) { init_to_kt_methods(TO_KT_VARIANT_FROM); }
+        static void (*variant_writers[Variant::VARIANT_MAX])(SharedBuffer*, const Variant&) = {
+            &VariantToBuffer::write_nil,
+
+            // atomic types
+            &VariantToBuffer::write_bool,
+            &VariantToBuffer::write_core_type<Variant::INT, uint64_t>,
+            &VariantToBuffer::write_core_type<Variant::FLOAT, double>,
+            &VariantToBuffer::write_string,
+
+            // math types
+            &VariantToBuffer::write_core_type<Variant::VECTOR2, Vector2>,
+            &VariantToBuffer::write_core_type<Variant::VECTOR2I, Vector2i>,
+            &VariantToBuffer::write_core_type<Variant::RECT2, Rect2>,
+            &VariantToBuffer::write_core_type<Variant::RECT2I, Rect2i>,
+            &VariantToBuffer::write_core_type<Variant::VECTOR3, Vector3>,
+            &VariantToBuffer::write_core_type<Variant::VECTOR3I, Vector3i>,
+            &VariantToBuffer::write_core_type<Variant::TRANSFORM2D, Transform2D>,
+            &VariantToBuffer::write_core_type<Variant::VECTOR4, Vector4>,
+            &VariantToBuffer::write_core_type<Variant::VECTOR4I, Vector4i>,
+            &VariantToBuffer::write_core_type<Variant::PLANE, Plane>,
+            &VariantToBuffer::write_core_type<Variant::QUATERNION, Quaternion>,
+            &VariantToBuffer::write_core_type<Variant::AABB, AABB>,
+            &VariantToBuffer::write_core_type<Variant::BASIS, Basis>,
+            &VariantToBuffer::write_core_type<Variant::TRANSFORM3D, Transform3D>,
+            &VariantToBuffer::write_core_type<Variant::PROJECTION, Projection>,
+
+            // misc types
+            &VariantToBuffer::write_core_type<Variant::COLOR, Color>,
+            &VariantToBuffer::write_native_core_type<Variant::STRING_NAME, StringName,&Variant::operator StringName>,
+            &VariantToBuffer::write_native_core_type<Variant::NODE_PATH, NodePath,&Variant::operator NodePath>,
+            &VariantToBuffer::write_core_type<Variant::RID, RID>,
+            &VariantToBuffer::write_object,
+            &VariantToBuffer::write_native_core_type<Variant::CALLABLE, Callable, &Variant::operator Callable>,
+            &VariantToBuffer::write_signal,
+            &VariantToBuffer::write_native_core_type<Variant::DICTIONARY, Dictionary,&Variant::operator Dictionary>,
+            &VariantToBuffer::write_array,
+
+            // typed arrays
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_BYTE_ARRAY,PackedByteArray, &Variant::operator PackedByteArray>,
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_INT32_ARRAY,PackedInt32Array, &Variant::operator PackedInt32Array>,
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_INT64_ARRAY,PackedInt64Array, &Variant::operator PackedInt64Array>,
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_FLOAT32_ARRAY,PackedFloat32Array, &Variant::operator PackedFloat32Array>,
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_FLOAT64_ARRAY,PackedFloat64Array, &Variant::operator PackedFloat64Array>,
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_STRING_ARRAY,PackedStringArray, &Variant::operator PackedStringArray>,
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_VECTOR2_ARRAY,PackedVector2Array, &Variant::operator PackedVector2Array>,
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_VECTOR3_ARRAY,PackedVector3Array, &Variant::operator PackedVector3Array>,
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_COLOR_ARRAY,PackedColorArray, &Variant::operator PackedColorArray>,
+            &VariantToBuffer::write_native_core_type<Variant::PACKED_VECTOR4_ARRAY,PackedVector4Array, &Variant::operator PackedVector4Array>
+        };
+
         Variant::Type type = variant.get_type();
-        TO_KT_VARIANT_FROM[type](byte_buffer, variant);
+        variant_writers[type](byte_buffer, variant);
+    }
+};
+
+
+class BufferToVariant {
+    template<class T>
+    static Variant read_core_type(SharedBuffer* byte_buffer) {
+        auto result {reinterpret_cast<T*>(byte_buffer->get_cursor())};
+        byte_buffer->increment_position(sizeof(T));
+        return Variant(*result);
     }
 
-    static Variant from_kvariant_tokNilValue(SharedBuffer* byte_buffer) {
+    template<class T>
+    static inline T* read_pointer(SharedBuffer* byte_buffer) {
+        auto ptr {static_cast<uintptr_t>(decode_uint64(byte_buffer->get_cursor()))};
+        byte_buffer->increment_position(PTR_SIZE);
+        return reinterpret_cast<T*>(ptr);
+    }
+
+    template<class T>
+    static Variant read_native_core_type(SharedBuffer* byte_buffer) {
+        return *read_pointer<T>(byte_buffer);
+    }
+
+    static Variant read_nil(SharedBuffer* byte_buffer) {
         return Variant();
     }
 
-    static Variant from_kvariant_tokStringValue(SharedBuffer* byte_buffer) {
+    static Variant read_bool(SharedBuffer* byte_buffer) {
+        bool b {static_cast<bool>(decode_uint32(byte_buffer->get_cursor()))};
+        byte_buffer->increment_position(BOOL_SIZE);
+        return Variant(b);
+    }
+
+    static Variant read_string(SharedBuffer* byte_buffer) {
         bool is_long {static_cast<bool>(decode_uint32(byte_buffer->get_cursor()))};
         byte_buffer->increment_position(BOOL_SIZE);
         if (unlikely(is_long)) {
@@ -188,105 +211,88 @@ namespace ktvariant {
         }
     }
 
-    static Variant from_kvariant_tokBoolValue(SharedBuffer* byte_buffer) {
-        bool b {static_cast<bool>(decode_uint32(byte_buffer->get_cursor()))};
-        byte_buffer->increment_position(BOOL_SIZE);
-        return Variant(b);
-    }
-
-    template<class T>
-    static Variant from_kvariant_to_kVariantCoreTypeValue(SharedBuffer* byte_buffer) {
-        auto result {reinterpret_cast<T*>(byte_buffer->get_cursor())};
-        byte_buffer->increment_position(sizeof(T));
-        return *result;
-    }
-
     static inline Object* to_godot_object(SharedBuffer* byte_buffer) {
         auto ptr {static_cast<uintptr_t>(decode_uint64(byte_buffer->get_cursor()))};
         byte_buffer->increment_position(PTR_SIZE);
         return reinterpret_cast<Object*>(ptr);
     }
 
-    template<class T>
-    static inline T* to_native_core_type(SharedBuffer* byte_buffer) {
-        auto ptr {static_cast<uintptr_t>(decode_uint64(byte_buffer->get_cursor()))};
-        byte_buffer->increment_position(PTR_SIZE);
-        return reinterpret_cast<T*>(ptr);
-    }
-
-    static Variant from_kvariant_toKSignalValue(SharedBuffer* byte_buffer) {
-        const Object* object {to_godot_object(byte_buffer)};
-        const StringName name {*to_native_core_type<StringName>(byte_buffer)};
-        return Variant(Signal(object, name));
-    }
-
-    template<class T>
-    static Variant from_kvariant_tokVariantNativeCoreTypeValue(SharedBuffer* byte_buffer) {
-        return Variant(*to_native_core_type<T>(byte_buffer));
-    }
-
-    static Variant from_kvariant_tKCallableValue(SharedBuffer* byte_buffer) {
-        bool is_custom {static_cast<bool>(decode_uint32(byte_buffer->get_cursor()))};
-        byte_buffer->increment_position(BOOL_SIZE);
-
-        if (is_custom) { return Callable(to_native_core_type<CallableCustom>(byte_buffer)); }
-
-        return from_kvariant_tokVariantNativeCoreTypeValue<Callable>(byte_buffer);
-    }
-
-    static Variant from_kvariant_toKObjectValue(SharedBuffer* byte_buffer) {
+    static Variant read_object(SharedBuffer* byte_buffer) {
         return Variant(to_godot_object(byte_buffer));
     }
 
-    static void init_to_gd_methods(Variant (*to_gd_array[Variant::Type::VARIANT_MAX])(SharedBuffer* byte_buffer)) {
-        to_gd_array[Variant::NIL] = from_kvariant_tokNilValue;
-        to_gd_array[Variant::BOOL] = from_kvariant_tokBoolValue;
-        to_gd_array[Variant::INT] = from_kvariant_to_kVariantCoreTypeValue<uint64_t>;
-        to_gd_array[Variant::FLOAT] = from_kvariant_to_kVariantCoreTypeValue<double>;
-        to_gd_array[Variant::STRING] = from_kvariant_tokStringValue;
-        to_gd_array[Variant::VECTOR2] = from_kvariant_to_kVariantCoreTypeValue<Vector2>;
-        to_gd_array[Variant::VECTOR2I] = from_kvariant_to_kVariantCoreTypeValue<Vector2i>;
-        to_gd_array[Variant::RECT2] = from_kvariant_to_kVariantCoreTypeValue<Rect2>;
-        to_gd_array[Variant::RECT2I] = from_kvariant_to_kVariantCoreTypeValue<Rect2i>;
-        to_gd_array[Variant::VECTOR3] = from_kvariant_to_kVariantCoreTypeValue<Vector3>;
-        to_gd_array[Variant::VECTOR3I] = from_kvariant_to_kVariantCoreTypeValue<Vector3i>;
-        to_gd_array[Variant::TRANSFORM2D] = from_kvariant_to_kVariantCoreTypeValue<Transform2D>;
-        to_gd_array[Variant::VECTOR4] = from_kvariant_to_kVariantCoreTypeValue<Vector4>;
-        to_gd_array[Variant::VECTOR4I] = from_kvariant_to_kVariantCoreTypeValue<Vector4i>;
-        to_gd_array[Variant::PLANE] = from_kvariant_to_kVariantCoreTypeValue<Plane>;
-        to_gd_array[Variant::QUATERNION] = from_kvariant_to_kVariantCoreTypeValue<Quaternion>;
-        to_gd_array[Variant::AABB] = from_kvariant_to_kVariantCoreTypeValue<AABB>;
-        to_gd_array[Variant::BASIS] = from_kvariant_to_kVariantCoreTypeValue<Basis>;
-        to_gd_array[Variant::TRANSFORM3D] = from_kvariant_to_kVariantCoreTypeValue<Transform3D>;
-        to_gd_array[Variant::PROJECTION] = from_kvariant_to_kVariantCoreTypeValue<Projection>;
-        to_gd_array[Variant::COLOR] = from_kvariant_to_kVariantCoreTypeValue<Color>;
-        to_gd_array[Variant::CALLABLE] = from_kvariant_tKCallableValue;
-        to_gd_array[Variant::SIGNAL] = from_kvariant_toKSignalValue;
-        to_gd_array[Variant::DICTIONARY] = from_kvariant_tokVariantNativeCoreTypeValue<Dictionary>;
-        to_gd_array[Variant::ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<Array>;
-        to_gd_array[Variant::STRING_NAME] = from_kvariant_tokVariantNativeCoreTypeValue<StringName>;
-        to_gd_array[Variant::NODE_PATH] = from_kvariant_tokVariantNativeCoreTypeValue<NodePath>;
-        to_gd_array[Variant::RID] = from_kvariant_to_kVariantCoreTypeValue<RID>;
-        to_gd_array[Variant::PACKED_BYTE_ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<PackedByteArray>;
-        to_gd_array[Variant::PACKED_INT32_ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<PackedInt32Array>;
-        to_gd_array[Variant::PACKED_INT64_ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<PackedInt64Array>;
-        to_gd_array[Variant::PACKED_FLOAT32_ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<PackedFloat32Array>;
-        to_gd_array[Variant::PACKED_FLOAT64_ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<PackedFloat64Array>;
-        to_gd_array[Variant::PACKED_STRING_ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<PackedStringArray>;
-        to_gd_array[Variant::PACKED_VECTOR2_ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<PackedVector2Array>;
-        to_gd_array[Variant::PACKED_VECTOR3_ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<PackedVector3Array>;
-        to_gd_array[Variant::PACKED_COLOR_ARRAY] = from_kvariant_tokVariantNativeCoreTypeValue<PackedColorArray>;
-        to_gd_array[Variant::OBJECT] = from_kvariant_toKObjectValue;
+    static Variant read_signal(SharedBuffer* byte_buffer) {
+        const Object* object {to_godot_object(byte_buffer)};
+        const StringName name {*read_pointer<StringName>(byte_buffer)};
+        return Variant(Signal(object, name));
     }
 
-    static void get_variant_from_buffer(SharedBuffer* byte_buffer, Variant& res) {
-        static Variant (*TO_GODOT_VARIANT_FROM[Variant::Type::VARIANT_MAX])(SharedBuffer* byte_buffer);
-        if (unlikely(!TO_GODOT_VARIANT_FROM[0])) { init_to_gd_methods(TO_GODOT_VARIANT_FROM); }
+    static Variant read_callable(SharedBuffer* byte_buffer) {
+        bool is_custom {static_cast<bool>(decode_uint32(byte_buffer->get_cursor()))};
+        byte_buffer->increment_position(BOOL_SIZE);
+
+        if (is_custom) { return Callable(read_pointer<CallableCustom>(byte_buffer)); }
+
+        return *read_pointer<Callable>(byte_buffer);
+    }
+
+public:
+
+    static void read_variant(SharedBuffer* byte_buffer, Variant& res) {
+        static Variant (*variant_readers[Variant::VARIANT_MAX])(SharedBuffer*) = {
+          &BufferToVariant::read_nil,
+
+          // atomic types
+          &BufferToVariant::read_bool,
+          &BufferToVariant::read_core_type<uint64_t>,
+          &BufferToVariant::read_core_type<double>,
+          &BufferToVariant::read_string,
+
+          // math types
+          &BufferToVariant::read_core_type<Vector2>,
+          &BufferToVariant::read_core_type<Vector2i>,
+          &BufferToVariant::read_core_type<Rect2>,
+          &BufferToVariant::read_core_type<Rect2i>,
+          &BufferToVariant::read_core_type<Vector3>,
+          &BufferToVariant::read_core_type<Vector3i>,
+          &BufferToVariant::read_core_type<Transform2D>,
+          &BufferToVariant::read_core_type<Vector4>,
+          &BufferToVariant::read_core_type<Vector4i>,
+          &BufferToVariant::read_core_type<Plane>,
+          &BufferToVariant::read_core_type<Quaternion>,
+          &BufferToVariant::read_core_type<AABB>,
+          &BufferToVariant::read_core_type<Basis>,
+          &BufferToVariant::read_core_type<Transform3D>,
+          &BufferToVariant::read_core_type<Projection>,
+
+          // misc types
+          &BufferToVariant::read_core_type<Color>,
+          &BufferToVariant::read_native_core_type<StringName>,
+          &BufferToVariant::read_native_core_type<NodePath>,
+          &BufferToVariant::read_core_type<RID>,
+          &BufferToVariant::read_object,
+          &BufferToVariant::read_callable,
+          &BufferToVariant::read_signal,
+          &BufferToVariant::read_native_core_type<Dictionary>,
+          &BufferToVariant::read_native_core_type<Array>,
+
+          // typed arrays
+          &BufferToVariant::read_native_core_type<PackedByteArray>,
+          &BufferToVariant::read_native_core_type<PackedInt32Array>,
+          &BufferToVariant::read_native_core_type<PackedInt64Array>,
+          &BufferToVariant::read_native_core_type<PackedFloat32Array>,
+          &BufferToVariant::read_native_core_type<PackedFloat64Array>,
+          &BufferToVariant::read_native_core_type<PackedStringArray>,
+          &BufferToVariant::read_native_core_type<PackedVector2Array>,
+          &BufferToVariant::read_native_core_type<PackedVector3Array>,
+          &BufferToVariant::read_native_core_type<PackedColorArray>,
+          &BufferToVariant::read_native_core_type<PackedVector4Array>
+        };
+
         uint32_t variant_type_int {decode_uint32(byte_buffer->get_cursor())};
         byte_buffer->increment_position(4);
-        res = TO_GODOT_VARIANT_FROM[static_cast<Variant::Type>(variant_type_int)](byte_buffer);
+        res = variant_readers[variant_type_int](byte_buffer);
     }
-
-}// namespace ktvariant
+};
 
 #endif// GODOT_JVM_KT_VARIANT_H


### PR DESCRIPTION
I noticed that we never added the new PackedVector4Array to the Variant.h.
So I just took the opportunity to rework the file a bit.

The function bodies are almost unchanged, only the general structure of the file changed. Instead of the KtVariant namespace, I have put all methods into the new `BufferToVariant ` and `VariantToBuffer` structures. Because everything is static, the structures act like a more fine-grained namespace. This is also how Godot does it through its codebase.

Note that I also removed the initializer function for the array of function pointers. It's now done statically, no "if" is required during runtime anymore.

Before :
```cpp
    static void init_to_kt_methods(void (*to_kt_array[Variant::Type::VARIANT_MAX])(SharedBuffer*, const Variant&)) {
      // Long initializer...
     }

    static void send_variant_to_buffer(const Variant& variant, SharedBuffer* byte_buffer) {
        // must match the value order of godot_variant_type
        static void (*TO_KT_VARIANT_FROM[Variant::Type::VARIANT_MAX])(SharedBuffer*, const Variant&);
        if (unlikely(!TO_KT_VARIANT_FROM[0])) { init_to_kt_methods(TO_KT_VARIANT_FROM); }
        Variant::Type type = variant.get_type();
        TO_KT_VARIANT_FROM[type](byte_buffer, variant);
    }
```
After:
```cpp
    static void write_variant(const Variant& variant, SharedBuffer* byte_buffer) {
        // must match the value order of godot_variant_type
        static void (*variant_writers[Variant::VARIANT_MAX])(SharedBuffer*, const Variant&) =  {
              // Long static initializer...
        };

        Variant::Type type = variant.get_type();
        variant_writers[type](byte_buffer, variant);
    }
```