### PR TITLE
Fix script reloading

### DIFF
--- a/src/language/jvm_language.cpp
+++ b/src/language/jvm_language.cpp
@@ -124,3 +124,8 @@ void JvmLanguage::reload_scripts(const Array& p_scripts, bool p_soft_reload) {}
 void JvmLanguage::reload_all_scripts() {}
 
 void JvmLanguage::reload_tool_script(const Ref<Script>& p_script, bool p_soft_reload) {}
+
+// TODO: Dummy to make reloading work again because of https://github.com/godotengine/godot/issues/104540. Should still be truly implemented at some point
+bool JvmLanguage::supports_documentation() const {
+    return true;
+}

--- a/src/language/jvm_language.h
+++ b/src/language/jvm_language.h
@@ -20,6 +20,7 @@ public:
     String validate_path(const String& p_path) const override;
 
     // Dummy Implementations
+    bool supports_documentation() const override;
     int find_function(const String& p_function, const String& p_code) const override;
     String make_function(const String& p_class, const String& p_name, const PackedStringArray& p_args) const override;
     Error open_in_external_editor(const Ref<Script>& p_script, int p_line, int p_col) override;


### PR DESCRIPTION
Yes, this is what Godot 4.4 actually requires now to be able to reload scripts.
