### PR TITLE
Use PagedAllocator for native core types

### DIFF
--- a/src/jvm_wrapper/bridge/callable_bridge.cpp
+++ b/src/jvm_wrapper/bridge/callable_bridge.cpp
@@ -4,18 +4,19 @@
 #include "constraints.h"
 #include "jvm_wrapper/kotlin_callable_custom.h"
 #include "jvm_wrapper/memory/transfer_context.h"
+#include "variant_allocator.h"
 
 using namespace bridges;
 
 uintptr_t CallableBridge::engine_call_constructor(JNIEnv* p_raw_env, jobject p_instance) {
-    return reinterpret_cast<uintptr_t>(memnew(Callable));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(Callable()));
 }
 
 uintptr_t CallableBridge::engine_call_constructor_object_string_name(JNIEnv* p_raw_env, jobject p_instance) {
     jni::Env env {p_raw_env};
     Variant args[2] = {};
     TransferContext::get_instance().read_args(env, args);
-    return reinterpret_cast<uintptr_t>(memnew(Callable(args[0].operator Object*(), args[1].operator StringName())));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(Callable(args[0].operator Object*(), args[1].operator StringName())));
 }
 
 uintptr_t CallableBridge::engine_call_constructor_kt_custom_callable(JNIEnv* p_raw_env, jobject p_instance,
@@ -24,7 +25,7 @@ uintptr_t CallableBridge::engine_call_constructor_kt_custom_callable(JNIEnv* p_r
                                                                      jboolean p_has_on_destroy) {
     jni::Env env {p_raw_env};
     return reinterpret_cast<uintptr_t>(
-        memnew(Callable(memnew(KotlinCallableCustom(env, p_kt_custom_callable_instance, static_cast<Variant::Type>(p_variant_type_ordinal), p_hash_code, p_has_on_destroy))))
+        VariantAllocator::alloc(Callable(memnew(KotlinCallableCustom(env, p_kt_custom_callable_instance, static_cast<Variant::Type>(p_variant_type_ordinal), p_hash_code, p_has_on_destroy))))
     );
 }
 
@@ -32,7 +33,7 @@ uintptr_t CallableBridge::engine_call_copy_constructor(JNIEnv* p_raw_env, jobjec
     jni::Env env {p_raw_env};
     Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-    return reinterpret_cast<uintptr_t>(memnew(Callable(args[0].operator Callable())));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(Callable(args[0].operator Callable())));
 }
 
 void CallableBridge::engine_call_bind(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/src/jvm_wrapper/bridge/dictionary_bridge.cpp
+++ b/src/jvm_wrapper/bridge/dictionary_bridge.cpp
@@ -5,11 +5,12 @@
 #include "jvm_wrapper/memory/transfer_context.h"
 #include "script/jvm_script.h"
 #include "script/jvm_script_manager.h"
+#include "variant_allocator.h"
 
 using namespace bridges;
 
 uintptr_t DictionaryBridge::engine_call_constructor(JNIEnv* p_raw_env, jobject p_instance) {
-    return reinterpret_cast<uintptr_t>(memnew(Dictionary));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(Dictionary()));
 }
 
 uintptr_t DictionaryBridge::engine_call_constructor_typed(JNIEnv* p_raw_env, jobject p_instance) {
@@ -17,7 +18,7 @@ uintptr_t DictionaryBridge::engine_call_constructor_typed(JNIEnv* p_raw_env, job
     Variant args[6] = {};
     TransferContext::get_instance().read_args(env, args);
 
-    auto ret {memnew(Dictionary)};
+    auto ret {VariantAllocator::alloc(Dictionary())};
 
     auto key_variant_type = args[0].operator uint32_t();
     auto key_engine_type_index {args[1].operator int64_t()};

--- a/src/jvm_wrapper/bridge/node_path_bridge.cpp
+++ b/src/jvm_wrapper/bridge/node_path_bridge.cpp
@@ -2,25 +2,26 @@
 
 #include "bridges_utils.h"
 #include "jvm_wrapper/memory/transfer_context.h"
+#include "variant_allocator.h"
 
 using namespace bridges;
 
 uintptr_t NodePathBridge::engine_call_constructor(JNIEnv* p_raw_env, jobject p_instance) {
-    return reinterpret_cast<uintptr_t>(memnew(NodePath));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(NodePath()));
 }
 
 uintptr_t NodePathBridge::engine_call_constructor_string(JNIEnv* p_raw_env, jobject p_instance) {
     jni::Env env {p_raw_env};
     Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-    return reinterpret_cast<uintptr_t>(memnew(NodePath(args[0].operator String())));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(NodePath(args[0].operator String())));
 }
 
 uintptr_t NodePathBridge::engine_call_constructor_node_path(JNIEnv* p_raw_env, jobject p_instance) {
     jni::Env env {p_raw_env};
     Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-    return reinterpret_cast<uintptr_t>(memnew(NodePath(args[0].operator NodePath())));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(NodePath(args[0].operator NodePath())));
 }
 
 void NodePathBridge::engine_call_path(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/src/jvm_wrapper/bridge/packed_array_bridge.h
+++ b/src/jvm_wrapper/bridge/packed_array_bridge.h
@@ -104,7 +104,7 @@ namespace bridges {
 
     template<class Derived, class T, const char* fq_name>
     uintptr_t PackedArrayBridge<Derived, T, fq_name>::engine_call_constructor(JNIEnv* p_raw_env, jobject p_instance) {
-        return reinterpret_cast<uintptr_t>(memnew(Vector<T>));
+        return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(Vector<T>()));
     }
 
     template<class Derived, class T, const char* fq_name>
@@ -113,7 +113,7 @@ namespace bridges {
         jni::Env env {p_raw_env};
         Variant args[1] = {};
         TransferContext::get_instance().read_args(env, args);
-        return reinterpret_cast<uintptr_t>(memnew(Vector<T>(args[0].operator Vector<T>())));
+        return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(Vector<T>(args[0].operator Vector<T>())));
     }
 
     template<class Derived, class T, const char* fq_name>
@@ -123,7 +123,7 @@ namespace bridges {
         TransferContext::get_instance().read_args(env, args);
 
         TypedArray<T> array {args[0].operator Array()};
-        auto* ret {memnew(Vector<T>)};
+        auto* ret {VariantAllocator::alloc(Vector<T>())};
         int size {array.size()};
         ret->resize(size);
         for (int i = 0; i < size; ++i) {

--- a/src/jvm_wrapper/bridge/packed_byte_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/packed_byte_array_bridge.cpp
@@ -380,7 +380,7 @@ uintptr_t PackedByteArrayBridge::engine_convert_to_godot(JNIEnv* p_raw_env, jobj
     vec.resize(size);
     arr.get_array_elements(env, reinterpret_cast<jbyte*>(vec.ptrw()), size);
 
-    return reinterpret_cast<uintptr_t>(memnew(PackedByteArray(vec)));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(PackedByteArray(vec)));
 }
 
 jbyteArray PackedByteArrayBridge::engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/src/jvm_wrapper/bridge/packed_float_32_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/packed_float_32_array_bridge.cpp
@@ -14,7 +14,7 @@ uintptr_t PackedFloat32ArrayBridge::engine_convert_to_godot(JNIEnv* p_raw_env, j
     vec.resize(size);
     arr.get_array_elements(env, reinterpret_cast<jfloat*>(vec.ptrw()), size);
 
-    return reinterpret_cast<uintptr_t>(memnew(PackedFloat32Array(vec)));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(PackedFloat32Array(vec)));
 }
 
 jfloatArray PackedFloat32ArrayBridge::engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/src/jvm_wrapper/bridge/packed_float_64_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/packed_float_64_array_bridge.cpp
@@ -14,7 +14,7 @@ uintptr_t PackedFloat64ArrayBridge::engine_convert_to_godot(JNIEnv* p_raw_env, j
     vec.resize(size);
     arr.get_array_elements(env, reinterpret_cast<jdouble*>(vec.ptrw()), size);
 
-    return reinterpret_cast<uintptr_t>(memnew(PackedFloat64Array(vec)));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(PackedFloat64Array(vec)));
 }
 
 jdoubleArray PackedFloat64ArrayBridge::engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/src/jvm_wrapper/bridge/packed_int_32_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/packed_int_32_array_bridge.cpp
@@ -14,7 +14,7 @@ uintptr_t PackedInt32ArrayBridge::engine_convert_to_godot(JNIEnv* p_raw_env, job
     vec.resize(size);
     arr.get_array_elements(env, reinterpret_cast<jint*>(vec.ptrw()), size);
 
-    return reinterpret_cast<uintptr_t>(memnew(PackedInt32Array(vec)));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(PackedInt32Array(vec)));
 }
 
 jintArray PackedInt32ArrayBridge::engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/src/jvm_wrapper/bridge/packed_int_64_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/packed_int_64_array_bridge.cpp
@@ -15,7 +15,7 @@ uintptr_t PackedInt64ArrayBridge::engine_convert_to_godot(JNIEnv* p_raw_env, job
     vec.resize(size);
     arr.get_array_elements(env, reinterpret_cast<jlong*>(vec.ptrw()), size);
 
-    return reinterpret_cast<uintptr_t>(memnew(PackedInt64Array(vec)));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(PackedInt64Array(vec)));
 }
 
 jlongArray PackedInt64ArrayBridge::engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/src/jvm_wrapper/bridge/string_name_bridge.cpp
+++ b/src/jvm_wrapper/bridge/string_name_bridge.cpp
@@ -6,21 +6,21 @@
 using namespace bridges;
 
 uintptr_t StringNameBridge::engine_call_constructor(JNIEnv* p_raw_env, jobject p_instance) {
-    return reinterpret_cast<uintptr_t>(memnew(StringName));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(StringName()));
 }
 
 uintptr_t StringNameBridge::engine_call_copy_constructor(JNIEnv* p_raw_env, jobject p_instance) {
     jni::Env env {p_raw_env};
     Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-    return reinterpret_cast<uintptr_t>(memnew(StringName(args[0].operator StringName())));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(StringName(args[0].operator StringName())));
 }
 
 uintptr_t StringNameBridge::engine_call_constructor_string(JNIEnv* p_raw_env, jobject p_instance) {
     jni::Env env {p_raw_env};
     Variant args[1] = {};
     TransferContext::get_instance().read_args(env, args);
-    return reinterpret_cast<uintptr_t>(memnew(StringName(args[0].operator String())));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(StringName(args[0].operator String())));
 }
 
 void StringNameBridge::engine_call_operator_string(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {

--- a/src/jvm_wrapper/bridge/variant_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/variant_array_bridge.cpp
@@ -7,7 +7,7 @@
 using namespace bridges;
 
 uintptr_t VariantArrayBridge::engine_call_constructor(JNIEnv* p_raw_env, jobject p_instance) {
-    return reinterpret_cast<uintptr_t>(memnew(Array));
+    return reinterpret_cast<uintptr_t>(VariantAllocator::alloc(Array()));
 }
 
 uintptr_t VariantArrayBridge::engine_call_constructor_typed(JNIEnv* p_raw_env, jobject p_instance) {
@@ -15,7 +15,7 @@ uintptr_t VariantArrayBridge::engine_call_constructor_typed(JNIEnv* p_raw_env, j
     Variant args[3] = {};
     TransferContext::get_instance().read_args(env, args);
 
-    auto ret {memnew(Array)};
+    auto ret {VariantAllocator::alloc(Array())};
 
     auto engineTypeIndex {args[1].operator int64_t()};
     auto userTypeIndex {args[2].operator int64_t()};

--- a/src/jvm_wrapper/memory/memory_manager.cpp
+++ b/src/jvm_wrapper/memory/memory_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "binding/kotlin_binding_manager.h"
 #include "script/jvm_script_manager.h"
+#include "variant_allocator.h"
 
 static LocalVector<uint64_t> ids;
 static LocalVector<uintptr_t> pointers;
@@ -42,49 +43,49 @@ void MemoryManager::unref_native_core_types(JNIEnv* p_raw_env, jobject p_instanc
         Variant::Type variant_type {static_cast<Variant::Type>(var_type)};
         switch (variant_type) {
             case Variant::CALLABLE:
-                memdelete(reinterpret_cast<Callable*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<Callable*>(p_raw_ptr));
                 break;
             case Variant::DICTIONARY:
-                memdelete(reinterpret_cast<Dictionary*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<Dictionary*>(p_raw_ptr));
                 break;
             case Variant::ARRAY:
-                memdelete(reinterpret_cast<Array*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<Array*>(p_raw_ptr));
                 break;
             case Variant::STRING_NAME:
-                memdelete(reinterpret_cast<StringName*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<StringName*>(p_raw_ptr));
                 break;
             case Variant::NODE_PATH:
-                memdelete(reinterpret_cast<NodePath*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<NodePath*>(p_raw_ptr));
                 break;
             case Variant::PACKED_BYTE_ARRAY:
-                memdelete(reinterpret_cast<PackedByteArray*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedByteArray*>(p_raw_ptr));
                 break;
             case Variant::PACKED_INT32_ARRAY:
-                memdelete(reinterpret_cast<PackedInt32Array*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedInt32Array*>(p_raw_ptr));
                 break;
             case Variant::PACKED_INT64_ARRAY:
-                memdelete(reinterpret_cast<PackedInt64Array*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedInt64Array*>(p_raw_ptr));
                 break;
             case Variant::PACKED_FLOAT32_ARRAY:
-                memdelete(reinterpret_cast<PackedFloat32Array*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedFloat32Array*>(p_raw_ptr));
                 break;
             case Variant::PACKED_FLOAT64_ARRAY:
-                memdelete(reinterpret_cast<PackedFloat64Array*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedFloat64Array*>(p_raw_ptr));
                 break;
             case Variant::PACKED_STRING_ARRAY:
-                memdelete(reinterpret_cast<PackedStringArray*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedStringArray*>(p_raw_ptr));
                 break;
             case Variant::PACKED_VECTOR2_ARRAY:
-                memdelete(reinterpret_cast<PackedVector2Array*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedVector2Array*>(p_raw_ptr));
                 break;
             case Variant::PACKED_VECTOR3_ARRAY:
-                memdelete(reinterpret_cast<PackedVector3Array*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedVector3Array*>(p_raw_ptr));
                 break;
             case Variant::PACKED_VECTOR4_ARRAY:
-                memdelete(reinterpret_cast<PackedVector4Array*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedVector4Array*>(p_raw_ptr));
                 break;
             case Variant::PACKED_COLOR_ARRAY:
-                memdelete(reinterpret_cast<PackedColorArray*>(p_raw_ptr));
+                VariantAllocator::free(reinterpret_cast<PackedColorArray*>(p_raw_ptr));
                 break;
             default:
                 break;
@@ -167,8 +168,6 @@ void MemoryManager::try_promotion(JvmInstance* script_instance) {
     script_instance->promote_reference();
     to_demote_mutex.unlock();
 }
-
-
 
 void MemoryManager::direct_object_deletion(jni::Env& p_env, Object* p_obj) {
     jvalue args[1] = {jni::to_jni_arg(p_obj->get_instance_id().operator uint64_t())};

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -7,6 +7,7 @@
 #include "jvm_wrapper/memory/type_manager.h"
 #include "logging.h"
 #include "shared_buffer.h"
+#include "variant_allocator.h"
 
 #include <core/io/marshalls.h>
 #include <core/os/os.h>
@@ -28,7 +29,7 @@ class VariantToBuffer {
     template<class TNativeCoreType>
     inline static void write_pointer(SharedBuffer* des, TNativeCoreType native_core_type) {
         des->increment_position(
-          encode_uint64(reinterpret_cast<uintptr_t>(memnew(TNativeCoreType(native_core_type))), des->get_cursor())
+          encode_uint64(reinterpret_cast<uintptr_t>(VariantAllocator::alloc(TNativeCoreType(native_core_type))), des->get_cursor())
         );
     }
 
@@ -71,7 +72,7 @@ class VariantToBuffer {
         Array arr = src.operator Array();
         uint64_t type = arr.get_typed_builtin();
         set_variant_type(des, Variant::Type::ARRAY);
-        des->increment_position(encode_uint64(reinterpret_cast<uintptr_t>(memnew(Array(arr))), des->get_cursor()));
+        des->increment_position(encode_uint64(reinterpret_cast<uintptr_t>(VariantAllocator::alloc(Array(arr))), des->get_cursor()));
         des->increment_position(encode_uint64(type, des->get_cursor()));
     }
 

--- a/src/variant_allocator.h
+++ b/src/variant_allocator.h
@@ -1,0 +1,67 @@
+#ifndef GODOT_JVM_VARIANT_ALLOCATOR_H
+#define GODOT_JVM_VARIANT_ALLOCATOR_H
+
+#include <core/templates/paged_allocator.h>
+#include <core/variant/variant.h>
+
+class VariantAllocator {
+    union BucketSmall {
+        BucketSmall() {}
+        ~BucketSmall() {}
+
+        StringName string_name;
+        NodePath node_path;
+        Array array;
+        Dictionary dictionary;
+    };
+
+    union BucketLarge {
+        BucketLarge() {}
+        ~BucketLarge() {}
+
+        Callable callable;
+        PackedByteArray byte_array;
+        PackedColorArray color_array;
+        PackedInt32Array int32_array;
+        PackedInt64Array int64_array;
+        PackedFloat32Array float_array;
+        PackedFloat64Array double_array;
+        PackedVector2Array vector2_array;
+        PackedVector3Array vector3_array;
+        PackedVector4Array vector4_array;
+        PackedStringArray string_array;
+    };
+
+    inline static PagedAllocator<BucketSmall, true> bucket_small;
+    inline static PagedAllocator<BucketLarge, true> bucket_large;
+
+public:
+    template<typename T>
+    static T* alloc(T&& variant) {
+        // Trigger compile-time error if T is larger than 16 bytes
+        static_assert(sizeof(T) <= sizeof(BucketLarge), "Variant doesn't fit inside the VariantAllocator");
+
+        T* ret;
+        if constexpr (sizeof(T) <= sizeof(BucketSmall)) {
+            ret = reinterpret_cast<T*>(bucket_small.alloc());
+        } else {
+            ret = reinterpret_cast<T*>(bucket_large.alloc());
+        }
+        memnew_placement(ret, T(variant));
+        return ret;
+    }
+
+    template<typename T>
+    static void free(T* variant) {
+        // Trigger compile-time error if T is larger than 16 bytes
+        static_assert(sizeof(T) <= sizeof(BucketLarge), "Variant doesn't fit inside the VariantAllocator");
+
+        if constexpr (sizeof(T) <= sizeof(BucketSmall)) {
+            bucket_small.free(reinterpret_cast<BucketSmall*>(variant));
+        } else {
+            bucket_large.free(reinterpret_cast<BucketLarge*>(variant));
+        }
+    }
+};
+
+#endif // GODOT_JVM_VARIANT_ALLOCATOR_H

--- a/src/variant_allocator.h
+++ b/src/variant_allocator.h
@@ -32,6 +32,9 @@ class VariantAllocator {
         PackedStringArray string_array;
     };
 
+    static_assert(sizeof(BucketSmall) == 8, "BucketSmall should have a size of 8 bytes");
+    static_assert(sizeof(BucketLarge) == 16, "BucketLarge should have a size of 16 bytes");
+
     inline static PagedAllocator<BucketSmall, true> bucket_small;
     inline static PagedAllocator<BucketLarge, true> bucket_large;
 


### PR DESCRIPTION
We profiled a long time ago that the constant use of memnew in kt_variant.h was a potential bottleneck in situation where a lot of data were exchange between Godot and the JVM. It wasn't high priority, but 2 years past, and we still didn't take the time to adress it.
I created our own little VariantAllocator, taking heavy inspiration of what Godot itself does in its implementation of Variant.
https://github.com/godotengine/godot/blob/2303ce843a362cf5497ca3336451de23793eb711/core/variant/variant.h#L164