### PR TITLE
GH-811 GH-813 Copy missing resource files for android exports

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/setupTasks.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/projectExt/setupTasks.kt
@@ -2,6 +2,7 @@ package godot.gradle.projectExt
 
 import godot.gradle.tasks.android.checkAndroidJarAccessibleTask
 import godot.gradle.tasks.android.checkD8ToolAccessibleTask
+import godot.gradle.tasks.android.createBootstrapDexJarTask
 import godot.gradle.tasks.android.createMainDexFileTask
 import godot.gradle.tasks.android.packageBootstrapDexJarTask
 import godot.gradle.tasks.android.packageMainDexJarTask
@@ -32,10 +33,13 @@ fun Project.setupTasks() {
             // START: android specific tasks
             val checkD8ToolAccessibleTask = checkD8ToolAccessibleTask()
             val checkAndroidJarAccessibleTask = checkAndroidJarAccessibleTask()
-            val packageBootstrapDexJarTask = packageBootstrapDexJarTask(
+            val createBootstrapDexJarTask = createBootstrapDexJarTask(
                 checkAndroidJarAccessibleTask = checkAndroidJarAccessibleTask,
                 checkD8ToolAccessibleTask = checkD8ToolAccessibleTask,
-                packageBootstrapJarTask = packageBootstrapJarTask
+                packageBootstrapJarTask = packageBootstrapJarTask,
+            )
+            val packageBootstrapDexJarTask = packageBootstrapDexJarTask(
+                createBootstrapDexJarTask = createBootstrapDexJarTask,
             )
             val createMainDexFileTask = createMainDexFileTask(
                 checkAndroidJarAccessibleTask = checkAndroidJarAccessibleTask,

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/createBootstrapDexJarTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/createBootstrapDexJarTask.kt
@@ -1,0 +1,67 @@
+package godot.gradle.tasks.android
+
+import godot.gradle.GodotPlugin
+import godot.gradle.projectExt.godotJvmExtension
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
+import java.io.File
+
+fun Project.createBootstrapDexJarTask(
+    checkAndroidJarAccessibleTask: TaskProvider<out Task>,
+    checkD8ToolAccessibleTask: TaskProvider<out Task>,
+    packageBootstrapJarTask: TaskProvider<out Task>
+): TaskProvider<out Task> {
+    return tasks.register("createBootstrapDexJar", Exec::class.java) {
+        with(it) {
+            group = "godot-kotlin-jvm"
+            description = "Converts the godot-bootstrap.jar to an android compatible version. Needed for android builds only"
+
+            dependsOn(checkD8ToolAccessibleTask, checkAndroidJarAccessibleTask, packageBootstrapJarTask)
+
+            doFirst {
+                val libsDir = project.layout.buildDirectory.asFile.get().resolve("libs")
+                val godotBootstrapJar = File(libsDir, "godot-bootstrap.jar")
+                val mainDexRules = project.layout.buildDirectory.asFile.get().resolve("main-dex-rules.proguard").also { mainDexRules ->
+                    mainDexRules.outputStream().use { outputStream ->
+                        requireNotNull(GodotPlugin::class.java.getResourceAsStream("android/main-dex-rules.proguard"))
+                            .copyTo(outputStream)
+                    }
+                }.absolutePath
+
+                workingDir = libsDir
+                if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
+                    commandLine(
+                        "cmd",
+                        "/c",
+                        godotJvmExtension.d8ToolPath.get().asFile.absolutePath,
+                        godotBootstrapJar.absolutePath,
+                        "--output",
+                        "godot-bootstrap-dex.jar",
+                        "--lib",
+                        "${godotJvmExtension.androidCompileSdkDir.get().asFile.absolutePath}${File.separator}android.jar",
+                        "--min-api",
+                        godotJvmExtension.androidMinApi.get(),
+                        "--main-dex-rules",
+                        mainDexRules,
+                    )
+                } else {
+                    commandLine(
+                        godotJvmExtension.d8ToolPath.get().asFile.absolutePath,
+                        godotBootstrapJar.absolutePath,
+                        "--output",
+                        "godot-bootstrap-dex.jar",
+                        "--lib",
+                        "${godotJvmExtension.androidCompileSdkDir.get().asFile.absolutePath}/android.jar",
+                        "--min-api",
+                        godotJvmExtension.androidMinApi.get(),
+                        "--main-dex-rules",
+                        mainDexRules,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageBootstrapDexJarTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageBootstrapDexJarTask.kt
@@ -1,7 +1,5 @@
 package godot.gradle.tasks.android
 
-import godot.gradle.GodotPlugin
-import godot.gradle.projectExt.godotJvmExtension
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.Exec
@@ -10,56 +8,67 @@ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import java.io.File
 
 fun Project.packageBootstrapDexJarTask(
-    checkAndroidJarAccessibleTask: TaskProvider<out Task>,
-    checkD8ToolAccessibleTask: TaskProvider<out Task>,
-    packageBootstrapJarTask: TaskProvider<out Task>
+    createBootstrapDexJarTask: TaskProvider<out Task>
 ): TaskProvider<out Task> {
     return tasks.register("packageBootstrapDexJar", Exec::class.java) {
         with(it) {
             group = "godot-kotlin-jvm"
-            description =
-                "Converts the godot-bootstrap.jar to an android compatible version. Needed for android builds only"
+            description = "Packages needed resources into godot-bootstrap-dex.jar. Needed for android builds only"
 
-            dependsOn(checkD8ToolAccessibleTask, checkAndroidJarAccessibleTask, packageBootstrapJarTask)
+            dependsOn(createBootstrapDexJarTask)
 
             doFirst {
                 val libsDir = project.layout.buildDirectory.asFile.get().resolve("libs")
                 val godotBootstrapJar = File(libsDir, "godot-bootstrap.jar")
-                val mainDexRules = project.layout.buildDirectory.asFile.get().resolve("main-dex-rules.proguard").also { mainDexRules ->
-                    mainDexRules.outputStream().use { outputStream ->
-                        requireNotNull(GodotPlugin::class.java.getResourceAsStream("android/main-dex-rules.proguard"))
-                            .copyTo(outputStream)
+                val godotBootstrapDexJar = File(libsDir, "godot-bootstrap-dex.jar")
+                val resourcesDir = libsDir.resolve("resources").apply { mkdirs() }
+
+                val resourcesToCopy = listOf(
+                    "build.properties",
+                )
+
+                val zipTree = zipTree(godotBootstrapJar)
+
+                resourcesToCopy.forEach { resourcePath ->
+                    val resourceFile = zipTree.firstOrNull { file -> file.path.endsWith(resourcePath) }
+
+                    if (resourceFile == null) {
+                        project.logger.error("Could not copy $resourcePath to godot-bootstrap-dex.jar")
+                    } else {
+                        resourceFile.copyTo(resourcesDir.resolve(resourcePath))
                     }
-                }.absolutePath
+                }
 
                 workingDir = libsDir
+
+
+                // assembles the following command: jar uf <path_to_bootstrap_dex_jar> -C <path_to_resource_dirs_containing_resources_to_copy> build.properties
+                // which updates the godot-bootstrap-dex.jar to include the necessary resources as the r8 tool handles only files
+                val resourceCopyCommands = resourcesToCopy
+                    .flatMap { resourcesToCopy ->
+                        listOf(
+                            "-C",
+                            resourcesDir.absolutePath,
+                            resourcesToCopy,
+                        )
+                    }
+                    .toTypedArray()
+
                 if (DefaultNativePlatform.getCurrentOperatingSystem().isWindows) {
                     commandLine(
                         "cmd",
                         "/c",
-                        godotJvmExtension.d8ToolPath.get().asFile.absolutePath,
-                        godotBootstrapJar.absolutePath,
-                        "--output",
-                        "godot-bootstrap-dex.jar",
-                        "--lib",
-                        "${godotJvmExtension.androidCompileSdkDir.get().asFile.absolutePath}${File.separator}android.jar",
-                        "--min-api",
-                        godotJvmExtension.androidMinApi.get(),
-                        "--main-dex-rules",
-                        mainDexRules,
+                        "jar",
+                        "uf",
+                        godotBootstrapDexJar.absolutePath,
+                        *resourceCopyCommands,
                     )
                 } else {
                     commandLine(
-                        godotJvmExtension.d8ToolPath.get().asFile.absolutePath,
-                        godotBootstrapJar.absolutePath,
-                        "--output",
-                        "godot-bootstrap-dex.jar",
-                        "--lib",
-                        "${godotJvmExtension.androidCompileSdkDir.get().asFile.absolutePath}/android.jar",
-                        "--min-api",
-                        godotJvmExtension.androidMinApi.get(),
-                        "--main-dex-rules",
-                        mainDexRules,
+                        "jar",
+                        "uf",
+                        godotBootstrapDexJar.absolutePath,
+                        *resourceCopyCommands,
                     )
                 }
             }

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageMainDexJarTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageMainDexJarTask.kt
@@ -16,6 +16,7 @@ fun Project.packageMainDexJarTask(
 
             archiveBaseName.set("main-dex")
 
+            from("src/main/resources").include("**/godot.registration.Entry")
             // add all dex files (converted class files)
             from("${project.layout.buildDirectory.asFile.get().absolutePath}/libs/").include("*.dex")
 

--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageMainDexJarTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageMainDexJarTask.kt
@@ -16,8 +16,16 @@ fun Project.packageMainDexJarTask(
 
             archiveBaseName.set("main-dex")
 
-            from("src/main/resources").include("**/godot.registration.Entry")
+            // add all dex files (converted class files)
             from("${project.layout.buildDirectory.asFile.get().absolutePath}/libs/").include("*.dex")
+
+            from(zipTree(project.layout.buildDirectory.asFile.get().resolve("libs/main.jar"))) { copySpec ->
+                // copy everything from the main.jar
+                copySpec.include("**/*")
+
+                // except class files as these are contained in converted form in the dex files
+                copySpec.exclude("**/*.class")
+            }
 
             dependsOn(createMainDexFileTask)
         }


### PR DESCRIPTION
Resolves #811 and resolves #813

This resolves a crash when running an exported android project.

The resulting godot-bootstrap-dex.jar does not contain any resource files, only class files as the r8 tool only handles class files.

I for now created a new task which modifies the jar after creation to add missing and required resources to it.
However: I'm not sure if there is not a better approach. This approach works, but is not ideal IMO. AFAIK there is no way to tell r8 to handle the resource copy for us. And I'm not aware of a gradle task which can handle this for us automatically.

Note: this resource copy problem only applies to the bootstrap dex jar. For the main dex jar, we already handled missing resources manually. See here: https://github.com/utopia-rise/godot-kotlin-jvm/blob/1b0a8359612e9727f18f2216af07a11f6746c0c0/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageMainDexJarTask.kt#L19

~~However, this only includes the registration Entry but NOT other resource files. This would also break user builds where user add custom resources.
For this, a new issue was created: https://github.com/utopia-rise/godot-kotlin-jvm/issues/813~~ -> This is now also fixed as part of this PR

~~My suggestion for these issues is; fix the issue at hand trough this PR (using the approach in this PR or another one). Then properly clenup dex file creation/handling on android~~ -> As discussed on discord, we properly cleanup the android export with the move to GDExtensions, as there we need to convert the android export to a Godot Android Plugin anyways.