### PR TITLE
Parse JNI Strings as utf8

### DIFF
--- a/src/jni/env.cpp
+++ b/src/jni/env.cpp
@@ -34,12 +34,6 @@ namespace jni {
         return JClass(cls);
     }
 
-    JObject Env::new_string(const char* str) {
-        auto jstr = env->NewStringUTF(str);
-        handle_exception();
-        return JObject(jstr);
-    }
-
     bool Env::exception_check() {
         return env->ExceptionCheck();
     }
@@ -85,10 +79,16 @@ namespace jni {
         return env->IsSameObject(obj_1.obj, obj_2.obj);
     }
 
+    JObject Env::new_string(const char* str) {
+        auto jstr = env->NewStringUTF(str);
+        handle_exception();
+        return JObject(jstr);
+    }
+
     String Env::from_jstring(jni::JString str) {
         auto jstr = (jstring) str.obj;
         auto utfString = env->GetStringUTFChars(jstr, nullptr);
-        auto ret = String(utfString);
+        String ret = String::utf8(utfString);
         handle_exception();
         env->ReleaseStringUTFChars(jstr, utfString);
         return ret;

--- a/src/kt_variant.h
+++ b/src/kt_variant.h
@@ -215,8 +215,7 @@ class BufferToVariant {
         } else {
             uint32_t size {decode_uint32(byte_buffer->get_cursor())};
             byte_buffer->increment_position(INT_SIZE);
-            String str;
-            str.parse_utf8(reinterpret_cast<const char*>(byte_buffer->get_cursor()), size);
+            String str = String::utf8(reinterpret_cast<const char*>(byte_buffer->get_cursor()), size);
             byte_buffer->increment_position(size);
             return Variant(str);
         }


### PR DESCRIPTION
FIx #808 

Little mistake we made when parsing a String from JNI instead of the bytebuffer. 
We were using Godot's String regular constructor that takes a char array, but that constructor assumes it's latin encoding and not utf8. 
We never noticed because we use the bytebuffer in most places, but non-ascii characters were breaking when printing to Godot for example.