### PR TITLE
Check module and jar have the same version

### DIFF
--- a/kt/godot-library/godot-core-library/build.gradle.kts
+++ b/kt/godot-library/godot-core-library/build.gradle.kts
@@ -27,6 +27,8 @@ java {
 dependencies {
     api("com.utopia-rise:common:$fullGodotKotlinJvmVersion")
     implementation(project(":godot-internal-library"))
+    implementation(project(":godot-build-props"))
+
     testImplementation("junit", "junit", "4.12")
     testImplementation("com.utopia-rise:common:$fullGodotKotlinJvmVersion")
 }

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/runtime/Bootstrap.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/runtime/Bootstrap.kt
@@ -1,12 +1,13 @@
 package godot.runtime
 
 import godot.core.KtClass
-import godot.internal.reflection.TypeManager
 import godot.core.VariantParser
 import godot.core.variantMapper
 import godot.internal.logging.JVMLogging
+import godot.internal.reflection.TypeManager
 import godot.registration.ClassRegistry
 import godot.registration.Entry
+import godot.utils.GodotBuildProperties
 import java.io.File
 import java.net.URL
 import java.net.URLClassLoader
@@ -31,7 +32,10 @@ internal class Bootstrap {
     }
 
     fun getVersion(): String{
-        return "0.12.0-4.4"
+        // we cannot use the assembled version here as it includes the git hash on local dev builds which is not present
+        // on the cpp side
+        // hence we assemble it manually here
+        return "${GodotBuildProperties.godotKotlinJvmVersion}-${GodotBuildProperties.godotVersion}"
     }
 
     fun finish() {

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/runtime/Bootstrap.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/runtime/Bootstrap.kt
@@ -30,6 +30,10 @@ internal class Bootstrap {
         }
     }
 
+    fun getVersion(): String{
+        return "0.12.0-4.4"
+    }
+
     fun finish() {
         Thread.currentThread().contextClassLoader = null
         clearClassesCache()

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -11,6 +11,10 @@
 #include <core/io/resource_loader.h>
 #include <main/main.h>
 
+#define DISPLAY_ERROR(cause, hint)                  \
+    display_initialization_error_hint(cause, hint); \
+    JVM_ERR_FAIL_V_MSG(false, cause)
+
 GDKotlin& GDKotlin::get_instance() {
     static GDKotlin instance;
     return instance;
@@ -38,14 +42,19 @@ bool GDKotlin::load_dynamic_lib() {
                 path_to_jvm_lib = environment_jvm;
             } else {
 #ifdef MACOS_ENABLED
-                JVM_ERR_FAIL_V_MSG(
-                  false,
-                  "The environment variable JAVA_HOME is not found and there is no embedded JRE. If you "
-                  "launched the editor through a double click on Godot.app, also make sure that JAVA_HOME "
-                  "is set through launchctl: `launchctl setenv JAVA_HOME </path/to/jdk>`"
+                DISPLAY_ERROR(
+                  "The environment variable JAVA_HOME is not found and there is no embedded JRE.",
+                  "Make sure the JAVA_HOME environment variable is set or add an embedded JRE to your project using "
+                  "jlink.\n"
+                  "If you launched the editor through a double click on Godot.app, also make sure that JAVA_HOME is "
+                  "set through launchctl: `launchctl setenv JAVA_HOME </path/to/jdk>`"
                 );
 #else
-                JVM_ERR_FAIL_V_MSG(false, "The environment variable JAVA_HOME is not found and there is no embedded JRE.");
+                DISPLAY_ERROR(
+                  "The environment variable JAVA_HOME is not found and there is no embedded JRE.",
+                  "Make sure the JAVA_HOME environment variable is set or add an embedded JRE to your project using "
+                  "jlink."
+                );
 #endif
             }
 #else
@@ -59,12 +68,7 @@ bool GDKotlin::load_dynamic_lib() {
             if (String native_jvm = get_path_to_native_image(); FileAccess::exists(native_jvm)) {
                 path_to_jvm_lib = native_jvm;
             } else {
-                JVM_ERR_FAIL_V_MSG(
-                  false,
-                  "Cannot find Graal VM user code native image! /n This usually happens when you "
-                  "define that your project should be executed using graalvm but did not "
-                  "successfully compile your project and thus usercode.(sh, dll, dylib) cannot be found."
-                );
+                DISPLAY_ERROR("Couldn't open Graal Native Image.", "Make sure you have built your JVM project with Graal native image enabled in your gradle build.");
             }
             break;
         default:
@@ -73,7 +77,10 @@ bool GDKotlin::load_dynamic_lib() {
     }
 
     if (OS::get_singleton()->open_dynamic_library(path_to_jvm_lib, jvm_dynamic_library_handle) != OK) {
-        JVM_ERR_FAIL_V_MSG(false, vformat("Failed to load the jvm dynamic library from path %s!", path_to_jvm_lib));
+        DISPLAY_ERROR(
+          "Failed to load the jvm dynamic library from path " + path_to_jvm_lib,
+          "Make sure you have built your JVM project with Graal native image enabled in your gradle build."
+        );
     }
     return true;
 }
@@ -222,31 +229,33 @@ String GDKotlin::copy_new_file_to_user_dir(const String& file_name) {
 
 bool GDKotlin::load_bootstrap() {
     jni::Env env {jni::Jvm::current_env()};
-    if (user_configuration.vm_type != jni::JvmType::GRAAL_NATIVE_IMAGE) {   //Bootstrap already part of the image
+    if (user_configuration.vm_type != jni::JvmType::GRAAL_NATIVE_IMAGE) { // Bootstrap already part of the image
 #ifdef TOOLS_ENABLED
         String bootstrap_jar {OS::get_singleton()->get_executable_path().get_base_dir().path_join(EDITOR_BOOTSTRAP_PATH)};
-        constexpr const char* error_text {"No godot-bootstrap.jar found! This file needs to stay alongside the godot "
-                                          "editor executable!"};
+        constexpr const char* hint_text {" This file needs to stay alongside the godot editor executable!"};
 #else
         String bootstrap_jar {ProjectSettings::get_singleton()->globalize_path(copy_new_file_to_user_dir(BOOTSTRAP_FILE))};
-        constexpr const char* error_text {"No godot-bootstrap.jar found!"};
+        constexpr const char* hint_text {"The export of the project might be invalid."};
 #endif
 
-        JVM_ERR_FAIL_COND_V_MSG(!FileAccess::exists(bootstrap_jar), false, error_text);
-        JVM_LOG_VERBOSE("Loading bootstrap jar: %s", bootstrap_jar);
+        if (!FileAccess::exists(bootstrap_jar)) { DISPLAY_ERROR("No godot-bootstrap.jar found!", hint_text); }
 
+        JVM_LOG_VERBOSE("Loading bootstrap jar: %s", bootstrap_jar);
         bootstrap_class_loader = ClassLoader::create_instance(env, bootstrap_jar, jni::JObject(nullptr));
         bootstrap_class_loader->set_as_context_loader(env);
     }
 
-    if(Bootstrap::initialize(env, bootstrap_class_loader)){
+    if (Bootstrap::initialize(env, bootstrap_class_loader)) {
         bootstrap = Bootstrap::create_instance(env, bootstrap_class_loader);
         String version = bootstrap->get_version(env);
-        if(version != String(GODOT_KOTLIN_VERSION)) {
-            JVM_ERR_FAIL_V_MSG(false, "Version mismatch! C++ module is : %s / Jar is : %s", GODOT_KOTLIN_VERSION, version);
+        if (version != String(GODOT_KOTLIN_VERSION)) {
+            DISPLAY_ERROR(
+              vformat("Version mismatch! C++ module is : %s / Jar is : %s.", GODOT_KOTLIN_VERSION, version),
+              "Check if your build.gradle file use the same version as the editor."
+            );
         }
     } else {
-        JVM_ERR_FAIL_V_MSG(false, "The bootstrap jar is not compatible with the build of Godot, check that the versions matche.");
+        DISPLAY_ERROR("The boostrap.jar is invalid and can't be loaded.", "Check if your build.gradle file use the same version as the editor.");
     }
 
     return true;
@@ -256,7 +265,12 @@ bool GDKotlin::initialize_core_library() {
     callable_middleman = memnew(Object);
     jni::Env env {jni::Jvm::current_env()};
 
-    if (!JvmManager::initialize_jvm_wrappers(env, bootstrap_class_loader)) { return false; }
+    if (!JvmManager::initialize_jvm_wrappers(env, bootstrap_class_loader)) {
+        DISPLAY_ERROR(
+          "The boostrap.jar is invalid and can't be loaded.",
+          "Check if your build.gradle file use the same version as the editor."
+          );
+    }
 
     if (user_configuration.max_string_size != -1) {
         LongStringQueue::get_instance().set_string_max_size(env, user_configuration.max_string_size);
@@ -398,71 +412,18 @@ Object* GDKotlin::get_callable_middleman() const {
     return callable_middleman;
 }
 
-#ifdef DEBUG_ENABLED
-void GDKotlin::validate_state() {
-    bool invalid {false};
-
+void GDKotlin::display_initialization_error_hint(String cause, String hint) {
     String warning {"Godot Kotlin/JVM module couldn't be fully initialized.\n"
                     "Java and Kotlin scripts will still appear in the editor but won't be functional.\n"
                     "The cause was:\n"};
-    String cause {"No cause identified."};
     String pre_hint {"\nOne possible solution is:\n"};
-    String hint {"No solution suggested."};
-
-    if (state == State::NOT_STARTED) {
-        invalid = true;
-#ifdef DYNAMIC_JVM
-#ifdef MACOS_ENABLED
-        if (user_configuration.vm_type == jni::JVM) {
-            cause = "Couldn't open JVM dynamic library.";
-            hint = "The environment variable JAVA_HOME is not found and there is no embedded JRE. If you "
-                   "launched the editor through a double click on Godot.app, also make sure that JAVA_HOME "
-                   "is set through launchctl: `launchctl setenv JAVA_HOME </path/to/jdk>`";
-        }
-#else
-        if (user_configuration.vm_type == jni::JVM) {
-            cause = "Couldn't open JVM dynamic library.";
-            hint =
-              "Make sure the JAVA_HOME environment variable is set or add an embedded JRE to your project using jlink.";
-        }
-#endif
-        else if (user_configuration.vm_type == jni::GRAAL_NATIVE_IMAGE) {
-            cause = "Couldn't open Graal Native Image.";
-            hint = "Make sure you have built your JVM project with Graal native image enabled in your gradle build.";
-        }
-#endif
-    }
-
-    if (state == State::JVM_LIBRARY_LOADED) {
-        invalid = true;
-        cause = "Couldn't start the JVM.";
-        hint = "Check your configuration file and command-line arguments for any invalid setting, including your "
-               "custom jvm arguments.";
-    }
-
-    if (state == State::JVM_STARTED) {
-        invalid = true;
-#ifdef DYNAMIC_JVM
-        if (user_configuration.vm_type == jni::JVM) {
-            cause = "Couldn't find the bootstrap.jar.";
-            hint = "Don't forget to set a up-to-date boostrap.jar next to the editor executable.";
-        }
-#endif
-    }
-
-    if (state == State::BOOTSTRAP_LOADED) {
-        invalid = true;
-        cause = "The Godot Kotlin core library couldn't be initialized.";
-        hint = "The Godot Kotlin version you use in your JVM project might not match the Godot executable.";
-    }
-
-    // Don't invalidate the state because everything is either loaded or the Kotlin project has simply not be built.
-    if (state == State::CORE_LIBRARY_INITIALIZED || state == State::JVM_SCRIPTS_INITIALIZED) { return; }
-
-    if (invalid) {
-        finalize_down_to(NOT_STARTED);
-        OS::get_singleton()->alert(warning + cause + pre_hint + hint, "Kotlin/JVM module initialization error");
-    }
+    OS::get_singleton()->alert(warning + cause + pre_hint + hint, "Kotlin/JVM module initialization error");
 }
 
-#endif
+void GDKotlin::validate_state() {
+        // Don't invalidate the state because everything is either loaded or the Kotlin project has simply not be built.
+    if (state == State::CORE_LIBRARY_INITIALIZED || state == State::JVM_SCRIPTS_INITIALIZED) { return; }
+
+    finalize_down_to(NOT_STARTED);
+    JVM_LOG_WARNING("JVM Module not properly started, you won't be able to use Java or Kotlin scripts.");
+}

--- a/src/gd_kotlin.h
+++ b/src/gd_kotlin.h
@@ -29,13 +29,13 @@ public:
 private:
     State state {State::NOT_STARTED};
 
-    JvmUserConfiguration user_configuration {};
-    JvmOptions jvm_options {};
+    JvmUserConfiguration user_configuration;
+    JvmOptions jvm_options;
 
     ClassLoader* bootstrap_class_loader {nullptr};
     Bootstrap* bootstrap {nullptr};
     Ref<JavaArchive> jar; // We keep a Reference to the jar in memory because the Godot editor require a resource to be in cache to reload.
-    Object* callable_middleman; //TODO: delete when https://github.com/godotengine/godot/issues/95231 is resolved
+    Object* callable_middleman {nullptr}; //TODO: delete when https://github.com/godotengine/godot/issues/95231 is resolved
 
     void fetch_user_configuration();
     void set_jvm_options();
@@ -75,6 +75,8 @@ public:
 
     void initialize_up_to(State target_state);
     void finalize_down_to(State target_state);
+    void display_initialization_error_hint(String cause, String hint);
+    void validate_state();
 
 #ifdef TOOLS_ENABLED
     void reload_user_code();
@@ -83,9 +85,6 @@ public:
     //TODO: delete when https://github.com/godotengine/godot/issues/95231 is resolved
     Object* get_callable_middleman() const;
 
-#ifdef DEBUG_ENABLED
-    void validate_state();
-#endif
 };
 
 #endif// GODOT_JVM_GD_KOTLIN_H

--- a/src/jvm_wrapper/bootstrap.cpp
+++ b/src/jvm_wrapper/bootstrap.cpp
@@ -53,6 +53,13 @@ void Bootstrap::init(jni::Env& p_env, const String& p_project_path, const String
     wrapped.call_void_method(p_env, INIT, args);
 }
 
+String Bootstrap::get_version(jni::Env& p_env) {
+    jni::JString str {wrapped.call_object_method(p_env, GET_VERSION)};
+    String ret {p_env.from_jstring(str)};
+    str.delete_local_ref(p_env);
+    return ret;
+}
+
 void Bootstrap::finish(jni::Env& p_env) {
     wrapped.call_void_method(p_env, FINISH);
 }

--- a/src/jvm_wrapper/bootstrap.h
+++ b/src/jvm_wrapper/bootstrap.h
@@ -13,7 +13,7 @@ JVM_INSTANCE_WRAPPER(Bootstrap, "godot.runtime.Bootstrap") {
 
     INIT_JNI_BINDINGS(
         INIT_JNI_METHOD(INIT, "init", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;)V")
-        INIT_JNI_METHOD(GET_VERSION, "getVersion", "()Ljava/lang/String;[Ljava/lang/String;")
+        INIT_JNI_METHOD(GET_VERSION, "getVersion", "()Ljava/lang/String;")
         INIT_JNI_METHOD(FINISH, "finish", "()V")
         INIT_NATIVE_METHOD("loadClasses", "([Lgodot/core/KtClass;)V", Bootstrap::load_classes)
         INIT_NATIVE_METHOD("registerManagedEngineTypes", "([Ljava/lang/String;[Ljava/lang/String;)V", Bootstrap::register_engine_type)

--- a/src/jvm_wrapper/bootstrap.h
+++ b/src/jvm_wrapper/bootstrap.h
@@ -9,9 +9,11 @@ JVM_INSTANCE_WRAPPER(Bootstrap, "godot.runtime.Bootstrap") {
     // clang-format off
     JNI_VOID_METHOD(INIT)
     JNI_VOID_METHOD(FINISH)
+    JNI_OBJECT_METHOD(GET_VERSION)
 
     INIT_JNI_BINDINGS(
         INIT_JNI_METHOD(INIT, "init", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/ClassLoader;)V")
+        INIT_JNI_METHOD(GET_VERSION, "getVersion", "()Ljava/lang/String;[Ljava/lang/String;")
         INIT_JNI_METHOD(FINISH, "finish", "()V")
         INIT_NATIVE_METHOD("loadClasses", "([Lgodot/core/KtClass;)V", Bootstrap::load_classes)
         INIT_NATIVE_METHOD("registerManagedEngineTypes", "([Ljava/lang/String;[Ljava/lang/String;)V", Bootstrap::register_engine_type)
@@ -30,6 +32,7 @@ public:
     ~Bootstrap() = default;
 
     void init(jni::Env& p_env, const String& p_project_path, const String& p_jar_file, const jni::JObject& p_class_loader);
+    String get_version(jni::Env& p_env);
     void finish(jni::Env& p_env);
 };
 

--- a/src/lifecycle/jvm_manager.cpp
+++ b/src/lifecycle/jvm_manager.cpp
@@ -96,8 +96,7 @@ bool JvmManager::initialize_or_get_jvm(void* lib_handle, JvmUserConfiguration& u
 
 bool JvmManager::initialize_jvm_wrappers(jni::Env& p_env, ClassLoader* class_loader) {
 
-    bool ret =  Bootstrap::initialize(p_env, class_loader)
-            && KtObject::initialize(p_env, class_loader)
+    bool ret = KtObject::initialize(p_env, class_loader)
             && KtPropertyInfo::initialize(p_env, class_loader)
             && KtProperty::initialize(p_env, class_loader)
             && KtConstructor::initialize(p_env, class_loader)
@@ -158,7 +157,6 @@ void JvmManager::finalize_jvm_wrappers(jni::Env& p_env, ClassLoader* class_loade
     bridges::PackedVector2ArrayBridge::finalize(p_env, class_loader);
     bridges::PackedVector3ArrayBridge::finalize(p_env, class_loader);
     bridges::PackedVector4ArrayBridge::finalize(p_env, class_loader);
-    Bootstrap::finalize(p_env, class_loader);
     KtObject::finalize(p_env, class_loader);
     KtPropertyInfo::finalize(p_env, class_loader);
     KtProperty::finalize(p_env, class_loader);


### PR DESCRIPTION
Resolve #757
The module will now refuse to fully boot and print an error if there is a mismatch between the version of the module and the version of the bootstrap.
Took the opportunity to change where bootstrap is loaded so it happens before any other risk of JNI signature mismatch due to difference in version.