### PR TITLE
Force early initialization for scripts classes

### DIFF
--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/runtime/Bootstrap.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/runtime/Bootstrap.kt
@@ -101,9 +101,13 @@ internal class Bootstrap {
         forceJvmInitializationOfSingletons()
         // END: order matters!
 
-        // Ugly but it will have to wait for when you rework Registration and Bootstrap
-        // Has to run after all classes are initialized in case a static block needs a Godot type
-        if(mainContext != null) {
+        fun forceJvmInitializationOfScripts() {
+            // Ugly but it will have to wait for when you rework Registration and Bootstrap
+            // Has to run after all classes are initialized in case a static block needs a Godot type
+            if (mainContext == null) {
+                return
+            }
+
             with(mainEntry) {
                 mainContext.getRegisteredClasses().forEach { clazz ->
                     // Force init of the class so any static block runs.
@@ -111,6 +115,8 @@ internal class Bootstrap {
                 }
             }
         }
+
+        forceJvmInitializationOfScripts()
     }
 
     private fun clearClassesCache() {


### PR DESCRIPTION
We had several reports of people having weird behavior with their scripts.
The cause was the existence of a companion object storing or using a reference to a Godot object.
A bit tricky to explain but basically the very first time an instance of a script was used, the class itself was initialized and so its static blocks. 
When an instance is created from Godot directly (via a scene for example), the native object already existe and we pass its pointer directly to the new script instance. This static class init had the side effect to pass this pointer to the Godot object created in the companion object instead of the script. 
The end result was an static object with the wrong pointer set and the script create a completely separate native object...

To fix this, I ensure that all those static blocks are initialized before we create any instance of a script.
The true root cause of the issue is that existence of that shared buffer that store the pointer of a native object (because we can't pass it to the constructor directly), but I never found a way to get rid of it so we can at best "by pass" the issue.