### PR TITLE
Add typing to JVM containers from buffer.

### DIFF
--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/Dictionary.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/Dictionary.kt
@@ -29,8 +29,8 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V> {
 
     @PublishedApi
     internal constructor(handle: VoidPtr, keyConverter: VariantConverter, valueConverter: VariantConverter) {
-        keyVariantConverter = keyConverter
-        valueVariantConverter = valueConverter
+        keyVariantConverter = if(keyConverter == VariantParser.NIL) VariantCaster.ANY else keyConverter
+        valueVariantConverter = if(valueConverter == VariantParser.NIL) VariantCaster.ANY else valueConverter
         ptr = handle
         MemoryManager.registerNativeCoreType(this, VariantParser.DICTIONARY)
     }

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/Dictionary.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/Dictionary.kt
@@ -27,12 +27,20 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V> {
         MemoryManager.registerNativeCoreType(this, VariantParser.DICTIONARY)
     }
 
+    @PublishedApi
+    internal constructor(handle: VoidPtr, keyConverter: VariantConverter, valueConverter: VariantConverter) {
+        keyVariantConverter = keyConverter
+        valueVariantConverter = valueConverter
+        ptr = handle
+        MemoryManager.registerNativeCoreType(this, VariantParser.DICTIONARY)
+    }
+
     constructor(keyClass: Class<*>, valueClass: Class<*>) : this(Reflection.getOrCreateKotlinClass(keyClass), Reflection.getOrCreateKotlinClass(valueClass))
 
     @PublishedApi
     internal constructor(keyClass: KClass<*>, valueClass: KClass<*>) {
         val keyVariantConverter = variantMapper[keyClass]
-        val valueVariantConverter  = variantMapper[valueClass]
+        val valueVariantConverter = variantMapper[valueClass]
 
         if (GodotJvmBuildConfig.DEBUG) {
             checkNotNull(keyVariantConverter) {
@@ -43,7 +51,7 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V> {
                 "Can't create a Dictionary with generic key ${valueClass}."
             }
         }
-        
+
         this.keyVariantConverter = keyVariantConverter!!
         this.valueVariantConverter = valueVariantConverter!!
 
@@ -137,10 +145,7 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V> {
 
             override operator fun contains(element: MutableMap.MutableEntry<K, V>): Boolean {
                 val value = get(element.key, null)
-                if (value == element.value) {
-                    return true
-                }
-                return false
+                return value == element.value
             }
 
             override operator fun iterator(): MapIterator<K, V> {
@@ -403,14 +408,14 @@ class Dictionary<K, V> : NativeCoreType, MutableMap<K, V> {
 
     companion object {
         inline operator fun <reified K, reified V> invoke(): Dictionary<K, V> {
-            
+
             // The nullable check can't be inside the regular constructor because of Java
             if (GodotJvmBuildConfig.DEBUG) {
-                if(isNullable<K>() && K::class in notNullableVariantSet){
+                if (isNullable<K>() && K::class in notNullableVariantSet) {
                     error("Can't create a Dictionary with generic key ${K::class} as nullable.")
                 }
 
-                if(isNullable<V>() && V::class in notNullableVariantSet){
+                if (isNullable<V>() && V::class in notNullableVariantSet) {
                     error("Can't create a Dictionary with generic value ${V::class} as nullable.")
                 }
             }

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/VariantArray.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/VariantArray.kt
@@ -647,11 +647,11 @@ class VariantArray<T> : NativeCoreType, MutableCollection<T> {
         external fun engine_call_operator_get(_handle: VoidPtr)
     }
 
-    companion object{
+    companion object {
         inline operator fun <reified T> invoke(): VariantArray<T> {
             // The nullable check can't be inside the regular constructor because of Java
             if (GodotJvmBuildConfig.DEBUG) {
-                if(isNullable<T>() && T::class in notNullableVariantSet){
+                if (isNullable<T>() && T::class in notNullableVariantSet) {
                     error("Can't create a VariantArray with generic ${T::class} as nullable.")
                 }
             }

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/VariantArray.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/bridge/VariantArray.kt
@@ -25,7 +25,7 @@ class VariantArray<T> : NativeCoreType, MutableCollection<T> {
 
     @PublishedApi
     internal constructor(handle: VoidPtr, converter: VariantConverter) {
-        variantConverter = converter
+        variantConverter = if(converter == VariantParser.NIL) VariantCaster.ANY else converter
         ptr = handle
         MemoryManager.registerNativeCoreType(this, VariantParser.ARRAY)
     }

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -76,6 +76,16 @@ class VariantToBuffer {
         des->increment_position(encode_uint64(type, des->get_cursor()));
     }
 
+    static void write_dictionary(SharedBuffer* des, const Variant& src) {
+        Dictionary dict = src.operator Dictionary();
+        uint64_t key_type = dict.get_typed_key_builtin();
+        uint64_t value_type = dict.get_typed_value_builtin();
+        set_variant_type(des, Variant::Type::DICTIONARY);
+        des->increment_position(encode_uint64(reinterpret_cast<uintptr_t>(VariantAllocator::alloc(Dictionary(dict))), des->get_cursor()));
+        des->increment_position(encode_uint64(key_type, des->get_cursor()));
+        des->increment_position(encode_uint64(value_type, des->get_cursor()));
+    }
+
     static void append_object(SharedBuffer* des, Object* ptr) {
         if (ptr == nullptr) {
             des->increment_position(encode_uint32(0, des->get_cursor()));
@@ -144,7 +154,7 @@ public:
             &VariantToBuffer::write_object,
             &VariantToBuffer::write_native_core_type<Variant::CALLABLE, Callable, &Variant::operator Callable>,
             &VariantToBuffer::write_signal,
-            &VariantToBuffer::write_native_core_type<Variant::DICTIONARY, Dictionary,&Variant::operator Dictionary>,
+            &VariantToBuffer::write_dictionary,
             &VariantToBuffer::write_array,
 
             // typed arrays


### PR DESCRIPTION
Partially solve #705
Sadly it doesn't work if the generic type use a VariantCaster like Int.
Any Variant<Int> is seen as having a Variant.LONG by the C++ side (because Variant.INT doesn't exist, everything is 64bits in a variant). It means that if you export a Variant<Int> and set it in the inspector, it won't work because we can only type it to Long and not Int causing a cast exception at runtime.
We will need a more refined solution for everything that is register by the users (method, properties, and callables)