### PR TITLE
Use the correct parent for ClassLoader

### DIFF
--- a/src/jni/types.cpp
+++ b/src/jni/types.cpp
@@ -56,7 +56,7 @@ namespace jni {
         p_env.env->DeleteLocalRef(obj);
     }
 
-    bool JObject::is_null() {
+    bool JObject::is_null() const{
         return obj == nullptr;
     }
 

--- a/src/jni/types.h
+++ b/src/jni/types.h
@@ -84,7 +84,7 @@ namespace jni {
         template<bool CHECK_EXCEPTION = true>
         JObject call_object_method(Env& p_env, ObjectMethodID method, jvalue* args = {}) const;
 
-        bool is_null();
+        bool is_null() const;
 
         bool is_same_object(Env& env, const JObject& other) const;
     };


### PR DESCRIPTION
So far we have always created a ClassLoader with a parent set to null. It was the right way to make one that default to the system classloader, back in Java 8...
Since then, they added the new module system and classLoaders without parent don't have access to any other module than the base one, any additional one would result in a ClassNotFound error for people trying to use java sql for example.

Related issue:
https://bugs.openjdk.org/browse/JDK-8161269

I confirmed with a user who couldn't use the java sql module that the change fixed their issue.