### PR TITLE
Make project.godot template version dynamic.

### DIFF
--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/module/GodotModuleBuilder.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/module/GodotModuleBuilder.kt
@@ -343,6 +343,21 @@ class GodotModuleBuilder : ModuleBuilder(), ModuleBuilderListener {
             outFile.writeText(
                 outFile
                     .readText()
+                    .replace(
+                        "GODOT_VERSION",
+                        GodotBuildProperties.godotVersion.run {
+                            // Ensure that the version string has at least one dot.
+                            val firstDotIndex = indexOf('.')
+                            if (firstDotIndex == -1) {
+                                throw IllegalArgumentException("Version must be in x.y or x.y.z format")
+                            }
+
+                            // If there's no second dot, the version is already in x.y format.
+                            // Otherwise, cut off the version after the second dot to handle x.y.z format.
+                            val secondDotIndex = indexOf('.', firstDotIndex + 1)
+                            if (secondDotIndex == -1) this else substring(0, secondDotIndex)
+                        }
+                    )
                     .replace("PROJECT_NAME", module.project.name)
             )
         }

--- a/kt/plugins/godot-intellij-plugin/src/main/resources/template/project.godot.intellij_template
+++ b/kt/plugins/godot-intellij-plugin/src/main/resources/template/project.godot.intellij_template
@@ -11,5 +11,5 @@ config_version=5
 [application]
 
 config/name="PROJECT_NAME"
-config/features=PackedStringArray("4.2", "Forward Plus")
+config/features=PackedStringArray("GODOT_VERSION", "Forward Plus")
 config/icon="res://icon.svg"


### PR DESCRIPTION
Fix #802
Version can only be x.y in this file, (like 4.2, 4.3, 4.4..., they never include the patch version in it).