### PR TITLE
Add support for jniLibs

### DIFF
--- a/src/gd_kotlin.h
+++ b/src/gd_kotlin.h
@@ -55,6 +55,10 @@ private:
     static String get_path_to_native_image();
 #endif
 
+#ifdef __ANDROID__
+    static Vector<String> get_res_files_recursively(const String &path);
+#endif
+
     bool load_bootstrap();
     void unload_boostrap();
 

--- a/src/kotlin_editor_export_plugin.h
+++ b/src/kotlin_editor_export_plugin.h
@@ -21,6 +21,7 @@ public:
 private:
     void _generate_export_configuration_file(jni::JvmType vm_type);
     void _add_exclude_filter_preset();
+    static Vector<String> _get_files_recursively(const String& path);
 };
 
 #endif// GODOT_JVM_KOTLINEDITOREXPORTPLUGIN_H

--- a/src/lifecycle/paths.h
+++ b/src/lifecycle/paths.h
@@ -4,6 +4,8 @@
 // Needs this as a macro if we want to append it to all other paths.
 #define JVM_DIRECTORY "jvm/"
 
+# define JNI_LIBS_BASE_DIR "android/jniLibs"
+
 static constexpr const char* USER_DIRECTORY {"user://"};
 static constexpr const char* RES_DIRECTORY {"res://"};
 
@@ -84,6 +86,18 @@ static constexpr const char* BOOTSTRAP_FILE {ANDROID_BOOTSTRAP_FILE};
 static constexpr const char* USER_CODE_FILE {ANDROID_USER_CODE_FILE};
 static constexpr const char* GRAAL_NATIVE_IMAGE_FILE {ANDROID_GRAAL_NATIVE_IMAGE_FILE};
 static constexpr const char* RELATIVE_JVM_LIB_PATH {ANDROID_RELATIVE_JVM_LIB_PATH};
+
+#ifdef __aarch64__
+static constexpr const char* JNI_LIBS_PATH {JVM_DIRECTORY JNI_LIBS_BASE_DIR "/" "arm64-v8a"};
+#elif defined(__arm__)
+static constexpr const char* JNI_LIBS_PATH {JVM_DIRECTORY JNI_LIBS_BASE_DIR "/" "armeabi"};
+#elif defined(__x86_64__)
+static constexpr const char* JNI_LIBS_PATH {JVM_DIRECTORY JNI_LIBS_BASE_DIR "/" "x86_64"};
+#elif defined(__i386__)
+static constexpr const char* JNI_LIBS_PATH {JVM_DIRECTORY JNI_LIBS_BASE_DIR "/" "x86"};
+#else
+#error "Unsupported architecture"
+#endif
 
 #elif IOS_ENABLED
 


### PR DESCRIPTION
Some libraries and user code require to load jni libs (dynamic libraries).

Our own [DexClassLoader](https://developer.android.com/reference/dalvik/system/DexClassLoader) has had only access to system libraries. Hence, any libraries one might want to bundle with the code, could not be used.

This PR makes use of the parameter `librarySearchPath` of the constructor from `DexClassLoader` and thus provides the `DexClassLoader` the ability to properly link the libraries.

An example of a library requiring such a case: https://github.com/xerial/sqlite-jdbc/blob/master/USAGE.md#how-to-use-with-android

In a plain android project, one would add the libraries to a jniLibs dir and the AGP plugin would bundle these with the apk.
But even if one, adds such libraries by hand using godot's gradle build, our classloader would not have access to it. For this, it's parent class loader would need to be the godot app class loader to which we do not have access from inside the cpp code.

Hence this PR provides a dir `jvm/android/jniLibs` to which a user can add all libraries which should be shipped with the app. And that folder is then passed in as a possible path for jniLibs to be loaded from for our `DexClassLoader`.

This PR is already in a working state but remains a draft for the following reasons:
- CPP code needs to be refined
- dir location needs to be defined
- general concept of the feature and whether and how we want to support it, needs to be discussed further