### PR TITLE
GH-801 Exclude jvm dir from export

### DIFF
--- a/src/kotlin_editor_export_plugin.cpp
+++ b/src/kotlin_editor_export_plugin.cpp
@@ -177,10 +177,16 @@ void KotlinEditorExportPlugin::_generate_export_configuration_file(jni::JvmType 
         get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + JVM_CONFIGURATION_PATH);
     }
 
-    // exclude build folder
-    get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + BUILD_DIRECTORY + "/*");
-    // exclude any jars in the embedded jre
-    get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + "res://" + JVM_DIRECTORY + "jre-*/**/*.jar");
+    if (const String build_dir = String {BUILD_DIRECTORY}.path_join("*"); !get_export_preset()->get_exclude_filter().contains(build_dir)) {
+        // exclude build folder
+        get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + build_dir);
+    }
+
+    if (const String jre_jars = String {"res://"} + JVM_DIRECTORY + "jre-*/**/*.jar";
+        !get_export_preset()->get_exclude_filter().contains(jre_jars)) {
+        // exclude any jars in the embedded jre
+        get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + jre_jars);
+    }
 
     add_file(JVM_CONFIGURATION_PATH, json_bytes, false);
 }

--- a/src/kotlin_editor_export_plugin.cpp
+++ b/src/kotlin_editor_export_plugin.cpp
@@ -130,8 +130,6 @@ void KotlinEditorExportPlugin::_export_begin(const HashSet<String>& p_features, 
             _generate_export_configuration_file(jni::JvmType::GRAAL_NATIVE_IMAGE);
         }
     } else if (is_android_export) {
-        files_to_add.push_back(String(RES_DIRECTORY).path_join(ANDROID_BOOTSTRAP_FILE));
-        files_to_add.push_back(String(RES_DIRECTORY).path_join(ANDROID_USER_CODE_FILE));
         _generate_export_configuration_file(jni::JvmType::ART);
     } else if (is_ios_export) {
         String base_ios_build_dir {String(RES_DIRECTORY).path_join(JVM_DIRECTORY).path_join("ios")};
@@ -179,9 +177,10 @@ void KotlinEditorExportPlugin::_generate_export_configuration_file(jni::JvmType 
         get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + JVM_CONFIGURATION_PATH);
     }
 
-    // we exclude the jvm directory here as the resource loaders for jar files would add all jar files a second time
-    // which breaks android builds
-    get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + "res://" + JVM_DIRECTORY + "*");
+    // exclude build folder
+    get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + BUILD_DIRECTORY + "/*");
+    // exclude any jars in the embedded jre
+    get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + "res://" + JVM_DIRECTORY + "jre-*/**/*.jar");
 
     add_file(JVM_CONFIGURATION_PATH, json_bytes, false);
 }

--- a/src/kotlin_editor_export_plugin.cpp
+++ b/src/kotlin_editor_export_plugin.cpp
@@ -156,12 +156,14 @@ void KotlinEditorExportPlugin::_export_begin(const HashSet<String>& p_features, 
         JVM_LOG_INFO("Exporting %s", file_to_add);
     }
 
+    _add_exclude_filter_preset();
+
     JVM_LOG_INFO("Finished Godot-Jvm specific exports.");
 }
 
 void KotlinEditorExportPlugin::_generate_export_configuration_file(jni::JvmType vm_type) {
-    JvmUserConfiguration configuration = GDKotlin::get_instance().get_configuration();// Copy
-    configuration.vm_type = vm_type;// We only need to change the vm type
+    JvmUserConfiguration configuration = GDKotlin::get_instance().get_configuration(); // Copy
+    configuration.vm_type = vm_type; // We only need to change the vm type
 
     const char32_t* json_string {JvmUserConfiguration::export_configuration_to_json(configuration).get_data()};
     Vector<uint8_t> json_bytes;
@@ -169,6 +171,10 @@ void KotlinEditorExportPlugin::_generate_export_configuration_file(jni::JvmType 
         json_bytes.push_back(json_string[i]);
     }
 
+    add_file(JVM_CONFIGURATION_PATH, json_bytes, false);
+}
+
+void KotlinEditorExportPlugin::_add_exclude_filter_preset() {
     // only add our configuration file to the exclude filter if it is not already present
     if (!get_export_preset()->get_exclude_filter().contains(JVM_CONFIGURATION_PATH)) {
         // we manually add the configuration file to the exclude filter to prevent it from being added multiple times
@@ -182,13 +188,10 @@ void KotlinEditorExportPlugin::_generate_export_configuration_file(jni::JvmType 
         get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + build_dir);
     }
 
-    if (const String jre_jars = String {"res://"} + JVM_DIRECTORY + "jre-*/**/*.jar";
-        !get_export_preset()->get_exclude_filter().contains(jre_jars)) {
+    if (const String jre_jars = String {"res://"} + JVM_DIRECTORY + "jre-*/**/*.jar"; !get_export_preset()->get_exclude_filter().contains(jre_jars)) {
         // exclude any jars in the embedded jre
         get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + jre_jars);
     }
-
-    add_file(JVM_CONFIGURATION_PATH, json_bytes, false);
 }
 
 String KotlinEditorExportPlugin::get_name() const {

--- a/src/kotlin_editor_export_plugin.cpp
+++ b/src/kotlin_editor_export_plugin.cpp
@@ -179,6 +179,10 @@ void KotlinEditorExportPlugin::_generate_export_configuration_file(jni::JvmType 
         get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + JVM_CONFIGURATION_PATH);
     }
 
+    // we exclude the jvm directory here as the resource loaders for jar files would add all jar files a second time
+    // which breaks android builds
+    get_export_preset()->set_exclude_filter(get_export_preset()->get_exclude_filter() + "," + "res://" + JVM_DIRECTORY + "*");
+
     add_file(JVM_CONFIGURATION_PATH, json_bytes, false);
 }
 

--- a/src/kotlin_editor_export_plugin.h
+++ b/src/kotlin_editor_export_plugin.h
@@ -20,6 +20,7 @@ public:
 
 private:
     void _generate_export_configuration_file(jni::JvmType vm_type);
+    void _add_exclude_filter_preset();
 };
 
 #endif// GODOT_JVM_KOTLINEDITOREXPORTPLUGIN_H

--- a/src/lifecycle/paths.h
+++ b/src/lifecycle/paths.h
@@ -7,6 +7,7 @@
 static constexpr const char* USER_DIRECTORY {"user://"};
 static constexpr const char* RES_DIRECTORY {"res://"};
 
+static constexpr const char* BUILD_DIRECTORY {"res://build"};
 static constexpr const char* ENTRY_DIRECTORY {"res://build/generated/ksp"};
 static constexpr const char* JVM_CONFIGURATION_PATH {"res://godot_kotlin_configuration.json"};
 


### PR DESCRIPTION
Resolves #801 

This explicitly excludes our jvm dir by default. The jars we need we add manually in the export plugin, and this takes predecence over what we exclude here. So these files are still present.

Before this change, these jar files were added twice, breaking the android export.

@CedNaru This change kinda prevents your idea of loading jars dynamically with the jar resource loader.
We can either worry about this once we implement multi jars or we can instead, not explicitly add the bootstrap jar and the main jar in the export plugin anymore and instead let it happen atomatically through the resource loader.

Because of this decision; this is still a draft