### PR TITLE
Handle null pointers in get_global_class_name

### DIFF
--- a/src/language/gdj_language.cpp
+++ b/src/language/gdj_language.cpp
@@ -88,8 +88,14 @@ Script* GdjLanguage::create_script() const {
 
 String GdjLanguage::get_global_class_name(const String& p_path, String* r_base_type, String* r_icon_path, bool *r_is_abstract, bool *r_is_tool) const {
     if (p_path.begins_with(ENTRY_DIRECTORY) || !p_path.ends_with(GODOT_JVM_REGISTRATION_FILE_EXTENSION)) { return {}; }
-    *r_is_abstract = false;
-    *r_is_tool = false;
+
+    if(r_is_abstract){
+        *r_is_abstract = false;
+    }
+    if(r_is_tool){
+        *r_is_tool = false;
+    }
+
     String script_name = JvmScript::get_script_file_name(p_path);
     Ref<NamedScript> named_script = JvmScriptManager::get_instance()->get_script_from_name(script_name);
     if (!named_script.is_null() && named_script.is_valid()) {


### PR DESCRIPTION
I didn't expect that those pointers could be null...
There are some cases when Godot does that in the editor, instantly causing a crash. (Like trying to extend a script through the UI)