### PR TITLE
Faster API Generation

### DIFF
--- a/kt/api-generator/src/main/kotlin/godot/codegen/constants/JvmReservedMethods.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/constants/JvmReservedMethods.kt
@@ -17,7 +17,6 @@ val jvmReservedMethods = listOf(
             arguments = null,
             description = null,
             briefDescription = null
-        ),
-        ""
+        )
     )
 )

--- a/kt/api-generator/src/main/kotlin/godot/codegen/generationEntry.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/generationEntry.kt
@@ -58,20 +58,12 @@ fun File.generateApiFrom(jsonSource: File) {
 
     //We first generate singletons so that their index in engine types and engine singleton lists are same.
     for (singleton in classService.getSingletons()) {
-        for (property in singleton.properties) {
-            classService.updatePropertyIfShouldUseSuper(singleton.name, property.name)
-        }
-
         generationService.generateSingleton(singleton).writeTo(this)
         generationService.generateEngineIndexesForClass(engineIndexFile, singleton)
         generationService.generateEngineTypesRegistrationForSingleton(registrationFileSpec, singleton)
     }
 
     for (enrichedClass in classService.getClasses()) {
-        for (property in enrichedClass.properties) {
-            classService.updatePropertyIfShouldUseSuper(enrichedClass.name, property.name)
-        }
-
         generationService.generateClass(enrichedClass).writeTo(this)
         generationService.generateEngineIndexesForClass(engineIndexFile, enrichedClass)
         generationService.generateEngineTypesRegistrationForClass(registrationFileSpec, enrichedClass)

--- a/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedClass.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedClass.kt
@@ -15,7 +15,7 @@ class EnrichedClass(val internal: Class) : TypedTrait, IDocumented {
     val inherits = internal.inherits?.escapeUnderscore()
     val engineClassDBIndexName = "ENGINECLASS_${internal.name.uppercase(Locale.US)}"
     val properties= internal.properties?.toEnriched() ?: listOf()
-    val methods = internal.methods?.toEnriched(engineClassDBIndexName) ?: listOf()
+    val methods = internal.methods?.toEnriched() ?: listOf()
     val apiType = ApiType.from(internal.apiType)
     override val description = internal.description
 

--- a/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedMethod.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedMethod.kt
@@ -11,7 +11,7 @@ import godot.tools.common.constants.Constraints
 import godot.tools.common.constants.GodotTypes
 import godot.tools.common.extensions.convertToCamelCase
 
-class EnrichedMethod(val internal: Method, engineClassIndexName: String) : CallableTrait, IDocumented {
+class EnrichedMethod(val internal: Method) : CallableTrait, IDocumented {
     override val arguments = internal.arguments?.toEnriched() ?: listOf()
     override val isVararg = internal.isVararg
     val name: String
@@ -36,7 +36,7 @@ class EnrichedMethod(val internal: Method, engineClassIndexName: String) : Calla
     override val description = internal.description
 }
 
-fun List<Method>.toEnriched(engineClassIndexName: String) = map { EnrichedMethod(it, engineClassIndexName) }
+fun List<Method>.toEnriched() = map { EnrichedMethod(it) }
 
 fun EnrichedMethod.isSameSignature(other: EnrichedMethod): Boolean {
     val otherInternal = other.internal

--- a/kt/api-generator/src/main/kotlin/godot/codegen/services/IClassService.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/services/IClassService.kt
@@ -5,6 +5,5 @@ import godot.codegen.models.enriched.EnrichedClass
 interface IClassService {
     fun getSingletons(): List<EnrichedClass>
     fun getClasses(): List<EnrichedClass>
-    fun updatePropertyIfShouldUseSuper(className: String, propertyName: String)
     fun findGetSetMethodsAndUpdateProperties()
 }

--- a/kt/api-generator/src/main/kotlin/godot/codegen/services/impl/ClassService.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/services/impl/ClassService.kt
@@ -20,14 +20,14 @@ class ClassService(
     private val singletonRepository: SingletonRepository,
     private val classGraphService: IClassGraphService
 ) : IClassService{
-    override fun getSingletons() = singletonRepository
+    private val singletons = singletonRepository
         .list()
         .map {
             classRepository.findByClassName(it.type)?.copy(it.name) ?: throw NoMatchingClassFoundException(it.type)
         }
         .filter { it.apiType == ApiType.CORE }
 
-    override fun getClasses() = classRepository
+    private val classes = classRepository
         .list()
         .filter {
             for (singleton in singletonRepository.list()) {
@@ -35,6 +35,10 @@ class ClassService(
             }
             it.apiType == ApiType.CORE
         }
+
+    override fun getSingletons() = singletons
+
+    override fun getClasses() = classes
 
     override fun updatePropertyIfShouldUseSuper(className: String, propertyName: String) {
         fun inner(className: String, propertyName: String, isSetter: Boolean) {


### PR DESCRIPTION
The code generation (and not the compile time) was more than 2 minutes on my computer. 
After profiling the generator, I found the culprit to be a single method responsible for 92% of the computation time.

![image](https://github.com/user-attachments/assets/28afd55e-fe8b-4ec1-92a4-3e4e631d0fa6)

ClassService::getClasses() was called in many places in the code, always computing the same expensive operation.
Simply caching the result into a variable completly erase the computation time.
With that change, the code generation takes now less than 3s.

I also took the opportunity to unify the search for the methods used by properties. It was previously done in 2 steps that I merged together.