### PR TITLE
Fix ide plugin deployment and remove obsolete ide plugin specific matrix

### DIFF
--- a/.github/workflows/deploy_jvm.yml
+++ b/.github/workflows/deploy_jvm.yml
@@ -132,34 +132,7 @@ jobs:
         run: |
           modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-gradle-plugin:publish :godot-gradle-plugin:publishPlugins -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET
 
-  deploy_godot_intellij_plugin:
-    strategy:
-      matrix:
-        ij_sdk: [ 2024.2 ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone Godot Engine
-        uses: actions/checkout@v4
-        with:
-          repository: godotengine/godot
-          ref: ${{ inputs.godot-version }}
-
-      - name: Clone Godot JVM module.
-        uses: actions/checkout@v4
-        with:
-          path: modules/kotlin_jvm
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: adopt-hotspot
-          java-version: ${{ inputs.jvm-version }}
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
-
-      - name: Deploy intellij plugin ${{ matrix.ij_sdk }}
+      - name: Deploy intellij plugin
         shell: sh
         run: |
-          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-intellij-plugin:publishPlugin -Pgodot.plugins.intellij.version=${{ matrix.ij_sdk }}
+          modules/kotlin_jvm/kt/gradlew -p modules/kotlin_jvm/kt/ :godot-intellij-plugin:publishPlugin


### PR DESCRIPTION
This fixes the ide plugin deployment.

Historically we had a build matrix for the ide plugin when we were targeting ide versions explicitly.
In #758 i forgot to update that matrix as is did not remember that we did it like this.

This build matrix is obsolete as we only have a single ide plugin version nowadays. Hence i removed it completely and let the gradle setup take care of the used idea sdk like we have for the regular ide verify build check for pull request workflows.

Now the deployment also uses the idea sdk version defined in `libs.versions.toml`