### PR TITLE
GH-812 Fix missing types on desugaring in r8

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/createMainDexFileTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/createMainDexFileTask.kt
@@ -47,6 +47,8 @@ fun Project.createMainDexFileTask(
                         mainJar.absolutePath,
                         "--lib",
                         "${godotJvmExtension.androidCompileSdkDir.get().asFile.absolutePath}${File.separator}android.jar",
+                        "--classpath",
+                        godotBootstrapJar.absolutePath,
                         "--min-api",
                         godotJvmExtension.androidMinApi.get(),
                         "--main-dex-rules",


### PR DESCRIPTION
Resolves #812 

On windows we forgot to add the bootstrap jar to the class path for the r8 task.

This lead to warnings like:
```
> Task :createMainDexFile
Warning in C:\Users\cedri\projects\05_random\androidexport\build\libs\main.jar:godot/entry/SimpleRegistrar$register$1$1$1.class:
Type `kotlin.jvm.internal.FunctionReferenceImpl` was not found, it is required for default or static interface methods desugaring of `godot.entry.SimpleRegistrar$register$1$1$1`
Warning in C:\Users\cedri\projects\05_random\androidexport\build\libs\main.jar:godot/entry/SimpleRegistrar.class:
Type `godot.registration.ClassRegistrar` was not found, it is required for default or static interface methods desugaring of `godot.entry.SimpleRegistrar`
Warning in C:\Users\cedri\projects\05_random\androidexport\build\libs\main.jar:com/example/game/Simple.class:
Type `godot.api.Node3D` was not found, it is required for default or static interface methods desugaring of `com.example.game.Simple`
Warning in C:\Users\cedri\projects\05_random\androidexport\build\libs\main.jar:godot/entry/SimpleRegistrar.class:
Type `kotlin.jvm.functions.Function1` was not found, it is required for default or static interface methods desugaring of `godot.entry.SimpleRegistrar$$InternalSyntheticLambda$2$cd6dace8551bbf7a8ef5ac63f7e9801a9f4144573bb174ae76002f9975ebac74$0`
Warning in C:\Users\cedri\projects\05_random\androidexport\build\libs\main.jar:godot/entry/ukJKaFByiPdTkFotsEFK/Entry.class:
Type `godot.registration.Entry` was not found, it is required for default or static interface methods desugaring of `godot.entry.ukJKaFByiPdTkFotsEFK.Entry`
Warning in C:\Users\cedri\projects\05_random\androidexport\build\libs\main.jar:godot/entry/SimpleRegistrar$register$1$1$1.class:
Type `kotlin.jvm.functions.Function0` was not found, it is required for default or static interface methods desugaring of `godot.entry.SimpleRegistrar$register$1$1$1`

BUILD SUCCESSFUL in 1m 1s
38 actionable tasks: 19 executed, 19 up-to-date
```

It might be possible that this can lead to crashes on older android devices if the app was built on a windows host.