### PR TITLE
Scan after generating project

### DIFF
--- a/src/editor/godot_kotlin_jvm_editor.cpp
+++ b/src/editor/godot_kotlin_jvm_editor.cpp
@@ -25,6 +25,7 @@ void GodotKotlinJvmEditor::on_menu_option_pressed(int option_id) {
 
 void GodotKotlinJvmEditor::on_generate_project(bool erase_existing) {
     ProjectGenerator::generate_jvm_files(erase_existing);
+    get_editor_interface()->get_resource_file_system()->scan();
     project_dialog->hide();
 }
 


### PR DESCRIPTION
Minor fix for the JVM project generation.
I realized that after generating the project, the files weren't appearing in the Godot editor.
The reason is that Godot only refresh its filesystem automatically when you unfocus the editor and focus it again.

The assumption is that the user left the Godot window to use some external tools that can potentially change files in the project. But for any changes made by Godot itself, you have to manually call the scanner. The reason is so the editor doesn't constantly check the file system for changes but only do it on demand.

