### PR TITLE
Update ide plugin

### DIFF
--- a/kt/gradle/libs.versions.toml
+++ b/kt/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ godotKotlinJvm = "0.12.3"
 kotlin = "2.1.10" # https://kotlinlang.org/docs/releases.html#release-details
 kotlinCoroutine = "1.10.1" # https://github.com/Kotlin/kotlinx.coroutines/releases
 godot = "4.4.1"
-ideaPluginDefaultIntellijVersion = "2024.3.3"
+ideaPluginDefaultIntellijVersion = "2025.1"
 
 toolchain-jvm="11"
 

--- a/kt/plugins/godot-intellij-plugin/build.gradle.kts
+++ b/kt/plugins/godot-intellij-plugin/build.gradle.kts
@@ -74,7 +74,7 @@ tasks {
         } else {
             this.pluginVersion.set("${project.version}-IJ$intellijVersion")
         }
-        sinceBuild.set("243.1")
+        sinceBuild.set("251.1")
         // magic values like 999.* are no longer supported. But we can support current version +2 years. Example: current 242.3 (2024.2.3) until 279.* (2027.9.*)
         // this prevents us from needing to update the ide plugin with every ide version update and gives us ~2 years time for that after the last release
         untilBuild.set("279.*")

--- a/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/gradle/GradleSystemListener.kt
+++ b/kt/plugins/godot-intellij-plugin/src/main/kotlin/godot/intellij/plugin/gradle/GradleSystemListener.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.idea.configuration.GRADLE_SYSTEM_ID
 class GradleSystemListener : ExternalSystemTaskNotificationListenerAdapter(null) {
     override fun onStart(
         id: ExternalSystemTaskId,
-        workingDir: String?,
+        workingDir: String,
     ) {
         if (id.projectSystemId == GRADLE_SYSTEM_ID && id.type == RESOLVE_PROJECT) {
             // Gradle sync just started, pause our existing import if one is happening.


### PR DESCRIPTION
This updates our ide plugin for intellij 2025.1

With 2025.1 the signature of `ExternalSystemTaskNotificationListenerAdapter` changed, wich prevents our plugin from working with 2025.1