### PR TITLE
Add documentation on known issue with microsofts jdk on windows

### DIFF
--- a/docs/src/doc/contribution/setup.md
+++ b/docs/src/doc/contribution/setup.md
@@ -10,7 +10,7 @@ Make sure that Java is installed and its `PATH` set in your system as well (**at
     echo $JAVA_HOME
     ```
     If the command outputs a directory path, then Java is installed on your system. Otherwise, we strongly suggest you
-    to install the JDK using [SDKMAN!](https://sdkman.io/)
+    to install the JDK using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/), [chocolatey](https://chocolatey.org/), [SDKMAN!](https://sdkman.io/), or another package manager for windows.
 
 !!! warning
     The microsoft jdk is known for causing issues on windows while building code for our IDE plugin. The issue is the same as described in [this issue](https://github.com/microsoft/openjdk/issues/339).    

--- a/docs/src/doc/contribution/setup.md
+++ b/docs/src/doc/contribution/setup.md
@@ -14,6 +14,10 @@ Make sure that Java is installed and its `PATH` set in your system as well (**at
 
 Once you have all the necessary dependencies, proceed to do the following:
 
+!!! warning
+    The microsoft jdk is known for causing issues on windows while building code for our IDE plugin. The issue is the same as described in [this issue](https://github.com/microsoft/openjdk/issues/339).  
+    Either use a different jvm vendor like [Adoptium temurin](https://adoptium.net/temurin/releases/) or create the folder `Packages` manually in the `JAVA_HOME` folder: `'C:\Program Files\Microsoft\jdk-21.0.6.7-hotspot\Packages` in order to build our module.
+
 1. Clone Godot's repository with the stable tag you want to develop for. Notice that the branch tag must be
 aligned to the current binding's version (e.g., current version `0.10.0-4.3.0`, we need Godot at `4.3.0` version).
 

--- a/docs/src/doc/contribution/setup.md
+++ b/docs/src/doc/contribution/setup.md
@@ -10,7 +10,7 @@ Make sure that Java is installed and its `PATH` set in your system as well (**at
     echo $JAVA_HOME
     ```
     If the command outputs a directory path, then Java is installed on your system. Otherwise, we strongly suggest you
-    to install the JDK using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/), [chocolatey](https://chocolatey.org/), [SDKMAN!](https://sdkman.io/), or another package manager for windows.
+    to install the JDK using [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/), [chocolatey](https://chocolatey.org/), [SDKMAN!](https://sdkman.io/), or another package manager on windows, [homebrew](https://brew.sh/) on macos or your distributions package manager on linux.
 
 !!! warning
     The microsoft jdk is known for causing issues on windows while building code for our IDE plugin. The issue is the same as described in [this issue](https://github.com/microsoft/openjdk/issues/339).    

--- a/docs/src/doc/contribution/setup.md
+++ b/docs/src/doc/contribution/setup.md
@@ -12,11 +12,11 @@ Make sure that Java is installed and its `PATH` set in your system as well (**at
     If the command outputs a directory path, then Java is installed on your system. Otherwise, we strongly suggest you
     to install the JDK using [SDKMAN!](https://sdkman.io/)
 
-Once you have all the necessary dependencies, proceed to do the following:
-
 !!! warning
-    The microsoft jdk is known for causing issues on windows while building code for our IDE plugin. The issue is the same as described in [this issue](https://github.com/microsoft/openjdk/issues/339).  
+    The microsoft jdk is known for causing issues on windows while building code for our IDE plugin. The issue is the same as described in [this issue](https://github.com/microsoft/openjdk/issues/339).    
     Either use a different jvm vendor like [Adoptium temurin](https://adoptium.net/temurin/releases/) or create the folder `Packages` manually in the `JAVA_HOME` folder: `'C:\Program Files\Microsoft\jdk-21.0.6.7-hotspot\Packages` in order to build our module.
+
+Once you have all the necessary dependencies, proceed to do the following:
 
 1. Clone Godot's repository with the stable tag you want to develop for. Notice that the branch tag must be
 aligned to the current binding's version (e.g., current version `0.10.0-4.3.0`, we need Godot at `4.3.0` version).

--- a/docs/src/doc/getting-started/requirements.md
+++ b/docs/src/doc/getting-started/requirements.md
@@ -8,9 +8,9 @@
 
 To use this module at least JDK 11 is needed, note you will need the JDK not just the JRE, and the environment variable `JAVA_HOME` to be present before being able to run the custom godot editor.
 
-### Mac & Linux
+### Mac
 
-You can install Java via [SDKMAN!](https://sdkman.io/). Once you installed it, you can run `sdk install java 11.0.11.hs-adpt` to install the LTS version of Java from [AdoptOpenJDK](https://adoptopenjdk.net/). If you want to pick a different version, you can run `sdk list java`.
+You can install Java via [homebrew](https://brew.sh/). Once you installed it, you can run `brew install openjdk@21` to install the LTS version of Java from openjdk. If you want to pick a different version, you can run `brew search jdk`.
 
 !!! warning
     On macOS apps started from the GUI cannot see environment variables from bash or zsh, only command line apps can. Set environment variable using launchctl.
@@ -18,9 +18,13 @@ You can install Java via [SDKMAN!](https://sdkman.io/). Once you installed it, y
     launchctl setenv JAVA_HOME pathtoyourjava
     ```
 
+### Linux
+
+You can install Java via your distributions package manager.
+
 ### Windows
 
-You can install Java via [Chocolatey](https://community.chocolatey.org/). For example, to install [AdoptOpenJDK](https://adoptopenjdk.net/) you can run `choco install adoptopenjdk11`.
+You can install Java via [Chocolatey](https://community.chocolatey.org/). For example, to install [AdoptOpenJDK](https://adoptopenjdk.net/) you can run `choco install adoptopenjdk21`.
 
 ## IDE
 


### PR DESCRIPTION
This adds a bit of warning documentation on the problems encountered while using microsofts jdk builds on windows when trying to build our project

The issue is outlined [here](https://github.com/microsoft/openjdk/issues/339) and also applicable to us.

Even if specifying a jvm vendor manually using jvmToolchain, the task `instrumentCode` from the intellij plugin sdk does not adhere to that constraint.

So there is nothing else we can do on our side to fix this issue.