### PR TITLE
Add missing core Object methods.

### DIFF
--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/KtObject.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/KtObject.kt
@@ -55,6 +55,15 @@ abstract class KtObject : NativeWrapper {
 
     protected abstract fun new(scriptIndex: Int)
 
+    open fun _get(property: StringName): Any = throw NotImplementedError("_get is not implemented for Object")
+    open fun _getPropertyList(): VariantArray<Dictionary<Any, Any>> = throw NotImplementedError("_getPropertyList is not implemented for Object")
+    open fun _propertyCanRevert(name: StringName) : Boolean = throw NotImplementedError("_propertyCanRevert is not implemented for Object")
+    open fun _propertyGetRevert(name: StringName): Any = throw NotImplementedError("_propertyGetRevert is not implemented for Object")
+    open fun _set(name: StringName, value: Any) : Unit = throw NotImplementedError("_set is not implemented for Object")
+    open fun _toString(): String = throw NotImplementedError("_toString is not implemented for Object")
+    open fun _validateProperty(): Boolean = throw NotImplementedError("_validateProperty is not implemented for Object")
+
+
     open fun _notification(): GodotNotification = godotNotification {}
 
     @Suppress("UNCHECKED_CAST")
@@ -78,7 +87,7 @@ abstract class KtObject : NativeWrapper {
 
 
     private fun removeScript(constructorIndex: Int) {
-        createScriptInstance(ptr, objectID,  TypeManager.engineTypesConstructors[constructorIndex])
+        createScriptInstance(ptr, objectID, TypeManager.engineTypesConstructors[constructorIndex])
     }
 
     protected external fun createNativeObject(classIndex: Int, scriptIndex: Int)

--- a/src/script/jvm_instance.cpp
+++ b/src/script/jvm_instance.cpp
@@ -164,7 +164,17 @@ void JvmInstance::validate_property(PropertyInfo& p_property) const {
 }
 
 String JvmInstance::to_string(bool* r_valid) {
-    return ScriptInstance::to_string(r_valid);
+    jni::Env env {jni::Jvm::current_env()};
+
+    if (KtFunction* function {kt_class->get_method(SNAME("_to_string"))}) {
+        const int arg_count = 0;
+        Variant ret;
+        function->invoke(env, kt_object, nullptr, arg_count, ret);
+        *r_valid = true;
+        return ret.operator String();
+    }
+    *r_valid = false;
+    return {};
 }
 
 void JvmInstance::refcount_incremented() {


### PR DESCRIPTION
Solve #744
It was technically possible to make those methods works, but they are special cases (like notification() and are not part of the regular Godot API so they are not generated alongside Object.kt.
I add them as unimplemented methods in KtObject and fixed toString in the Script instance.