### PR TITLE
Remove explicit registration entry copy as it creates a duplicate entry

### DIFF
--- a/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageMainDexJarTask.kt
+++ b/kt/plugins/godot-gradle-plugin/src/main/kotlin/godot/gradle/tasks/android/packageMainDexJarTask.kt
@@ -16,7 +16,6 @@ fun Project.packageMainDexJarTask(
 
             archiveBaseName.set("main-dex")
 
-            from("src/main/resources").include("**/godot.registration.Entry")
             // add all dex files (converted class files)
             from("${project.layout.buildDirectory.asFile.get().absolutePath}/libs/").include("*.dex")
 


### PR DESCRIPTION
This fixes an issue introduced with #814

As we now copy all resources, we created duplicate entries for the registration service file, which caused issues on android exports where the jar could not be loaded because of duplicate jar entries (the service file)