### PR TITLE
Add batched conversion to PackedVector arrays

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/packedarray/PackedArrayTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/packedarray/PackedArrayTest.kt
@@ -8,6 +8,8 @@ import godot.core.PackedFloat32Array
 import godot.core.PackedFloat64Array
 import godot.core.PackedInt32Array
 import godot.core.PackedInt64Array
+import godot.core.PackedVector2Array
+import godot.core.Vector2
 
 @RegisterClass
 class PackedArrayTest : Node() {
@@ -43,6 +45,12 @@ class PackedArrayTest : Node() {
     }
 
     @RegisterFunction
+    fun convertVector2Array() : PackedVector2Array {
+        val arr = arrayOf(Vector2(0.0, 1.0), Vector2(2.0, 3.0), Vector2(4.0, 5.0), Vector2(1024.0, 2048.0))
+        return PackedVector2Array(arr);
+    }
+
+    @RegisterFunction
     fun getByteArrayValue(arr: PackedByteArray, index: Int) : Byte {
         val kotlinArr = arr.toByteArray()
         return kotlinArr[index];
@@ -69,6 +77,12 @@ class PackedArrayTest : Node() {
     @RegisterFunction
     fun getDoubleArrayValue(arr: PackedFloat64Array, index: Int) : Double {
         val kotlinArr = arr.toDoubleArray()
+        return kotlinArr[index];
+    }
+
+    @RegisterFunction
+    fun getVector2ArrayValue(arr: PackedVector2Array, index: Int) : Vector2  {
+        val kotlinArr = arr.toVector2Array()
         return kotlinArr[index];
     }
 }

--- a/harness/tests/src/main/kotlin/godot/tests/packedarray/PackedArrayTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/packedarray/PackedArrayTest.kt
@@ -9,80 +9,108 @@ import godot.core.PackedFloat64Array
 import godot.core.PackedInt32Array
 import godot.core.PackedInt64Array
 import godot.core.PackedVector2Array
+import godot.core.PackedVector3Array
+import godot.core.PackedVector4Array
 import godot.core.Vector2
+import godot.core.Vector3
+import godot.core.Vector4
 
 @RegisterClass
 class PackedArrayTest : Node() {
 
     @RegisterFunction
-    fun convertByteArray() : PackedByteArray {
+    fun convertByteArray(): PackedByteArray {
         val arr = byteArrayOf(0, 1, 2, 4, 8, 16, 32, 64, 127)
         return PackedByteArray(arr);
     }
 
     @RegisterFunction
-    fun convertIntArray() : PackedInt32Array {
+    fun convertIntArray(): PackedInt32Array {
         val arr = intArrayOf(0, 1, 2, 4, 8, 16, 32, 64, 127)
         return PackedInt32Array(arr);
     }
 
     @RegisterFunction
-    fun convertLongArray() : PackedInt64Array {
+    fun convertLongArray(): PackedInt64Array {
         val arr = longArrayOf(0L, 1L, 2L, 4L, 8L, 16L, 32L, 64L, 127L)
         return PackedInt64Array(arr);
     }
 
     @RegisterFunction
-    fun convertFloatArray() : PackedFloat32Array {
+    fun convertFloatArray(): PackedFloat32Array {
         val arr = floatArrayOf(0f, 1f, 2f, 4f, 8f, 16f, 32f, 64f, 127f)
         return PackedFloat32Array(arr);
     }
 
     @RegisterFunction
-    fun convertDoubleArray() : PackedFloat64Array {
+    fun convertDoubleArray(): PackedFloat64Array {
         val arr = doubleArrayOf(0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 127.0)
         return PackedFloat64Array(arr);
     }
 
     @RegisterFunction
-    fun convertVector2Array() : PackedVector2Array {
+    fun convertVector2Array(): PackedVector2Array {
         val arr = arrayOf(Vector2(0.0, 1.0), Vector2(2.0, 3.0), Vector2(4.0, 5.0), Vector2(1024.0, 2048.0))
         return PackedVector2Array(arr);
     }
 
     @RegisterFunction
-    fun getByteArrayValue(arr: PackedByteArray, index: Int) : Byte {
+    fun convertVector3Array(): PackedVector3Array {
+        val arr = arrayOf(Vector3(0.0, 1.0, 2.0), Vector3(3.0, 4.0, 5.0), Vector3(6.0, 7.0, 8.0), Vector3(1024.0, 2048.0, 4096.0))
+        return PackedVector3Array(arr);
+    }
+
+    @RegisterFunction
+    fun convertVector4Array(): PackedVector4Array {
+        val arr = arrayOf(Vector4(0.0, 1.0, 2.0, 3.0), Vector4(4.0, 5.0, 6.0, 7.0), Vector4(8.0, 9.0, 10.0, 11.0), Vector4(1024.0, 2048.0, 4096.0, 8092.0))
+        return PackedVector4Array(arr);
+    }
+
+    @RegisterFunction
+    fun getByteArrayValue(arr: PackedByteArray, index: Int): Byte {
         val kotlinArr = arr.toByteArray()
         return kotlinArr[index];
     }
 
     @RegisterFunction
-    fun getIntArrayValue(arr: PackedInt32Array, index: Int) : Int {
+    fun getIntArrayValue(arr: PackedInt32Array, index: Int): Int {
         val kotlinArr = arr.toIntArray()
         return kotlinArr[index];
     }
 
     @RegisterFunction
-    fun getLongArrayValue(arr: PackedInt64Array, index: Int) : Long {
+    fun getLongArrayValue(arr: PackedInt64Array, index: Int): Long {
         val kotlinArr = arr.toLongArray()
         return kotlinArr[index];
     }
 
     @RegisterFunction
-    fun getFloatArrayValue(arr: PackedFloat32Array, index: Int) : Float {
+    fun getFloatArrayValue(arr: PackedFloat32Array, index: Int): Float {
         val kotlinArr = arr.toFloatArray()
         return kotlinArr[index];
     }
 
     @RegisterFunction
-    fun getDoubleArrayValue(arr: PackedFloat64Array, index: Int) : Double {
+    fun getDoubleArrayValue(arr: PackedFloat64Array, index: Int): Double {
         val kotlinArr = arr.toDoubleArray()
         return kotlinArr[index];
     }
 
     @RegisterFunction
-    fun getVector2ArrayValue(arr: PackedVector2Array, index: Int) : Vector2  {
+    fun getVector2ArrayValue(arr: PackedVector2Array, index: Int): Vector2 {
         val kotlinArr = arr.toVector2Array()
+        return kotlinArr[index];
+    }
+
+    @RegisterFunction
+    fun getVector3ArrayValue(arr: PackedVector3Array, index: Int): Vector3 {
+        val kotlinArr = arr.toVector3Array()
+        return kotlinArr[index];
+    }
+
+    @RegisterFunction
+    fun getVector4ArrayValue(arr: PackedVector4Array, index: Int): Vector4 {
+        val kotlinArr = arr.toVector4Array()
         return kotlinArr[index];
     }
 }

--- a/harness/tests/test/unit/test_packed_arrays.gd
+++ b/harness/tests/test/unit/test_packed_arrays.gd
@@ -334,3 +334,35 @@ func test_packed_vector2_array_bulk_conversion() -> void:
 	assert_eq(script.get_vector2_array_value(packed, 3), Vector2(1024.0, 2048.0), "The original Godot PackedArray value should match the values in the Kotlin Vector2")
 
 	script.free()
+
+func test_packed_vector3_array_bulk_conversion() -> void:
+	var script: Object = PackedArrayTest.new()
+	var packed = script.convert_vector3_array()
+
+	assert_eq(packed[0], Vector3(0.0, 1.0, 2.0), "The Godot PackedArray value should match the values in the original Kotlin Vector3")
+	assert_eq(packed[1], Vector3(3.0, 4.0, 5.0), "The Godot PackedArray value should match the values in the original Kotlin Vector3")
+	assert_eq(packed[2], Vector3(6.0, 7.0, 8.0), "The Godot PackedArray value should match the values in the original Kotlin Vector3")
+	assert_eq(packed[3], Vector3(1024.0, 2048.0, 4096.0), "The Godot PackedArray value should match the values in the original Kotlin Vector3")
+
+	assert_eq(script.get_vector3_array_value(packed, 0), Vector3(0.0, 1.0, 2.0), "The original Godot PackedArray value should match the values in the Kotlin Vector3")
+	assert_eq(script.get_vector3_array_value(packed, 1), Vector3(3.0, 4.0, 5.0), "The original Godot PackedArray value should match the values in the Kotlin Vector3")
+	assert_eq(script.get_vector3_array_value(packed, 2), Vector3(6.0, 7.0, 8.0), "The original Godot PackedArray value should match the values in the Kotlin Vector3")
+	assert_eq(script.get_vector3_array_value(packed, 3), Vector3(1024.0, 2048.0, 4096.0), "The original Godot PackedArray value should match the values in the Kotlin Vector3")
+
+	script.free()
+
+func test_packed_vector4_array_bulk_conversion() -> void:
+	var script: Object = PackedArrayTest.new()
+	var packed = script.convert_vector4_array()
+
+	assert_eq(packed[0], Vector4(0.0, 1.0, 2.0, 3.0), "The Godot PackedArray value should match the values in the original Kotlin Vector4")
+	assert_eq(packed[1], Vector4(4.0, 5.0, 6.0, 7.0), "The Godot PackedArray value should match the values in the original Kotlin Vector4")
+	assert_eq(packed[2], Vector4(8.0, 9.0, 10.0, 11.0), "The Godot PackedArray value should match the values in the original Kotlin Vector4")
+	assert_eq(packed[3], Vector4(1024.0, 2048.0, 4096.0, 8092.0), "The Godot PackedArray value should match the values in the original Kotlin Vector4")
+
+	assert_eq(script.get_vector4_array_value(packed, 0), Vector4(0.0, 1.0, 2.0, 3.0), "The original Godot PackedArray value should match the values in the Kotlin Vector4")
+	assert_eq(script.get_vector4_array_value(packed, 1), Vector4(4.0, 5.0, 6.0, 7.0), "The original Godot PackedArray value should match the values in the Kotlin Vector4")
+	assert_eq(script.get_vector4_array_value(packed, 2), Vector4(8.0, 9.0, 10.0, 11.0), "The original Godot PackedArray value should match the values in the Kotlin Vector4")
+	assert_eq(script.get_vector4_array_value(packed, 3), Vector4(1024.0, 2048.0, 4096.0, 8092.0), "The original Godot PackedArray value should match the values in the Kotlin Vector4")
+
+	script.free()

--- a/harness/tests/test/unit/test_packed_arrays.gd
+++ b/harness/tests/test/unit/test_packed_arrays.gd
@@ -318,3 +318,19 @@ func test_packed_double_array_bulk_conversion() -> void:
 	assert_eq(script.get_double_array_value(packed, 8), 127.0, "The original Godot PackedArray value should match the values in the Kotlin DoubleArray")
 
 	script.free()
+
+func test_packed_vector2_array_bulk_conversion() -> void:
+	var script: Object = PackedArrayTest.new()
+	var packed = script.convert_vector2_array()
+
+	assert_eq(packed[0], Vector2(0.0, 1.0), "The Godot PackedArray value should match the values in the original Kotlin Vector2")
+	assert_eq(packed[1], Vector2(2.0, 3.0), "The Godot PackedArray value should match the values in the original Kotlin Vector2")
+	assert_eq(packed[2], Vector2(4.0, 5.0), "The Godot PackedArray value should match the values in the original Kotlin Vector2")
+	assert_eq(packed[3], Vector2(1024.0, 2048.0), "The Godot PackedArray value should match the values in the original Kotlin Vector2")
+
+	assert_eq(script.get_vector2_array_value(packed, 0), Vector2(0.0, 1.0), "The original Godot PackedArray value should match the values in the Kotlin Vector2")
+	assert_eq(script.get_vector2_array_value(packed, 1), Vector2(2.0, 3.0), "The original Godot PackedArray value should match the values in the Kotlin Vector2")
+	assert_eq(script.get_vector2_array_value(packed, 2), Vector2(4.0, 5.0), "The original Godot PackedArray value should match the values in the Kotlin Vector2")
+	assert_eq(script.get_vector2_array_value(packed, 3), Vector2(1024.0, 2048.0), "The original Godot PackedArray value should match the values in the Kotlin Vector2")
+
+	script.free()

--- a/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
+++ b/kt/entry-generation/godot-entry-generator/src/main/kotlin/godot/entrygenerator/ext/TypeExtensions.kt
@@ -30,6 +30,7 @@ import godot.tools.common.constants.VARIANT_PARSER_PACKED_INT_64_ARRAY
 import godot.tools.common.constants.VARIANT_PARSER_PACKED_STRING_ARRAY
 import godot.tools.common.constants.VARIANT_PARSER_PACKED_VECTOR2_ARRAY
 import godot.tools.common.constants.VARIANT_PARSER_PACKED_VECTOR3_ARRAY
+import godot.tools.common.constants.VARIANT_PARSER_PACKED_VECTOR4_ARRAY
 import godot.tools.common.constants.VARIANT_PARSER_STRING
 import godot.tools.common.constants.VARIANT_PARSER_STRING_NAME
 import godot.tools.common.constants.VARIANT_PARSER_TRANSFORM2D
@@ -71,6 +72,7 @@ fun Type?.toKtVariantType(): ClassName = when {
     fqName == "$godotCorePackage.${GodotTypes.packedStringArray}" -> VARIANT_PARSER_PACKED_STRING_ARRAY
     fqName == "$godotCorePackage.${GodotTypes.packedVector2Array}" -> VARIANT_PARSER_PACKED_VECTOR2_ARRAY
     fqName == "$godotCorePackage.${GodotTypes.packedVector3Array}" -> VARIANT_PARSER_PACKED_VECTOR3_ARRAY
+    fqName == "$godotCorePackage.${GodotTypes.packedVector4Array}" -> VARIANT_PARSER_PACKED_VECTOR4_ARRAY
     fqName == "$godotCorePackage.${GodotTypes.packedColorArray}" -> VARIANT_PARSER_PACKED_COLOR_ARRAY
     fqName.startsWith("$godotCorePackage.${GodotTypes.lambdaCallable}") -> VARIANT_PARSER_PACKED_CALLABLE
     isCoreType() -> ClassName(
@@ -201,6 +203,7 @@ fun Type.getAsVariantTypeOrdinal(): Int? = when (fqName) {
     "$godotCorePackage.${GodotTypes.packedVector2Array}" -> 35
     "$godotCorePackage.${GodotTypes.packedVector3Array}" -> 36
     "$godotCorePackage.${GodotTypes.packedColorArray}" -> 37
+    "$godotCorePackage.${GodotTypes.packedVector4Array}" -> 38
     else -> if (this.isCompatibleListType()) {
         28
     } else {

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/packed/PackedVector2Array.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/packed/PackedVector2Array.kt
@@ -42,7 +42,7 @@ class PackedVector2Array : PackedArray<PackedVector2Array, Vector2> {
     }
 
     /**
-     * Constructs a new [PackedVector2Array] from an existing Kotlin [Collection<Vector2>] or Java float[].
+     * Constructs a new [PackedVector2Array] from an existing Kotlin [Collection<Vector2>].
      */
     constructor(from: Array<Vector2>) {
         val floatArray = FloatArray(from.size * 2)
@@ -55,6 +55,11 @@ class PackedVector2Array : PackedArray<PackedVector2Array, Vector2> {
         ptr = Bridge.engine_convert_to_godot(floatArray)
         MemoryManager.registerNativeCoreType(this, VariantParser.PACKED_VECTOR2_ARRAY)
     }
+
+    /**
+     * Constructs a new [PackedVector2Array] from an existing Kotlin [Collection<Vector2>].
+     */
+    constructor(from: Collection<Vector2>) : this(from.toTypedArray<Vector2>())
 
     override fun toString(): String {
         return "PoolVector2Array(${size})"

--- a/kt/tools-common/src/main/kotlin/godot/tools/common/constants/Classes.kt
+++ b/kt/tools-common/src/main/kotlin/godot/tools/common/constants/Classes.kt
@@ -98,6 +98,7 @@ object GodotTypes {
     const val packedStringArray = "PackedStringArray"
     const val packedVector2Array = "PackedVector2Array"
     const val packedVector3Array = "PackedVector3Array"
+    const val packedVector4Array = "PackedVector4Array"
     const val packedColorArray = "PackedColorArray"
     const val quaternion = "Quaternion"
     const val rect2 = "Rect2"
@@ -142,6 +143,7 @@ object GodotTypes {
         packedStringArray,
         packedVector2Array,
         packedVector3Array,
+        packedVector4Array,
         packedColorArray,
         quaternion,
         rect2,
@@ -233,6 +235,7 @@ val VARIANT_PARSER_PACKED_FLOAT_64_ARRAY = ClassName(variantParserPackage, "PACK
 val VARIANT_PARSER_PACKED_STRING_ARRAY = ClassName(variantParserPackage, "PACKED_STRING_ARRAY")
 val VARIANT_PARSER_PACKED_VECTOR2_ARRAY = ClassName(variantParserPackage, "PACKED_VECTOR2_ARRAY")
 val VARIANT_PARSER_PACKED_VECTOR3_ARRAY = ClassName(variantParserPackage, "PACKED_VECTOR3_ARRAY")
+val VARIANT_PARSER_PACKED_VECTOR4_ARRAY = ClassName(variantParserPackage, "PACKED_VECTOR4_ARRAY")
 val VARIANT_PARSER_PACKED_COLOR_ARRAY = ClassName(variantParserPackage, "PACKED_COLOR_ARRAY")
 val VARIANT_PARSER_PACKED_CALLABLE = ClassName(variantParserPackage, "CALLABLE")
 val VARIANT_PARSER_OBJECT = ClassName(variantParserPackage, "OBJECT")

--- a/src/jvm_wrapper/bridge/packed_vector2_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/packed_vector2_array_bridge.cpp
@@ -3,3 +3,32 @@
 using namespace bridges;
 
 PackedVector2ArrayBridge::~PackedVector2ArrayBridge() = default;
+
+uintptr_t PackedVector2ArrayBridge::engine_convert_to_godot(JNIEnv* p_raw_env, jobject p_instance, jfloatArray p_array) {
+    jni::Env env {p_raw_env};
+    jni::JFloatArray arr {p_array};
+
+    jint float_size = arr.length(env);
+    uint64_t vector_size = float_size / 2;
+
+    PackedVector2Array* vector_packed = memnew(PackedVector2Array);
+    vector_packed->resize(vector_size);
+    Vector2* ptr = vector_packed->ptrw();
+    arr.get_array_elements(env, reinterpret_cast<jfloat*>(ptr), float_size);
+
+    return reinterpret_cast<uintptr_t>(vector_packed);
+}
+
+jfloatArray PackedVector2ArrayBridge::engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {
+    jni::Env env {p_raw_env};
+    PackedVector2Array* vector_packed {from_uint_to_ptr<PackedVector2Array>(p_raw_ptr)};
+
+    uint64_t vector_size = vector_packed->size();
+    jint float_size = vector_size * 2;
+
+    jni::JFloatArray arr {env, float_size};
+    const Vector2* ptr = vector_packed->ptr();
+    arr.set_array_elements(env, reinterpret_cast<const jfloat*>(ptr), float_size);
+
+    return reinterpret_cast<jfloatArray>(arr.get_wrapped());
+}

--- a/src/jvm_wrapper/bridge/packed_vector2_array_bridge.h
+++ b/src/jvm_wrapper/bridge/packed_vector2_array_bridge.h
@@ -7,17 +7,18 @@ namespace bridges {
     PACKED_ARRAY_BRIDGE(PackedVector2ArrayBridge, Vector2, "godot.core.PackedVector2Array$Bridge") {
         PACKED_ARRAY_BRIDGE_CLASS(PackedVector2ArrayBridge, Vector2)
 
-    // clang-format off
+        // clang-format off
         INIT_JNI_BINDINGS(
             PackedArrayBridge<PackedVector2ArrayBridge, Vector2, PackedVector2ArrayBridgeQualifiedName>::initialize_jni_binding(p_env, class_loader);
             INIT_NATIVE_METHOD("engine_convert_to_godot", "([F)J", PackedVector2ArrayBridge::engine_convert_to_godot)
             INIT_NATIVE_METHOD("engine_convert_to_jvm", "(J)[F", PackedVector2ArrayBridge::engine_convert_to_jvm)
         )
-    // clang-format on
+        // clang-format on
+
     public:
-        static uintptr_t engine_convert_to_godot(JNIEnv* p_raw_env, jobject p_instance, jfloatArray p_array);
-        static jfloatArray engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr);
+        static uintptr_t engine_convert_to_godot(JNIEnv * p_raw_env, jobject p_instance, jfloatArray p_array);
+        static jfloatArray engine_convert_to_jvm(JNIEnv * p_raw_env, jobject p_instance, jlong p_raw_ptr);
     };
-}// namespace bridge
+} // namespace bridges
 
 #endif

--- a/src/jvm_wrapper/bridge/packed_vector2_array_bridge.h
+++ b/src/jvm_wrapper/bridge/packed_vector2_array_bridge.h
@@ -8,10 +8,15 @@ namespace bridges {
         PACKED_ARRAY_BRIDGE_CLASS(PackedVector2ArrayBridge, Vector2)
 
     // clang-format off
-      INIT_JNI_BINDINGS(
-          PackedArrayBridge<PackedVector2ArrayBridge, Vector2, PackedVector2ArrayBridgeQualifiedName>::initialize_jni_binding(p_env, class_loader);
-      )
+        INIT_JNI_BINDINGS(
+            PackedArrayBridge<PackedVector2ArrayBridge, Vector2, PackedVector2ArrayBridgeQualifiedName>::initialize_jni_binding(p_env, class_loader);
+            INIT_NATIVE_METHOD("engine_convert_to_godot", "([F)J", PackedVector2ArrayBridge::engine_convert_to_godot)
+            INIT_NATIVE_METHOD("engine_convert_to_jvm", "(J)[F", PackedVector2ArrayBridge::engine_convert_to_jvm)
+        )
     // clang-format on
+    public:
+        static uintptr_t engine_convert_to_godot(JNIEnv* p_raw_env, jobject p_instance, jfloatArray p_array);
+        static jfloatArray engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr);
     };
 }// namespace bridge
 

--- a/src/jvm_wrapper/bridge/packed_vector3_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/packed_vector3_array_bridge.cpp
@@ -3,3 +3,32 @@
 using namespace bridges;
 
 PackedVector3ArrayBridge::~PackedVector3ArrayBridge() = default;
+
+uintptr_t PackedVector3ArrayBridge::engine_convert_to_godot(JNIEnv* p_raw_env, jobject p_instance, jfloatArray p_array) {
+    jni::Env env {p_raw_env};
+    jni::JFloatArray arr {p_array};
+    
+    jint float_size = arr.length(env);
+    uint64_t vector_size = float_size / 2;
+
+    PackedVector3Array* vector_packed = memnew(PackedVector3Array);
+    vector_packed->resize(vector_size);
+    Vector3* ptr = vector_packed->ptrw();
+    arr.get_array_elements(env, reinterpret_cast<jfloat*>(ptr), float_size);
+
+    return reinterpret_cast<uintptr_t>(vector_packed);
+}
+
+jfloatArray PackedVector3ArrayBridge::engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {
+    jni::Env env {p_raw_env};
+    PackedVector3Array* vector_packed {from_uint_to_ptr<PackedVector3Array>(p_raw_ptr)};
+
+    uint64_t vector_size = vector_packed->size();
+    jint float_size = vector_size * 2;
+
+    jni::JFloatArray arr {env, float_size};
+    const Vector3* ptr = vector_packed->ptr();
+    arr.set_array_elements(env, reinterpret_cast<const jfloat*>(ptr), float_size);
+
+    return reinterpret_cast<jfloatArray>(arr.get_wrapped());
+}

--- a/src/jvm_wrapper/bridge/packed_vector3_array_bridge.h
+++ b/src/jvm_wrapper/bridge/packed_vector3_array_bridge.h
@@ -8,11 +8,17 @@ namespace bridges {
         PACKED_ARRAY_BRIDGE_CLASS(PackedVector3ArrayBridge, Vector3)
 
         // clang-format off
-      INIT_JNI_BINDINGS(
-          PackedArrayBridge<PackedVector3ArrayBridge, Vector3, PackedVector3ArrayBridgeQualifiedName>::initialize_jni_binding(p_env, class_loader);
-      )
+        INIT_JNI_BINDINGS(
+            PackedArrayBridge<PackedVector3ArrayBridge, Vector3, PackedVector3ArrayBridgeQualifiedName>::initialize_jni_binding(p_env, class_loader);
+            INIT_NATIVE_METHOD("engine_convert_to_godot", "([F)J", PackedVector3ArrayBridge::engine_convert_to_godot)
+            INIT_NATIVE_METHOD("engine_convert_to_jvm", "(J)[F", PackedVector3ArrayBridge::engine_convert_to_jvm)
+        )
         // clang-format on
+
+    public:
+        static uintptr_t engine_convert_to_godot(JNIEnv * p_raw_env, jobject p_instance, jfloatArray p_array);
+        static jfloatArray engine_convert_to_jvm(JNIEnv * p_raw_env, jobject p_instance, jlong p_raw_ptr);
     };
-}// namespace bridge
+} // namespace bridges
 
 #endif

--- a/src/jvm_wrapper/bridge/packed_vector4_array_bridge.cpp
+++ b/src/jvm_wrapper/bridge/packed_vector4_array_bridge.cpp
@@ -3,3 +3,32 @@
 using namespace bridges;
 
 PackedVector4ArrayBridge::~PackedVector4ArrayBridge() = default;
+
+uintptr_t PackedVector4ArrayBridge::engine_convert_to_godot(JNIEnv* p_raw_env, jobject p_instance, jfloatArray p_array) {
+    jni::Env env {p_raw_env};
+    jni::JFloatArray arr {p_array};
+
+    jint float_size = arr.length(env);
+    uint64_t vector_size = float_size / 4;
+
+    PackedVector4Array* vector_packed = memnew(PackedVector4Array);
+    vector_packed->resize(vector_size);
+    Vector4* ptr = vector_packed->ptrw();
+    arr.get_array_elements(env, reinterpret_cast<jfloat*>(ptr), float_size);
+
+    return reinterpret_cast<uintptr_t>(vector_packed);
+}
+
+jfloatArray PackedVector4ArrayBridge::engine_convert_to_jvm(JNIEnv* p_raw_env, jobject p_instance, jlong p_raw_ptr) {
+    jni::Env env {p_raw_env};
+    PackedVector4Array* vector_packed {from_uint_to_ptr<PackedVector4Array>(p_raw_ptr)};
+
+    uint64_t vector_size = vector_packed->size();
+    jint float_size = vector_size * 4;
+
+    jni::JFloatArray arr {env, float_size};
+    const Vector4* ptr = vector_packed->ptr();
+    arr.set_array_elements(env, reinterpret_cast<const jfloat*>(ptr), float_size);
+
+    return reinterpret_cast<jfloatArray>(arr.get_wrapped());
+}

--- a/src/jvm_wrapper/bridge/packed_vector4_array_bridge.h
+++ b/src/jvm_wrapper/bridge/packed_vector4_array_bridge.h
@@ -8,11 +8,17 @@ namespace bridges {
         PACKED_ARRAY_BRIDGE_CLASS(PackedVector4ArrayBridge, Vector4)
 
         // clang-format off
-      INIT_JNI_BINDINGS(
-          PackedArrayBridge<PackedVector4ArrayBridge, Vector4, PackedVector4ArrayBridgeQualifiedName>::initialize_jni_binding(p_env, class_loader);
-      )
+        INIT_JNI_BINDINGS(
+            PackedArrayBridge<PackedVector4ArrayBridge, Vector4, PackedVector4ArrayBridgeQualifiedName>::initialize_jni_binding(p_env, class_loader);
+            INIT_NATIVE_METHOD("engine_convert_to_godot", "([F)J", PackedVector4ArrayBridge::engine_convert_to_godot)
+            INIT_NATIVE_METHOD("engine_convert_to_jvm", "(J)[F", PackedVector4ArrayBridge::engine_convert_to_jvm)
+        )
         // clang-format on
-    };
-}
 
-#endif //GODOT_JVM_PACKED_VECTOR4_ARRAY_BRIDGE_H
+    public:
+        static uintptr_t engine_convert_to_godot(JNIEnv * p_raw_env, jobject p_instance, jfloatArray p_array);
+        static jfloatArray engine_convert_to_jvm(JNIEnv * p_raw_env, jobject p_instance, jlong p_raw_ptr);
+    };
+} // namespace bridges
+
+#endif // GODOT_JVM_PACKED_VECTOR4_ARRAY_BRIDGE_H


### PR DESCRIPTION
Like we did with the byte/int/float versions of PackedArrays, I added another batch conversion for Vector PackedArray.
It's the same pattern as before, except there is an extra conversion step to/from a FloatArray (because obviously the JVM doesn't have any native Vector2 arrays).
For example, we pass a Vector2 has a pair of floats, so an array of Vector2 is converted into an array of floats with double the size.