### PR TITLE
Experimental: JDK 22 Foreign API

### DIFF
--- a/harness/bunnymark/benchmarks/BunnymarkV1DrawTexture/gdj/BunnymarkV1DrawTexture.gdj
+++ b/harness/bunnymark/benchmarks/BunnymarkV1DrawTexture/gdj/BunnymarkV1DrawTexture.gdj
@@ -11,6 +11,8 @@ supertypes = [
 	godot.Node,
 	godot.Object,
 	godot.core.KtObject,
+	godot.common.interop.IdentityPointer,
+	godot.common.interop.ValuePointer,
 	kotlin.Any
 ]
 signals = [

--- a/harness/bunnymark/benchmarks/BunnymarkV3/gdj/Bunny.gdj
+++ b/harness/bunnymark/benchmarks/BunnymarkV3/gdj/Bunny.gdj
@@ -12,6 +12,8 @@ supertypes = [
 	godot.Node,
 	godot.Object,
 	godot.core.KtObject,
+	godot.common.interop.IdentityPointer,
+	godot.common.interop.ValuePointer,
 	kotlin.Any
 ]
 signals = [

--- a/harness/bunnymark/scripts/godot/benchmark/bunnymark/BunnymarkV1Sprites.gdj
+++ b/harness/bunnymark/scripts/godot/benchmark/bunnymark/BunnymarkV1Sprites.gdj
@@ -1,9 +1,9 @@
 // THIS FILE IS GENERATED! DO NOT EDIT OR DELETE IT. EDIT OR DELETE THE ASSOCIATED SOURCE CODE FILE INSTEAD
 // Note: You can however freely move this file inside your godot project if you want. Keep in mind however, that if you rename the originating source code file, this file will be deleted and regenerated as a new file instead of being updated! Other modifications to the source file however, will result in this file being updated.
 
-registeredName = BunnymarkV3
-fqName = godot.benchmark.bunnymark.BunnymarkV3
-relativeSourcePath = src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV3.kt
+registeredName = BunnymarkV1Sprites
+fqName = godot.benchmark.bunnymark.BunnymarkV1Sprites
+relativeSourcePath = src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1Sprites.kt
 baseType = Node2D
 supertypes = [
     godot.Node2D,
@@ -11,6 +11,8 @@ supertypes = [
 	godot.Node,
 	godot.Object,
 	godot.core.KtObject,
+	godot.common.interop.IdentityPointer,
+	godot.common.interop.ValuePointer,
 	kotlin.Any
 ]
 signals = [

--- a/harness/bunnymark/scripts/godot/benchmark/bunnymark/BunnymarkV2.gdj
+++ b/harness/bunnymark/scripts/godot/benchmark/bunnymark/BunnymarkV2.gdj
@@ -11,6 +11,8 @@ supertypes = [
 	godot.Node,
 	godot.Object,
 	godot.core.KtObject,
+	godot.common.interop.IdentityPointer,
+	godot.common.interop.ValuePointer,
 	kotlin.Any
 ]
 signals = [

--- a/harness/bunnymark/scripts/godot/benchmark/bunnymark/BunnymarkV3.gdj
+++ b/harness/bunnymark/scripts/godot/benchmark/bunnymark/BunnymarkV3.gdj
@@ -1,9 +1,9 @@
 // THIS FILE IS GENERATED! DO NOT EDIT OR DELETE IT. EDIT OR DELETE THE ASSOCIATED SOURCE CODE FILE INSTEAD
 // Note: You can however freely move this file inside your godot project if you want. Keep in mind however, that if you rename the originating source code file, this file will be deleted and regenerated as a new file instead of being updated! Other modifications to the source file however, will result in this file being updated.
 
-registeredName = BunnymarkV1Sprites
-fqName = godot.benchmark.bunnymark.BunnymarkV1Sprites
-relativeSourcePath = src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1Sprites.kt
+registeredName = BunnymarkV3
+fqName = godot.benchmark.bunnymark.BunnymarkV3
+relativeSourcePath = src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV3.kt
 baseType = Node2D
 supertypes = [
     godot.Node2D,
@@ -11,6 +11,8 @@ supertypes = [
 	godot.Node,
 	godot.Object,
 	godot.core.KtObject,
+	godot.common.interop.IdentityPointer,
+	godot.common.interop.ValuePointer,
 	kotlin.Any
 ]
 signals = [

--- a/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1DrawTexture.kt
+++ b/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1DrawTexture.kt
@@ -8,13 +8,13 @@ import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 import godot.annotation.RegisterSignal
 import godot.core.Vector2
-import godot.signals.signal
+import godot.core.signal1
 
 @RegisterClass("BunnymarkV1DrawTexture")
 class BunnymarkV1DrawTexture : Node2D() {
 
 	@RegisterSignal
-	val benchmarkFinished by signal<Int>("bunnyCount")
+	val benchmarkFinished by signal1<Int>("bunnyCount")
 
 	data class Bunny(var position: Vector2, var speed: Vector2)
 

--- a/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1Sprites.kt
+++ b/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV1Sprites.kt
@@ -5,13 +5,12 @@ import godot.*
 import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 import godot.annotation.RegisterSignal
-import godot.signals.signal
 
 @RegisterClass("BunnymarkV1Sprites")
 class BunnymarkV1Sprites : Node2D() {
 
 	@RegisterSignal
-	val benchmarkFinished by signal<Int>("bunnyCount")
+	val benchmarkFinished by signal1<Int>("bunnyCount")
 
 	private data class Bunny(var sprite: Sprite2D, var speed: Vector2)
 

--- a/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV2.kt
+++ b/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV2.kt
@@ -5,13 +5,12 @@ import godot.*
 import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 import godot.annotation.RegisterSignal
-import godot.signals.signal
 
 @RegisterClass("BunnymarkV2")
 class BunnymarkV2 : Node2D() {
 
 	@RegisterSignal
-	val benchmarkFinished by signal<Int>("bunnyCount")
+	val benchmarkFinished by signal1<Int>("bunnyCount")
 
 	private val gravity = 500
 	private val bunnySpeeds = mutableListOf<Vector2>()

--- a/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV3.kt
+++ b/harness/bunnymark/src/main/kotlin/godot/benchmark/bunnymark/BunnymarkV3.kt
@@ -6,13 +6,13 @@ import godot.annotation.RegisterFunction
 import godot.annotation.RegisterSignal
 import godot.benchmark.bunnymark.v3.Bunny
 import godot.core.Vector2
-import godot.signals.signal
+import godot.core.signal1
 
 @RegisterClass("BunnymarkV3")
 class BunnymarkV3 : Node2D() {
 
 	@RegisterSignal
-	val benchmarkFinished by signal<Int>("bunnyCount")
+	val benchmarkFinished by signal1<Int>("bunnyCount")
 
 	private val randomNumberGenerator = RandomNumberGenerator()
 	private val bunnyTexture = ResourceLoader.load("res://images/godot_bunny.png") as Texture2D

--- a/kt/api-generator/build.gradle.kts
+++ b/kt/api-generator/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 gradlePlugin {

--- a/kt/build-logic/convention/build.gradle.kts
+++ b/kt/build-logic/convention/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 dependencies {

--- a/kt/common/build.gradle.kts
+++ b/kt/common/build.gradle.kts
@@ -13,7 +13,7 @@ version = fullGodotKotlinJvmVersion
 group = "com.utopia-rise"
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 publishing {

--- a/kt/entry-generation/godot-entry-generator/build.gradle.kts
+++ b/kt/entry-generation/godot-entry-generator/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 dependencies {

--- a/kt/entry-generation/godot-kotlin-symbol-processor/build.gradle.kts
+++ b/kt/entry-generation/godot-kotlin-symbol-processor/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 dependencies {

--- a/kt/godot-coroutine-library/build.gradle.kts
+++ b/kt/godot-coroutine-library/build.gradle.kts
@@ -17,7 +17,7 @@ kotlinDefinitions {
 
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 java {

--- a/kt/godot-library/build.gradle.kts
+++ b/kt/godot-library/build.gradle.kts
@@ -25,12 +25,23 @@ apiGenerator {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 java {
     withSourcesJar()
     withJavadocJar()
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "22"  // Make sure this matches the JVM version
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.compilerArgs.add("--enable-preview")
+    options.release.set(22)  // Match the Java version you are using
 }
 
 dependencies {

--- a/kt/godot-library/src/main/kotlin/godot/core/memory/MemoryManager.kt
+++ b/kt/godot-library/src/main/kotlin/godot/core/memory/MemoryManager.kt
@@ -197,6 +197,11 @@ internal object MemoryManager {
         ObjectDB.remove(ObjectID(id))
     }
 
+    fun getScriptInstance(id: Long) =  lock.read {
+            ObjectDB[ObjectID(id)]!!.instance!!
+    }
+
+
     fun getInstanceOrCreate(ptr: VoidPtr, id: Long, constructorIndex: Int): KtObject {
         val objectID = ObjectID(id)
 

--- a/kt/plugins/godot-gradle-plugin/build.gradle.kts
+++ b/kt/plugins/godot-gradle-plugin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 gradlePlugin {

--- a/kt/plugins/godot-intellij-plugin/build.gradle.kts
+++ b/kt/plugins/godot-intellij-plugin/build.gradle.kts
@@ -36,7 +36,7 @@ group = "com.utopia-rise"
 val intellijVersion: String = project.properties["godot.plugins.intellij.version"]?.toString() ?: libs.versions.ideaPluginDefaultIntellijVersion.get()
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(22)
 }
 
 dependencies {

--- a/kt/plugins/godot-plugins-common/build.gradle.kts
+++ b/kt/plugins/godot-plugins-common/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 repositories {

--- a/kt/tools-common/build.gradle.kts
+++ b/kt/tools-common/build.gradle.kts
@@ -13,7 +13,7 @@ version = fullGodotKotlinJvmVersion
 group = "com.utopia-rise"
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 dependencies {

--- a/kt/utils/godot-build-props/build.gradle.kts
+++ b/kt/utils/godot-build-props/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(22)
 }
 
 tasks {

--- a/src/jvm_wrapper/memory/transfer_context.h
+++ b/src/jvm_wrapper/memory/transfer_context.h
@@ -9,10 +9,11 @@ JVM_SINGLETON_WRAPPER(TransferContext, "godot.core.memory.TransferContext") {
     SINGLETON_CLASS(TransferContext)
 
     JNI_OBJECT_METHOD(GET_BUFFER)
+    JNI_OBJECT_METHOD(ICALL_STUB)
 
     INIT_JNI_BINDINGS(
         INIT_JNI_METHOD(GET_BUFFER, "getBuffer", "()Ljava/nio/ByteBuffer;")
-        INIT_NATIVE_METHOD("icall", "(JJI)V", TransferContext::icall)
+        INIT_JNI_METHOD(ICALL_STUB, "createIcallStub", "(J)V")
     )
 
 public:
@@ -23,7 +24,9 @@ public:
     uint32_t read_args(jni::Env& p_env, Variant* args);
     void write_object_data(jni::Env& p_env, uintptr_t ptr, ObjectID id);
 
-    static void icall(JNIEnv* rawEnv, jobject instance, jlong j_ptr, jlong j_method_ptr, jint expectedReturnType);
+    void create_icall_stub(jni::Env& p_env);
+
+    static void icall(uint64_t j_ptr, uint64_t j_method_ptr);
 
 private:
     SharedBuffer* get_and_rewind_buffer(jni::Env& p_env);

--- a/src/jvm_wrapper/registration/kt_function.h
+++ b/src/jvm_wrapper/registration/kt_function.h
@@ -6,6 +6,8 @@
 #include "kt_property.h"
 #include "kt_rpc_config.h"
 
+using InvokeFunction = void (*)(uint64_t);
+
 JVM_INSTANCE_WRAPPER(KtFunctionInfo, "godot.core.KtFunctionInfo") {
     JVM_CLASS(KtFunctionInfo)
 
@@ -43,12 +45,15 @@ JVM_INSTANCE_WRAPPER(KtFunction, "godot.core.KtFunction") {
     JNI_INT_METHOD(GET_PARAMETER_COUNT)
     JNI_VOID_METHOD(INVOKE)
     JNI_OBJECT_METHOD(INVOKE_WITH_RETURN)
+    JNI_LONG_METHOD(GET_INVOKE_STUB)
+
 
     INIT_JNI_BINDINGS(
         INIT_JNI_METHOD(GET_FUNCTION_INFO, "getFunctionInfo", "()Lgodot/core/KtFunctionInfo;")
         INIT_JNI_METHOD(GET_PARAMETER_COUNT, "getParameterCount", "()I")
         INIT_JNI_METHOD(INVOKE, "invoke", "(Lgodot/core/KtObject;)V")
         INIT_JNI_METHOD(INVOKE_WITH_RETURN, "invokeWithReturn", "(Lgodot/core/KtObject;)Ljava/lang/Object;")
+        INIT_JNI_METHOD(GET_INVOKE_STUB, "getInvokeStub", "()J")
     )
     // clang-format on
 
@@ -56,6 +61,7 @@ private:
     int parameter_count;
     KtFunctionInfo* method_info;
     bool has_return_value;
+    void (*invoke_stub)(uint64_t);
 
 public:
     explicit KtFunction(jni::Env& p_env, jni::JObject p_wrapped);
@@ -68,7 +74,9 @@ public:
     MethodInfo get_member_info();
     KtFunctionInfo* get_kt_function_info();
 
-    void invoke(jni::Env& p_env, const KtObject* instance, const Variant** p_args, int args_count, Variant& r_ret);
+    InvokeFunction get_invoke_stub(jni::Env & p_env);
+
+    void invoke(jni::Env& p_env, const KtObject* kt_object, const uint64_t id, const Variant** p_args, int args_count, Variant& r_ret);
 };
 
 #endif// GODOT_JVM_KT_FUNCTION_H

--- a/src/lifecycle/jvm_manager.cpp
+++ b/src/lifecycle/jvm_manager.cpp
@@ -96,9 +96,7 @@ bool JvmManager::initialize_or_get_jvm(void* lib_handle, JvmUserConfiguration& u
 }
 
 bool JvmManager::initialize_jvm_wrappers(jni::Env& p_env, ClassLoader* class_loader) {
-    jni::Env::set_exception_handler(&bridges::JvmStackTrace::print_exception_stacktrace);
-
-    return  Bootstrap::initialize(p_env, class_loader)
+    bool ret =  Bootstrap::initialize(p_env, class_loader)
             && KtObject::initialize(p_env, class_loader)
             && KtPropertyInfo::initialize(p_env, class_loader)
             && KtProperty::initialize(p_env, class_loader)
@@ -131,6 +129,11 @@ bool JvmManager::initialize_jvm_wrappers(jni::Env& p_env, ClassLoader* class_loa
             && bridges::PackedVector2ArrayBridge::initialize(p_env, class_loader)
             && bridges::PackedVector3ArrayBridge::initialize(p_env, class_loader)
             && bridges::PackedVector4ArrayBridge::initialize(p_env, class_loader);
+
+    TransferContext::get_instance().create_icall_stub(p_env);
+    jni::Env::set_exception_handler(&bridges::JvmStackTrace::print_exception_stacktrace);
+
+    return ret;
 }
 
 void JvmManager::finalize_jvm_wrappers(jni::Env& p_env, ClassLoader* class_loader) {

--- a/src/lifecycle/jvm_options.cpp
+++ b/src/lifecycle/jvm_options.cpp
@@ -25,6 +25,9 @@ void JvmOptions::add_jmx_option(uint16_t p_port) {
     options.push_back("-Dcom.sun.management.jmxremote.local.only=false");
     options.push_back("-Dcom.sun.management.jmxremote.authenticate=false");
     options.push_back("-Dcom.sun.management.jmxremote.ssl=false");
+    options.push_back("--enable-preview");
+    options.push_back("--add-modules jdk.incubator.foreign");
+    options.push_back("--enable-native-access=ALL-UNNAMED");
     JVM_LOG_VERBOSE("Started JMX on port: %s", jvm_jmx_port);
 }
 

--- a/src/script/jvm_instance.cpp
+++ b/src/script/jvm_instance.cpp
@@ -52,7 +52,7 @@ bool JvmInstance::set(const StringName& p_name, const Variant& p_value) {
         const int arg_count = 2;
         Variant name = p_name;
         const Variant* args[arg_count] {&name, &p_value};
-        function->invoke(env, kt_object, args, arg_count, ret);
+        function->invoke(env, kt_object, owner->get_instance_id(), args, arg_count, ret);
         return true;
     }
 
@@ -79,7 +79,7 @@ bool JvmInstance::get(const StringName& p_name, Variant& r_ret) const {
         const int arg_count = 1;
         Variant name = p_name;
         const Variant* args[arg_count] = {&name};
-        function->invoke(env, kt_object, args, arg_count, r_ret);
+        function->invoke(env, kt_object, owner->get_instance_id(), args, arg_count, r_ret);
         return true;
     }
 
@@ -107,7 +107,7 @@ void JvmInstance::get_property_list(List<PropertyInfo>* p_properties) const {
 
     if (KtFunction* function {kt_class->get_method(SNAME("_get_property_list"))}) {
         Variant ret_var;
-        function->invoke(env, kt_object, {}, 0, ret_var);
+        function->invoke(env, kt_object, owner->get_instance_id(), {}, 0, ret_var);
         Array ret_array = ret_var;
         for (int i = 0; i < ret_array.size(); ++i) {
             p_properties->push_back(PropertyInfo::from_dict(ret_array.get(i)));
@@ -137,7 +137,7 @@ Variant JvmInstance::callp(const StringName& p_method, const Variant** p_args, i
     KtFunction* function {kt_class->get_method(p_method)};
     Variant ret_var;
     if (function) {
-        function->invoke(env, kt_object, p_args, p_argcount, ret_var);
+        function->invoke(env, kt_object, owner->get_instance_id(), p_args, p_argcount, ret_var);
     } else {
         r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
     }
@@ -159,7 +159,7 @@ void JvmInstance::validate_property(PropertyInfo& p_property) const {
         Variant property_arg = (Dictionary) p_property;
         const int arg_count {1};
         const Variant* args[arg_count] = {&property_arg};
-        function->invoke(env, kt_object, args, arg_count, ret_var);
+        function->invoke(env, kt_object, owner->get_instance_id(), args, arg_count, ret_var);
         p_property = PropertyInfo::from_dict(property_arg);
     }
 }
@@ -248,7 +248,7 @@ bool JvmInstance::property_can_revert(const StringName& p_name) const {
         Variant ret;
         Variant name = p_name;
         const Variant* args[arg_count] = {&name};
-        function->invoke(env, kt_object, args, arg_count, ret);
+        function->invoke(env, kt_object, owner->get_instance_id(), args, arg_count, ret);
         return ret.operator bool();
     }
 
@@ -262,7 +262,7 @@ bool JvmInstance::property_get_revert(const StringName& p_name, Variant& r_ret) 
         const int arg_count = 1;
         Variant name = p_name;
         const Variant* args[arg_count] = {&name};
-        function->invoke(env, kt_object, args, arg_count, r_ret);
+        function->invoke(env, kt_object, owner->get_instance_id(), args, arg_count, r_ret);
         return true;
     }
 


### PR DESCRIPTION
Not meant to be merged.
This is purely to make my tests using the new JDK foreign API more visible.

I didn't convert the whole codebase to the new API. I simply replace our two most important calls in the module
The `KtFunction::invoke` used when Godot calls scripts methods like `process` or `enter_tree` and the `TransferContext::icall` used for any call to the Godot API.

Regarding the results I don't have good new:
I ran our worst and best bunnymark on both master and this branch using the official Hotspot 22 build.

- C++ to JVM Bunnymark: 29k --> 22k.  We actually lose performances.
- JVM to C++ Bunnymark: 65k for both. The performances are unchanged.

Part of the loss in the slow bunny mark might be caused by the fact that so far I haven't found a way for the Foreign API to use JVM instances as parameters. It means that unlike with JNI, I have to retrieve the JVM wrapper/scripts by fetching the MemoryManager which involve hashmap reading and locks.

Another thing I noted. Even when running the master branch, the results are quite different from what was previously measured and recorded here : https://github.com/utopia-rise/godot-kotlin-jvm/tree/master/harness/bunnymark.
Those previous results were made 1 year ago, but I ran the bunnymark quite a lot this summer when working on the memory rework and the results remained mostly the same.

The only difference this time is that I used Hotspot 22 instead of Azul 17. I need more investigation, but it seems that hotspot is quite better for calls from C++ to JVM but worse for calls from the JVM to C++ (We gain 10K for our worse benchmark but lose 20K for our best).  Maybe going from Godot 4.2 to 4.3 also had an effect, it's hard to tell.

But overall, as it is right now, the Foreign API is not worth it. And unlike what it says, it doesn't bring any extra security. The difference is mostly that the "binding code" is written in Java instead of C++ and that we use an API to defined function signatures instead of strings. But it's still as easy as before to have a mismatch between the C++ and JVM signatures. 

This API seems to be really designed around using jextract on a C header and then use it alongside a dynamic library. But in the context of our project being C++ driven, I have yet to see the benefits, even from a maintainability point of view.
This API is still in preview and will evolve in future JDK version, so it might get better. On top of that, finding examples and tutorial is hard so far. I had to rely on minimal examples on the Oracle website and then just the raw API documentation, so I'm not sure if I'm using it correctly.

