### PR TITLE
Remove editor bootstrap

### DIFF
--- a/.github/workflows/assemble_linux.yml
+++ b/.github/workflows/assemble_linux.yml
@@ -35,12 +35,6 @@ jobs:
           name: editor_${{ matrix.target }}_linux_${{ matrix.arch }}
           path: godot-kotlin-jvm_editor_linuxbsd_${{ matrix.arch }}_${{ matrix.target }}_${{ inputs.godot-kotlin-jvm-version }}
 
-      - name: Download ${{ matrix.target }} bootstrap jar
-        uses: actions/download-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_${{ matrix.target }}
-          path: godot-kotlin-jvm_editor_linuxbsd_${{ matrix.arch }}_${{ matrix.target }}_${{ inputs.godot-kotlin-jvm-version }}
-
       - name: Create linux editor zip
         run: |
           cd godot-kotlin-jvm_editor_linuxbsd_${{ matrix.arch }}_${{ matrix.target }}_${{ inputs.godot-kotlin-jvm-version }}

--- a/.github/workflows/assemble_macos.yml
+++ b/.github/workflows/assemble_macos.yml
@@ -89,20 +89,12 @@ jobs:
           name: editor_${{ matrix.target }}_macos_universal
           path: .
 
-      - name: Download ${{ matrix.target }} bootstrap jar
-        uses: actions/download-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_${{ matrix.target }}
-          path: .
-
       - name: Create MacOs editor app
         run: |
           cp -r misc/dist/macos_tools.app ./Godot.app
           mkdir -p Godot.app/Contents/MacOS
           cp godot.macos.editor.${{ matrix.target }}.universal Godot.app/Contents/MacOS/Godot
           chmod +x Godot.app/Contents/MacOS/Godot
-          cp godot-bootstrap.jar Godot.app/Contents/MacOS/
-          chmod +x Godot.app/Contents/MacOS/godot-bootstrap.jar
           zip -q -9 -r godot-kotlin-jvm_editor_macos_${{ matrix.arch }}_${{ matrix.target }}_${{ inputs.godot-kotlin-jvm-version }}.zip Godot.app
         shell: bash
 

--- a/.github/workflows/assemble_windows.yml
+++ b/.github/workflows/assemble_windows.yml
@@ -36,12 +36,6 @@ jobs:
           name: editor_${{ matrix.target }}_windows_${{ matrix.arch }}
           path: godot-kotlin-jvm_editor_windows_${{ matrix.arch }}_${{ matrix.target }}_${{ inputs.godot-kotlin-jvm-version }}
 
-      - name: Download ${{ matrix.target }} bootstrap jar
-        uses: actions/download-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_${{ matrix.target }}
-          path: godot-kotlin-jvm_editor_windows_${{ matrix.arch }}_${{ matrix.target }}_${{ inputs.godot-kotlin-jvm-version }}
-
       - name: Create windows editor zip
         run: |
           cd godot-kotlin-jvm_editor_windows_${{ matrix.arch }}_${{ matrix.target }}_${{ inputs.godot-kotlin-jvm-version }}

--- a/.github/workflows/build_jvm.yml
+++ b/.github/workflows/build_jvm.yml
@@ -40,7 +40,6 @@ jobs:
           cache-cleanup: always
 
       - name: Compilation
-        # we build the release bootstrap jar here. Debug gets its own trigger later
         run: |
           kt/gradlew -p kt/ build -Prelease buildPlugin
 
@@ -49,12 +48,6 @@ jobs:
         with:
           name: jvm_api-generator
           path: kt/api-generator/build/libs/api-generator.jar
-
-      - name: Upload release bootstrap artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_release
-          path: kt/godot-library/build/libs/godot-bootstrap.jar
 
       - name: Upload entry-generator artifact
         uses: actions/upload-artifact@v4
@@ -91,16 +84,6 @@ jobs:
         with:
           name: jvm_tools-common
           path: kt/tools-common/build/libs/tools-common-*.jar
-
-      - name: Bootstrap debug compilation
-        run: |
-          kt/gradlew -p kt/ build -Pdebug
-
-      - name: Upload debug bootstrap artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_debug
-          path: kt/godot-library/build/libs/godot-bootstrap.jar
 
       - name: Verify ide plugin
         run: |

--- a/.github/workflows/test_linux.yml
+++ b/.github/workflows/test_linux.yml
@@ -22,10 +22,10 @@ jobs:
         include:
           - name: dev tests
             target: dev
-            bootstrap-target: debug
+            jvm-target: debug
           - name: release tests
             target: release
-            bootstrap-target: release
+            jvm-target: release
 
     steps:
       - name: Clone Godot JVM module.
@@ -47,15 +47,9 @@ jobs:
           name: editor_${{ matrix.target }}_linux_x86_64
           path: './harness/tests/bin'
 
-      - name: Download godot-bootstrap ${{ matrix.bootstrap-target }}
-        uses: actions/download-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_${{ matrix.bootstrap-target }}
-          path: './harness/tests/bin'
-
       - name: Build tests project
         run: |
-          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.bootstrap-target }}
+          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.jvm-target }}
 
       - name: Run Tests
         run: |

--- a/.github/workflows/test_linux_exports.yml
+++ b/.github/workflows/test_linux_exports.yml
@@ -22,10 +22,10 @@ jobs:
         include:
           - name: dev tests
             target: dev
-            bootstrap-target: debug
+            jvm-target: debug
           - name: release tests
             target: release
-            bootstrap-target: release
+            jvm-target: release
 
     steps:
       - name: Clone Godot JVM module.
@@ -47,27 +47,21 @@ jobs:
           name: editor_${{ matrix.target }}_linux_x86_64
           path: './harness/tests/bin'
 
-      - name: Download godot-bootstrap ${{ matrix.bootstrap-target }}
+      - name: Download linux x86_64 ${{ matrix.jvm-target }} export template
         uses: actions/download-artifact@v4
         with:
-          name: jvm_godot-bootstrap_${{ matrix.bootstrap-target }}
-          path: './harness/tests/bin'
-
-      - name: Download linux x86_64 ${{ matrix.bootstrap-target }} export template
-        uses: actions/download-artifact@v4
-        with:
-          name: export_template_${{ matrix.bootstrap-target }}_linux_x86_64
+          name: export_template_${{ matrix.jvm-target }}_linux_x86_64
           path: "./"
 
       - name: Prepare export
         run: |
           chmod +x harness/tests/bin/godot.*
           mkdir -p harness/tests/export
-          mv godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }} harness/tests/godot.linuxbsd.template_${{ matrix.bootstrap-target }}.x86_64
+          mv godot.linuxbsd.template_${{ matrix.jvm-target }}.x86_64.jvm.${{ inputs.build-version }} harness/tests/godot.linuxbsd.template_${{ matrix.jvm-target }}.x86_64
 
       - name: Build tests project
         run: |
-          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.bootstrap-target }}
+          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.jvm-target }}
 
       - name: Create JRE
         run: |
@@ -75,14 +69,14 @@ jobs:
           jlink --add-modules java.base,java.logging --output jvm/jre-amd64-linux
 
       - name: Export tests debug
-        if: ${{ matrix.bootstrap-target == 'debug' }}
+        if: ${{ matrix.jvm-target == 'debug' }}
         run: |
           cd harness/tests/
           ./gradlew exportDebug
         timeout-minutes: 30
 
       - name: Export tests release
-        if: ${{ matrix.bootstrap-target == 'release' }}
+        if: ${{ matrix.jvm-target == 'release' }}
         run: |
           cd harness/tests/
           ./gradlew exportRelease

--- a/.github/workflows/test_macos.yml
+++ b/.github/workflows/test_macos.yml
@@ -22,10 +22,10 @@ jobs:
         include:
           - name: dev tests
             target: dev
-            bootstrap-target: debug
+            jvm-target: debug
           - name: release tests
             target: release
-            bootstrap-target: release
+            jvm-target: release
 
     steps:
       - name: Clone Godot JVM module.
@@ -47,15 +47,9 @@ jobs:
           name: editor_${{ matrix.target }}_macos_universal
           path: './harness/tests/bin'
 
-      - name: Download godot-bootstrap ${{ matrix.bootstrap-target }}
-        uses: actions/download-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_${{ matrix.bootstrap-target }}
-          path: './harness/tests/bin'
-
       - name: Build tests project
         run: |
-          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.bootstrap-target }}
+          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.jvm-target }}
 
       - name: Run Tests
         run: |

--- a/.github/workflows/test_macos_exports.yml
+++ b/.github/workflows/test_macos_exports.yml
@@ -22,10 +22,10 @@ jobs:
         include:
           - name: dev tests
             target: dev
-            bootstrap-target: debug
+            jvm-target: debug
           - name: release tests
             target: release
-            bootstrap-target: release
+            jvm-target: release
 
     steps:
       - name: Clone Godot JVM module.
@@ -47,12 +47,6 @@ jobs:
           name: editor_${{ matrix.target }}_macos_universal
           path: './harness/tests/bin'
 
-      - name: Download godot-bootstrap ${{ matrix.bootstrap-target }}
-        uses: actions/download-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_${{ matrix.bootstrap-target }}
-          path: './harness/tests/bin'
-
       - name: Download macos export template
         uses: actions/download-artifact@v4
         with:
@@ -67,7 +61,7 @@ jobs:
 
       - name: Build tests project
         run: |
-          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.bootstrap-target }}
+          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.jvm-target }}
 
       - name: Create JRE
         run: |
@@ -76,14 +70,14 @@ jobs:
           mkdir jvm/jre-amd64-macos #create a fake jre dir for amd64 so the export is happy. The test will run on arm anyways
 
       - name: Export tests debug
-        if: ${{ matrix.bootstrap-target == 'debug' }}
+        if: ${{ matrix.jvm-target == 'debug' }}
         run: |
           cd harness/tests/
           ./gradlew exportDebug
         timeout-minutes: 30
 
       - name: Export tests release
-        if: ${{ matrix.bootstrap-target == 'release' }}
+        if: ${{ matrix.jvm-target == 'release' }}
         run: |
           cd harness/tests/
           ./gradlew exportRelease

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -22,10 +22,10 @@ jobs:
         include:
           - name: dev tests
             target: dev
-            bootstrap-target: debug
+            jvm-target: debug
           - name: release tests
             target: release
-            bootstrap-target: release
+            jvm-target: release
 
     steps:
       - name: Clone Godot JVM module.
@@ -47,15 +47,9 @@ jobs:
           name: editor_${{ matrix.target }}_windows_x86_64
           path: './harness/tests/bin'
 
-      - name: Download godot-bootstrap ${{ matrix.bootstrap-target }}
-        uses: actions/download-artifact@v4
-        with:
-          name: jvm_godot-bootstrap_${{ matrix.bootstrap-target }}
-          path: './harness/tests/bin'
-
       - name: Build tests project
         run: |
-          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.bootstrap-target }}
+          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.jvm-target }}
 
       - name: Run Tests
         run: |

--- a/.github/workflows/test_windows_exports.yml
+++ b/.github/workflows/test_windows_exports.yml
@@ -22,10 +22,10 @@ jobs:
         include:
           - name: dev tests
             target: dev
-            bootstrap-target: debug
+            jvm-target: debug
           - name: release tests
             target: release
-            bootstrap-target: release
+            jvm-target: release
 
     steps:
       - name: Clone Godot JVM module.
@@ -47,26 +47,20 @@ jobs:
           name: editor_${{ matrix.target }}_windows_x86_64
           path: './harness/tests/bin'
 
-      - name: Download godot-bootstrap ${{ matrix.bootstrap-target }}
+      - name: Download windows x86_64 ${{ matrix.jvm-target }} export template
         uses: actions/download-artifact@v4
         with:
-          name: jvm_godot-bootstrap_${{ matrix.bootstrap-target }}
-          path: './harness/tests/bin'
-
-      - name: Download windows x86_64 ${{ matrix.bootstrap-target }} export template
-        uses: actions/download-artifact@v4
-        with:
-          name: export_template_${{ matrix.bootstrap-target }}_windows_x86_64
+          name: export_template_${{ matrix.jvm-target }}_windows_x86_64
           path: "./"
 
       - name: Prepare export
         run: |
           mkdir -p harness/tests/export
-          mv godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.jvm.${{ inputs.build-version }}.exe harness/tests/godot.windows.template_${{ matrix.bootstrap-target }}.x86_64.exe
+          mv godot.windows.template_${{ matrix.jvm-target }}.x86_64.jvm.${{ inputs.build-version }}.exe harness/tests/godot.windows.template_${{ matrix.jvm-target }}.x86_64.exe
 
       - name: Build tests project
         run: |
-          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.bootstrap-target }}
+          harness/tests/gradlew -p harness/tests/ build -P${{ matrix.jvm-target }}
 
       - name: Create JRE
         run: |
@@ -74,14 +68,14 @@ jobs:
           jlink --add-modules java.base,java.logging --output jvm/jre-amd64-windows
 
       - name: Export tests debug
-        if: ${{ matrix.bootstrap-target == 'debug' }}
+        if: ${{ matrix.jvm-target == 'debug' }}
         run: |
           cd harness/tests/
           ./gradlew exportDebug
         timeout-minutes: 30
 
       - name: Export tests release
-        if: ${{ matrix.bootstrap-target == 'release' }}
+        if: ${{ matrix.jvm-target == 'release' }}
         run: |
           cd harness/tests/
           ./gradlew exportRelease

--- a/kt/build.gradle.kts
+++ b/kt/build.gradle.kts
@@ -135,13 +135,13 @@ tasks {
     @Suppress("UNUSED_VARIABLE")
     val buildAndRunEngineDebug by registering {
         group = "godot-kotlin-jvm"
-        dependsOn(buildEngineDebug, getTasksByName("copyBootstrapJar", true).first())
+        dependsOn(buildEngineDebug)
         finalizedBy(runEngineDebug)
     }
     @Suppress("UNUSED_VARIABLE")
     val buildAndRunEngineReleaseDebug by registering {
         group = "godot-kotlin-jvm"
-        dependsOn(buildEngineReleaseDebug, getTasksByName("copyBootstrapJar", true).first())
+        dependsOn(buildEngineReleaseDebug)
         finalizedBy(runEngineReleaseDebug)
     }
 }

--- a/kt/godot-library/build.gradle.kts
+++ b/kt/godot-library/build.gradle.kts
@@ -56,32 +56,6 @@ tasks {
     withType<Jar> {
         dependsOn(generateAPI)
     }
-
-    @Suppress("UNUSED_VARIABLE")
-    val jar by getting {
-        outputs.upToDateWhen {
-            // force this to always run. So we ensure that the bootstrap jar in the godot bin dir is always up to date
-            // only relevant for local testing
-            false
-        }
-        finalizedBy(shadowJar)
-    }
-    build.get().finalizedBy(shadowJar)
-
-    val copyBootstrapJar by registering(Copy::class) {
-        group = "godot-jvm"
-        from(shadowJar)
-        destinationDir = File("${projectDir.absolutePath}/../../../../bin/")
-        dependsOn(shadowJar)
-    }
-
-    withType<ShadowJar> {
-        archiveBaseName.set("godot-bootstrap")
-        archiveVersion.set("")
-        archiveClassifier.set("")
-        exclude("**/module-info.class") //for android support: excludes java 9+ module info which cannot be parsed by the dx tool
-        finalizedBy(copyBootstrapJar)
-    }
 }
 
 val targetSuffix = if (isRelease) "release" else "debug"

--- a/kt/godot-library/godot-core-library/build.gradle.kts
+++ b/kt/godot-library/godot-core-library/build.gradle.kts
@@ -11,7 +11,6 @@ val isRelease = project.hasProperty("release")
 
 kotlinDefinitions {
     definitionsObjectName.set("GodotJvmBuildConfig")
-
     define("DEBUG", !isRelease)
 }
 

--- a/kt/godot-library/godot-coroutine-library/build.gradle.kts
+++ b/kt/godot-library/godot-coroutine-library/build.gradle.kts
@@ -11,10 +11,8 @@ val isRelease = project.hasProperty("release")
 
 kotlinDefinitions {
     definitionsObjectName.set("GodotJvmBuildConfig")
-
     define("DEBUG", !isRelease)
 }
-
 
 kotlin {
     jvmToolchain(libs.versions.toolchain.jvm.get().toInt())

--- a/kt/godot-library/godot-extension-library/build.gradle.kts
+++ b/kt/godot-library/godot-extension-library/build.gradle.kts
@@ -11,7 +11,6 @@ val isRelease = project.hasProperty("release")
 
 kotlinDefinitions {
     definitionsObjectName.set("GodotJvmBuildConfig")
-
     define("DEBUG", !isRelease)
 }
 

--- a/src/editor/godot_kotlin_jvm_editor.cpp
+++ b/src/editor/godot_kotlin_jvm_editor.cpp
@@ -43,9 +43,9 @@ void GodotKotlinJvmEditor::on_filesystem_change() {
     if (GDKotlin::get_instance().state == GDKotlin::State::JVM_SCRIPTS_INITIALIZED) { return; }
 
     // We check for changes in the file system in case the main.jar has been added (not reloaded, just was not present when the editor started)
-    if (GDKotlin::get_instance().state == GDKotlin::State::CORE_LIBRARY_INITIALIZED) {
-        String user_code_path {String(RES_DIRECTORY).path_join(USER_CODE_FILE)};
-        if (FileAccess::exists(user_code_path)) {
+    if (GDKotlin::get_instance().state == GDKotlin::State::JVM_STARTED) {
+        String bootstrap {String(RES_DIRECTORY).path_join(BOOTSTRAP_FILE)};
+        if (FileAccess::exists(bootstrap)) {
             GDKotlin::get_instance().initialize_up_to(GDKotlin::State::JVM_SCRIPTS_INITIALIZED);
         }
     }

--- a/src/lifecycle/paths.h
+++ b/src/lifecycle/paths.h
@@ -7,10 +7,8 @@
 static constexpr const char* USER_DIRECTORY {"user://"};
 static constexpr const char* RES_DIRECTORY {"res://"};
 
-static constexpr const char* EDITOR_BOOTSTRAP_PATH {"godot-bootstrap.jar"};
 static constexpr const char* ENTRY_DIRECTORY {"res://build/generated/ksp"};
 static constexpr const char* JVM_CONFIGURATION_PATH {"res://godot_kotlin_configuration.json"};
-
 
 static constexpr const char* DESKTOP_BOOTSTRAP_FILE {JVM_DIRECTORY "godot-bootstrap.jar"};
 static constexpr const char* DESKTOP_USER_CODE_FILE {JVM_DIRECTORY "main.jar"};


### PR DESCRIPTION
We worked on removing dependency of the editor on the `bootstrap.jar` little by little over the months.
It's time to say goodbye to it.

From now on, only a single bootstrap will be generated at the same time as the main.jar