### PR TITLE
Improve Gradle Task Runner

### DIFF
--- a/src/editor/build/build_manager.cpp
+++ b/src/editor/build/build_manager.cpp
@@ -8,7 +8,6 @@
 #include "logging.h"
 
 #include <core/config/project_settings.h>
-#include <editor/editor_node.h>
 
 Mutex build_mutex {};
 
@@ -28,54 +27,85 @@ String get_gradlew_path() {
     return gradle_wrapper_path.path_join(gradle_wrapper);
 }
 
-Error BuildManager::build_project() {
+Error GradleTaskManager::run_task(GradleTaskManager::Task task, String& log, bool blocking) {
+    JVM_ERR_FAIL_COND_V_MSG(
+      !FileAccess::create(FileAccess::AccessType::ACCESS_RESOURCES)->file_exists(get_build_gradle_path()),
+      Error::ERR_FILE_NOT_FOUND,
+      missing_gradle_project
+    );
+
     List<String> args {};
     args.push_back("build");
 
     String gradlew_path = get_gradlew_path();
-    JVM_LOG_INFO("Running %s build task...", gradlew_path);
 
-    int exit_code;
-    Error result = OS::get_singleton()->execute(gradlew_path, args, &build_log, &exit_code, true, &build_mutex, false);
-    return result;
-}
+    if (blocking) {
+        int exit_code;
+        Error result = OS::get_singleton()->execute(gradlew_path, args, &log, &exit_code, true, &build_mutex, false);
+        return result;
+    } else {
+        Dictionary info = OS::get_singleton()->execute_with_pipe(gradlew_path, args, /*blocking=*/false);
 
-bool BuildManager::build_project_blocking() {
-    JVM_ERR_FAIL_COND_V_MSG(!FileAccess::create(FileAccess::AccessType::ACCESS_RESOURCES)->file_exists(get_build_gradle_path()), false, missing_gradle_project);
+        if (info.is_empty()) { JVM_ERR_FAIL_V_MSG(Error::ERR_CANT_CREATE, "Failed to start process"); }
 
-    build_log.clear();
-
-    if (build_project() != Error::OK) {
-        // When in blocking mode, only make the window appears when it fails
-        GodotKotlinJvmEditor::get_instance()->update_build_dialog(build_log);
-        return false;
-    }
-    GodotKotlinJvmEditor::get_instance()->on_build_finished();
-    return true;
-}
-
-void BuildManager::build_task(void* p_userdata) {
-    GodotKotlinJvmEditor::get_instance()->update_build_dialog(start_build);
-
-    if (BuildManager::get_instance().build_project() == Error::OK) {
-        GodotKotlinJvmEditor::get_instance()->on_build_finished();
+        log = vformat("Running %s build task...", gradlew_path);
+        stdio = info["stdio"];
+        stderr_io = info["stderr"];
+        pid = info["pid"];
     }
 
-    GodotKotlinJvmEditor::get_instance()->update_build_dialog(BuildManager::get_instance().build_log);
-    BuildManager::get_instance().taskId = WorkerThreadPool::INVALID_TASK_ID;
+    return Error::OK;
 }
 
-void BuildManager::build_project_non_blocking() {
-    if (taskId != WorkerThreadPool::INVALID_TASK_ID) { return; }
-    JVM_ERR_FAIL_COND_MSG(!FileAccess::create(FileAccess::AccessType::ACCESS_RESOURCES)->file_exists(get_build_gradle_path()), missing_gradle_project);
-
-    build_log.clear();
-    taskId = WorkerThreadPool::get_singleton()->add_native_task(build_task, nullptr);
-}
-
-BuildManager& BuildManager::get_instance() {
-    static BuildManager instance;
+GradleTaskManager& GradleTaskManager::get_instance() {
+    static GradleTaskManager instance;
     return instance;
 }
 
-#endif// TOOLS_ENABLED
+bool GradleTaskManager::is_task_started() {
+    return pid > -1;
+}
+
+bool GradleTaskManager::is_task_terminated() {
+    bool ret = !OS::get_singleton()->is_process_running(pid);
+    if (ret) { reset(); }
+    return ret;
+}
+
+void GradleTaskManager::get_task_output(String& log, String& error) {
+    if (stdio.is_valid()) {
+        // keep reading until no full line is available
+        Error err;
+        do {
+            String line = stdio->get_line();
+            err = stdio->get_error();
+            if (!line.is_empty()) {
+                log += line + "\n";
+            }
+        } while (err == OK);
+    }
+
+    if (stderr_io.is_valid()) {
+        // keep reading until no full line is available
+        Error err;
+        do {
+            String line = stderr_io->get_line();
+            err = stderr_io->get_error();
+            if (!line.is_empty()) {
+                error += line + "\n";
+            }
+        } while (err == OK);
+    }
+}
+
+void GradleTaskManager::reset() {
+    stdio = {};
+    stderr_io = {};
+    pid = -1;
+}
+
+void GradleTaskManager::cleanup() {
+    reset();
+}
+
+#endif // TOOLS_ENABLED

--- a/src/editor/build/build_manager.h
+++ b/src/editor/build/build_manager.h
@@ -4,30 +4,40 @@
 #ifndef GODOT_JVM_BUILD_MANAGER_H
 #define GODOT_JVM_BUILD_MANAGER_H
 
+#include <core/object/worker_thread_pool.h>
 #include <core/os/os.h>
 #include <core/os/thread.h>
-#include <core/object/worker_thread_pool.h>
 
-class BuildManager {
-    WorkerThreadPool::TaskID taskId = WorkerThreadPool::INVALID_TASK_ID;
-
-    String build_log;
-
-    BuildManager() = default;
-    Error build_project();
-
-    static void build_task(void* p_userdata);
-
+class GradleTaskManager {
 public:
-    static BuildManager& get_instance();
+    enum class Task {
+        NONE,
+        BUILD_DEBUG,
+        BUILD_RELEASE,
+        GENERATE_EMBEDDED_JVM
+    };
 
-    BuildManager(const BuildManager&) = delete;
-    BuildManager& operator=(const BuildManager&) = delete;
+private:
+    Ref<FileAccess> stdio;
+    Ref<FileAccess> stderr_io;
+    int pid = -1;
 
-    bool build_project_blocking();
-    void build_project_non_blocking();
+    GradleTaskManager() = default;
+
+    void reset();
+public:
+    static GradleTaskManager& get_instance();
+    void cleanup();
+
+    GradleTaskManager(const GradleTaskManager&) = delete;
+    GradleTaskManager& operator=(const GradleTaskManager&) = delete;
+
+    Error run_task(Task task, String& log, bool blocking);
+    bool is_task_started();
+    bool is_task_terminated();
+    void get_task_output(String& log, String& error);
 };
 
-#endif// GODOT_JVM_BUILD_MANAGER_H
+#endif // GODOT_JVM_BUILD_MANAGER_H
 
-#endif// TOOLS_ENABLED
+#endif // TOOLS_ENABLED

--- a/src/editor/build/gradle_task_runner.cpp
+++ b/src/editor/build/gradle_task_runner.cpp
@@ -45,6 +45,8 @@ Error GradleTaskRunner::run_task(int task_id, String& log, bool blocking) {
         case Task::GENERATE_EMBEDDED_JVM:
             args.push_back("generateEmbeddedJre");
             break;
+        default:
+            return Error::ERR_INVALID_PARAMETER;
     }
 
     String gradlew_path = get_gradlew_path();
@@ -58,7 +60,7 @@ Error GradleTaskRunner::run_task(int task_id, String& log, bool blocking) {
 
         if (info.is_empty()) { JVM_ERR_FAIL_V_MSG(Error::ERR_CANT_CREATE, "Failed to start process"); }
 
-        log = vformat("Running %s build task...", gradlew_path);
+        log = vformat("Running gradle task: %s", args.get(0));
         stdio = info["stdio"];
         stderr_io = info["stderr"];
         pid = info["pid"];

--- a/src/editor/build/gradle_task_runner.h
+++ b/src/editor/build/gradle_task_runner.h
@@ -8,10 +8,9 @@
 #include <core/os/os.h>
 #include <core/os/thread.h>
 
-class GradleTaskManager {
+class GradleTaskRunner {
 public:
-    enum class Task {
-        NONE,
+    enum Task {
         BUILD_DEBUG,
         BUILD_RELEASE,
         GENERATE_EMBEDDED_JVM
@@ -22,17 +21,18 @@ private:
     Ref<FileAccess> stderr_io;
     int pid = -1;
 
-    GradleTaskManager() = default;
+    GradleTaskRunner() = default;
 
     void reset();
+
 public:
-    static GradleTaskManager& get_instance();
+    static GradleTaskRunner& get_instance();
     void cleanup();
 
-    GradleTaskManager(const GradleTaskManager&) = delete;
-    GradleTaskManager& operator=(const GradleTaskManager&) = delete;
+    GradleTaskRunner(const GradleTaskRunner&) = delete;
+    GradleTaskRunner& operator=(const GradleTaskRunner&) = delete;
 
-    Error run_task(Task task, String& log, bool blocking);
+    Error run_task(int task_id, String& log, bool blocking);
     bool is_task_started();
     bool is_task_terminated();
     void get_task_output(String& log, String& error);

--- a/src/editor/dialog/build_dialog.cpp
+++ b/src/editor/dialog/build_dialog.cpp
@@ -3,43 +3,61 @@
 
 #include "build_dialog.h"
 
-#include "editor/build/build_manager.h"
+#include "editor/build/gradle_task_runner.h"
 #include "logging.h"
 
 #include <editor/themes/editor_scale.h>
 
-BuildDialog::BuildDialog() : scroll_container(memnew(ScrollContainer)), log_label(memnew(Label)) {
-    set_title("Godot Kotlin/JVM Gradle build");
+TaskDialog::TaskDialog() :
+  scroll_container(memnew(ScrollContainer)),
+  log_label(memnew(Label)),
+  progress_bar(memnew(ProgressBar)),
+  vertical_container(memnew(VBoxContainer)) {
+    set_title("Gradle Task Runner");
 }
 
-void BuildDialog::set_scrollbar_at_bottom() {
+void TaskDialog::set_scrollbar_at_bottom() {
     scroll_container->set_v_scroll(static_cast<int>(scroll_container->get_v_scroll_bar()->get_max()));
 }
 
-void BuildDialog::make_appear() {
+void TaskDialog::make_appear() {
     log_label->set_text("");
+    set_transient(true);
+    set_exclusive(true);
+    progress_bar->show();
     popup_centered();
 }
 
-void BuildDialog::update_state(String log) {
+void TaskDialog::update_state(String log) {
     if (log.is_empty()) { return; }
     log_label->set_text(log_label->get_text() + log);
 
     StringName signal = SNAME("draw");
-    Callable callback = callable_mp(this, &BuildDialog::set_scrollbar_at_bottom);
+    Callable callback = callable_mp(this, &TaskDialog::set_scrollbar_at_bottom);
 
     if (!scroll_container->is_connected(signal, callback)) {
         scroll_container->connect(signal, callback, CONNECT_ONE_SHOT);
     }
 }
 
-void BuildDialog::_notification(int notification) {
+void TaskDialog::stop() {
+    progress_bar->hide();
+    set_exclusive(false);
+}
+
+void TaskDialog::_notification(int notification) {
     if (notification != NOTIFICATION_ENTER_TREE) { return; }
     scroll_container->set_custom_minimum_size(Size2 {600, 400} * EDSCALE);
-    add_child(scroll_container);
+    vertical_container->add_child(scroll_container);
 
     log_label->set_h_size_flags(Control::SizeFlags::SIZE_EXPAND_FILL);
     scroll_container->add_child(log_label);
+
+    progress_bar->set_editor_preview_indeterminate(true);
+    progress_bar->set_indeterminate(true);
+    vertical_container->add_child(progress_bar);
+
+    add_child(vertical_container);
 }
 
 #endif // TOOLS_ENABLED

--- a/src/editor/dialog/build_dialog.cpp
+++ b/src/editor/dialog/build_dialog.cpp
@@ -16,11 +16,14 @@ void BuildDialog::set_scrollbar_at_bottom() {
     scroll_container->set_v_scroll(static_cast<int>(scroll_container->get_v_scroll_bar()->get_max()));
 }
 
-void BuildDialog::update_state(String log) {
-    log_label->set_text(log);
-    JVM_LOG_INFO(log);
-
+void BuildDialog::make_appear() {
+    log_label->set_text("");
     popup_centered();
+}
+
+void BuildDialog::update_state(String log) {
+    if (log.is_empty()) { return; }
+    log_label->set_text(log_label->get_text() + log);
 
     StringName signal = SNAME("draw");
     Callable callback = callable_mp(this, &BuildDialog::set_scrollbar_at_bottom);
@@ -39,4 +42,4 @@ void BuildDialog::_notification(int notification) {
     scroll_container->add_child(log_label);
 }
 
-#endif// TOOLS_ENABLED
+#endif // TOOLS_ENABLED

--- a/src/editor/dialog/build_dialog.h
+++ b/src/editor/dialog/build_dialog.h
@@ -17,6 +17,7 @@ public:
     BuildDialog();
 
     void set_scrollbar_at_bottom();
+    void make_appear();
     void update_state(String log);
     void _notification(int notification);
 };

--- a/src/editor/dialog/build_dialog.h
+++ b/src/editor/dialog/build_dialog.h
@@ -5,23 +5,27 @@
 #define GODOT_JVM_BUILD_DIALOG_H
 
 #include <scene/gui/dialogs.h>
+#include <scene/gui/progress_bar.h>
 #include <scene/gui/scroll_container.h>
 
-class BuildDialog : public AcceptDialog {
-    GDCLASS(BuildDialog, AcceptDialog)
+class TaskDialog : public AcceptDialog {
+    GDCLASS(TaskDialog, AcceptDialog)
 
     ScrollContainer* scroll_container;
     Label* log_label;
+    ProgressBar* progress_bar;
+    VBoxContainer* vertical_container;
 
 public:
-    BuildDialog();
+    TaskDialog();
 
     void set_scrollbar_at_bottom();
     void make_appear();
     void update_state(String log);
+    void stop();
     void _notification(int notification);
 };
 
-#endif// GODOT_JVM_BUILD_DIALOG_H
+#endif // GODOT_JVM_BUILD_DIALOG_H
 
-#endif// TOOLS_ENABLED
+#endif // TOOLS_ENABLED

--- a/src/editor/godot_kotlin_jvm_editor.h
+++ b/src/editor/godot_kotlin_jvm_editor.h
@@ -5,23 +5,29 @@
 
 #include "dialog/about_dialog.h"
 #include "dialog/build_dialog.h"
+#include "scene/gui/option_button.h"
+#include "scene/gui/separator.h"
 
 #include <editor/plugins/editor_plugin.h>
 
 class GodotKotlinJvmEditor : public EditorPlugin {
     GDCLASS(GodotKotlinJvmEditor, EditorPlugin)
-    friend class GradleTaskManager;
+    friend class GradleTaskRunner;
 
-    enum KOTLIN_JVM_MENU_OPTIONS{
+    enum KOTLIN_JVM_MENU_OPTIONS {
         GENERATE_PROJECT,
         ABOUT
     };
 
     PopupMenu* about_pop_menu;
     AboutDialog* about_dialog;
-    BuildDialog* task_dialog;
+    TaskDialog* task_dialog;
+
     AcceptDialog* project_dialog;
-    Button* tool_bar_build_button;
+
+    VSeparator* separator;
+    Button* tool_bar_gradle_task_button;
+    OptionButton* tool_bar_gradle_task_choice;
 
     GodotKotlinJvmEditor();
     ~GodotKotlinJvmEditor();
@@ -39,9 +45,8 @@ public:
 
     GodotKotlinJvmEditor(const GodotKotlinJvmEditor&) = delete;
     void _notification(int notification);
-
 };
 
-#endif// GODOT_JVM_GODOT_KOTLIN_JVM_EDITOR_H
+#endif // GODOT_JVM_GODOT_KOTLIN_JVM_EDITOR_H
 
-#endif// TOOLS_ENABLED
+#endif // TOOLS_ENABLED

--- a/src/editor/godot_kotlin_jvm_editor.h
+++ b/src/editor/godot_kotlin_jvm_editor.h
@@ -10,7 +10,7 @@
 
 class GodotKotlinJvmEditor : public EditorPlugin {
     GDCLASS(GodotKotlinJvmEditor, EditorPlugin)
-    friend class BuildManager;
+    friend class GradleTaskManager;
 
     enum KOTLIN_JVM_MENU_OPTIONS{
         GENERATE_PROJECT,
@@ -19,17 +19,16 @@ class GodotKotlinJvmEditor : public EditorPlugin {
 
     PopupMenu* about_pop_menu;
     AboutDialog* about_dialog;
-    BuildDialog* build_dialog;
+    BuildDialog* task_dialog;
     AcceptDialog* project_dialog;
     Button* tool_bar_build_button;
 
     GodotKotlinJvmEditor();
     ~GodotKotlinJvmEditor();
 
-    void on_build_project_pressed();
+    void on_gradle_task_pressed();
     void on_menu_option_pressed(int option_id);
     void on_generate_project(bool erase_existing);
-    void on_build_finished();
     void on_filesystem_change();
 
 protected:
@@ -39,9 +38,7 @@ public:
     static GodotKotlinJvmEditor* get_instance();
 
     GodotKotlinJvmEditor(const GodotKotlinJvmEditor&) = delete;
-
     void _notification(int notification);
-    void update_build_dialog(String log);
 
 };
 

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -241,7 +241,7 @@ bool GDKotlin::load_bootstrap() {
 #endif
 
         if (!FileAccess::exists(bootstrap_jar)) {
-            if (Engine::get_singleton()->is_project_manager_hint()) {
+            if (Engine::get_singleton()->is_editor_hint()) {
                 // Most likely when starting a new project, there is no need to log it as an error or warning as long as the users doesn't run the game.
                 // We already have node warning if they try to attach a JVM script without building.
                 return false;


### PR DESCRIPTION
The build task was only displaying something when the entire task was done running.
I added streaming to it so you can see what is happening in case the task takes a while. On top of that, I added a small animation to show that there is activity.
You also have now a selector to pick which task you want to run.

So far, only 3 options are present:
- Regular build (debug by default)
- Release build
- Generate Embedded JRE.

I also fixed a small bug, the editor was still complaining about the lack of bootstrap (if the project hasn't been built once yet).
It was an error I made in the PR removing the editor bootstrap, I only wanted to display an error if the game itself was launched without bootstrap, but I used the project manager hint instead of the editor hint.


https://github.com/user-attachments/assets/7ecd8f41-1df7-4bed-9b18-07592390fa2f



