### PR TITLE
Add CallableX and MethodCallableX classes

### DIFF
--- a/harness/tests/src/main/kotlin/godot/tests/callable/CallableMethodBindTest.kt
+++ b/harness/tests/src/main/kotlin/godot/tests/callable/CallableMethodBindTest.kt
@@ -4,9 +4,12 @@ import godot.api.Node
 import godot.annotation.RegisterClass
 import godot.annotation.RegisterFunction
 import godot.annotation.RegisterProperty
-import godot.core.MethodCallable
+import godot.core.Callable0
+import godot.core.Callable1
+import godot.core.Callable2
+import godot.core.Callable3
 import godot.core.VariantArray
-import godot.core.toGodotName
+import godot.core.callable3
 import godot.core.variantArrayOf
 import godot.global.GD
 
@@ -17,22 +20,28 @@ class CallableMethodBindTest: Node() {
 
     @RegisterFunction
     fun callWithMethodWithAllBinds() {
-        MethodCallable(this, CallableMethodBindTest::readySignalMethodBindTest.toGodotName()).bindUnsafe(1, 2, 3).callUnsafe()
+        val unboundCallable: Callable3<Unit, Int, Int, Int> = callable3(CallableMethodBindTest::readySignalMethodBindTest)
+        val boundCallable: Callable0<Unit> = unboundCallable.bind(1, 2, 3)
+        boundCallable.call()
     }
 
     @RegisterFunction
     fun callWithMethodWithTwoBinds() {
-        MethodCallable(this, CallableMethodBindTest::readySignalMethodBindTest.toGodotName()).bindUnsafe(2, 3).callUnsafe(0)
+        val unboundCallable: Callable3<Unit, Int, Int, Int> = callable3(CallableMethodBindTest::readySignalMethodBindTest)
+        val boundCallable: Callable1<Unit, Int> = unboundCallable.bind(5, 6)
+        boundCallable.call(4)
     }
 
     @RegisterFunction
     fun callWithMethodWithOneBind() {
-        MethodCallable(this, CallableMethodBindTest::readySignalMethodBindTest.toGodotName()).bindUnsafe(3).callUnsafe(0, 0)
+        val unboundCallable: Callable3<Unit, Int, Int, Int> = callable3(CallableMethodBindTest::readySignalMethodBindTest)
+        val boundCallable: Callable2<Unit, Int, Int> = unboundCallable.bind(9)
+        boundCallable.call(7, 8)
     }
 
     @RegisterFunction
     fun callWithMethodWithNoBind() {
-        MethodCallable(this, CallableMethodBindTest::readySignalMethodBindTest.toGodotName()).bindUnsafe().callUnsafe(0, 0, 0)
+        callable3(CallableMethodBindTest::readySignalMethodBindTest).call(10, 11, 12)
     }
 
     @RegisterFunction

--- a/harness/tests/test/unit/test_callable_method_bind.gd
+++ b/harness/tests/test/unit/test_callable_method_bind.gd
@@ -26,17 +26,17 @@ func test_method_bind_passing_correct_binds_with_one_args_provided() -> void:
 	binds_test_script.call_with_method_with_two_binds()
 	assert_eq(
 		binds_test_script.method_binds[0],
-		0,
+		4,
 		"Incorrect bind value passed"
 	)
 	assert_eq(
 		binds_test_script.method_binds[1],
-		2,
+		5,
 		"Incorrect bind value passed"
 	)
 	assert_eq(
 		binds_test_script.method_binds[2],
-		3,
+		6,
 		"Incorrect bind value passed"
 	)
 	binds_test_script.free()
@@ -46,17 +46,17 @@ func test_method_bind_passing_correct_binds_with_two_args_provided() -> void:
 	binds_test_script.call_with_method_with_one_bind()
 	assert_eq(
 		binds_test_script.method_binds[0],
-		0,
+		7,
 		"Incorrect bind value passed"
 	)
 	assert_eq(
 		binds_test_script.method_binds[1],
-		0,
+		8,
 		"Incorrect bind value passed"
 	)
 	assert_eq(
 		binds_test_script.method_binds[2],
-		3,
+		9,
 		"Incorrect bind value passed"
 	)
 	binds_test_script.free()
@@ -66,17 +66,17 @@ func test_method_bind_passing_correct_binds_with_three_args_provided() -> void:
 	binds_test_script.call_with_method_with_no_bind()
 	assert_eq(
 		binds_test_script.method_binds[0],
-		0,
+		10,
 		"Incorrect bind value passed"
 	)
 	assert_eq(
 		binds_test_script.method_binds[1],
-		0,
+		11,
 		"Incorrect bind value passed"
 	)
 	assert_eq(
 		binds_test_script.method_binds[2],
-		0,
+		12,
 		"Incorrect bind value passed"
 	)
 	binds_test_script.free()

--- a/kt/api-generator/src/main/kotlin/godot/codegen/services/impl/CallableGenerationService.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/services/impl/CallableGenerationService.kt
@@ -13,49 +13,63 @@ import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.TypeVariableName
+import com.squareup.kotlinpoet.asClassName
 import godot.codegen.poet.GenericClassNameInfo
 import godot.codegen.services.ICallableGenerationService
 import godot.common.constants.Constraints
+import godot.tools.common.constants.GODOT_METHOD_CALLABLE
+import godot.tools.common.constants.GODOT_OBJECT
 import godot.tools.common.constants.GodotFunctions
 import godot.tools.common.constants.GodotKotlinJvmTypes
+import godot.tools.common.constants.STRING_NAME
+import godot.tools.common.constants.TO_GODOT_NAME_UTIL_FUNCTION
 import godot.tools.common.constants.VARIANT_PARSER_NIL
 import godot.tools.common.constants.godotCorePackage
 import godot.tools.common.constants.godotInteropPackage
 import java.io.File
+import kotlin.reflect.KCallable
 
 
 object CallableGenerationService : ICallableGenerationService {
     private const val CALLABLE_NAME = "Callable"
     private const val LAMBDA_CALLABLE_NAME = "LambdaCallable"
     private const val LAMBDA_CONTAINER_NAME = "LambdaContainer"
+    private const val METHOD_CALLABLE_NAME = "MethodCallable"
 
     private const val FUNCTION_PARAMETER_NAME = "function"
     private const val CONTAINER_ARGUMENT_NAME = "container"
+    private const val TARGET_ARGUMENT_NAME = "target"
+    private const val METHOD_NAME_ARGUMENT_NAME = "methodName"
     private const val BOUND_ARGS_ARGUMENT_NAME = "boundArgs"
     private const val CALLABLE_FUNCTION_NAME = "callable"
     private const val VARIANT_TYPE_RETURN_NAME = "returnConverter"
     private const val VARIANT_TYPE_ARGUMENT_NAME = "typeConverters"
 
+    private val CALLABLE_CLASS_NAME = ClassName(godotCorePackage, CALLABLE_NAME)
     private val LAMBDA_CALLABLE_CLASS_NAME = ClassName(godotCorePackage, LAMBDA_CALLABLE_NAME)
     private val LAMBDA_CONTAINER_CLASS_NAME = ClassName(godotCorePackage, LAMBDA_CONTAINER_NAME)
-    private val CALLABLE_CLASS_NAME = ClassName(godotCorePackage, CALLABLE_NAME)
+    private val METHOD_CALLABLE_CLASS_NAME = ClassName(godotCorePackage, METHOD_CALLABLE_NAME)
+
     private val returnTypeParameter = TypeVariableName("R", ANY.copy(nullable = true))
     private val variantConverterClassName = ClassName(godotInteropPackage, GodotKotlinJvmTypes.variantConverter)
 
     override fun generate(outputDir: File) {
-        val lambdaFileSpec = FileSpec.builder(godotCorePackage, "LambdaCallables")
-        val containerFileSpec = FileSpec.builder(godotCorePackage, "LambdaContainers")
-        val callableFileSpec = FileSpec.builder(godotCorePackage, "Callables")
+        val callableFileSpec = FileSpec.builder(godotCorePackage, CALLABLE_NAME + "s")
+        val lambdaFileSpec = FileSpec.builder(godotCorePackage, LAMBDA_CALLABLE_NAME + "s")
+        val containerFileSpec = FileSpec.builder(godotCorePackage, LAMBDA_CONTAINER_NAME + "s")
+        val methodFileSpec = FileSpec.builder(godotCorePackage, METHOD_CALLABLE_NAME + "s")
 
         for (argCount in 0..Constraints.MAX_FUNCTION_ARG_COUNT) {
 
+            val callableClassName = ClassName(godotCorePackage, "$CALLABLE_NAME$argCount")
             val lambdaContainerClassName = ClassName(godotCorePackage, "$LAMBDA_CONTAINER_NAME$argCount")
             val lambdaCallableClassName = ClassName(godotCorePackage, "$LAMBDA_CALLABLE_NAME$argCount")
-            val callableClassName = ClassName(godotCorePackage, "$CALLABLE_NAME$argCount")
+            val methodCallableClassName = ClassName(godotCorePackage, "$METHOD_CALLABLE_NAME$argCount")
 
+            val callableInfo = GenericClassNameInfo(callableClassName, argCount)
             val containerInfo = GenericClassNameInfo(lambdaContainerClassName, argCount)
             val lambdaInfo = GenericClassNameInfo(lambdaCallableClassName, argCount)
-            val callableInfo = GenericClassNameInfo(callableClassName, argCount)
+            val methodCallableInfo = GenericClassNameInfo(methodCallableClassName, argCount)
 
             val genericParameters = containerInfo.genericTypes
             val lambdaTypeName = lambdaInfo.toLambdaTypeName(returnType = returnTypeParameter)
@@ -207,14 +221,58 @@ object CallableGenerationService : ICallableGenerationService {
                         .addAnnotation(PublishedApi::class)
                         .build()
                 )
-                .addSuperclassConstructorParameter(CONTAINER_ARGUMENT_NAME, BOUND_ARGS_ARGUMENT_NAME)
+                .addSuperclassConstructorParameter(CONTAINER_ARGUMENT_NAME)
+                .addSuperclassConstructorParameter(BOUND_ARGS_ARGUMENT_NAME)
 
+            val methodCallableClassBuilder = TypeSpec
+                .classBuilder(methodCallableClassName)
+                .superclass(METHOD_CALLABLE_CLASS_NAME)
+                .addSuperinterface(callableClassName.parameterizedBy(listOf(returnTypeParameter) + genericParameters))
+                .addTypeVariable(returnTypeParameter)
+                .addTypeVariables(genericParameters)
+                .primaryConstructor(
+                    FunSpec
+                        .constructorBuilder()
+                        .addModifiers(KModifier.INTERNAL)
+                        .addParameter(
+                            ParameterSpec
+                                .builder(
+                                    TARGET_ARGUMENT_NAME,
+                                    GODOT_OBJECT
+                                )
+                                .build()
+                        )
+                        .addParameter(
+                            ParameterSpec
+                                .builder(
+                                    METHOD_NAME_ARGUMENT_NAME,
+                                    STRING_NAME
+                                )
+                                .build()
+                        )
+                        .addParameter(
+                            ParameterSpec
+                                .builder(
+                                    BOUND_ARGS_ARGUMENT_NAME,
+                                    ARRAY.parameterizedBy(ANY.copy(nullable = true))
+                                )
+                                .defaultValue("emptyArray()")
+                                .build()
+                        )
+                        .addAnnotation(PublishedApi::class)
+                        .build()
+                )
+                .addSuperclassConstructorParameter(TARGET_ARGUMENT_NAME)
+                .addSuperclassConstructorParameter(METHOD_NAME_ARGUMENT_NAME)
+                .addSuperclassConstructorParameter(BOUND_ARGS_ARGUMENT_NAME)
 
             val typeVariables = genericParameters.toMutableList()
             var remainingParameters = 0
             while (typeVariables.isNotEmpty()) {
-                val boundLambdaCallableClassName = ClassName(godotCorePackage, "$LAMBDA_CALLABLE_NAME${remainingParameters}")
                 val boundCallableClassName = ClassName(godotCorePackage, "$CALLABLE_NAME${remainingParameters}")
+                val boundLambdaCallableClassName = ClassName(godotCorePackage, "$LAMBDA_CALLABLE_NAME${remainingParameters}")
+                val boundMethodCallableClassName = ClassName(godotCorePackage, "$METHOD_CALLABLE_NAME${remainingParameters}")
+
                 val bindInfo = GenericClassNameInfo(boundLambdaCallableClassName, remainingParameters)
 
                 callableClassBuilder.addFunction(
@@ -241,16 +299,41 @@ object CallableGenerationService : ICallableGenerationService {
                         )
                         .addCode(
                             buildString {
-                                append("return·%T($CONTAINER_ARGUMENT_NAME, arrayOf(")
+                                append("return·%T($CONTAINER_ARGUMENT_NAME, arrayOf<Any?>(")
 
                                 for (index in (0..<typeVariables.size)) {
                                     if (index != 0) append(",·")
                                     append("p${index + remainingParameters}")
                                 }
 
-                                append("))")
+                                append(", *$BOUND_ARGS_ARGUMENT_NAME))")
                             },
                             boundLambdaCallableClassName.parameterizedBy(listOf(returnTypeParameter) + bindInfo.genericTypes),
+                        )
+                        .build()
+                )
+
+                methodCallableClassBuilder.addFunction(
+                    FunSpec.builder("bind")
+                        .addModifiers(KModifier.OVERRIDE)
+                        .addParameters(
+                            typeVariables.mapIndexed { index: Int, typeVariableName: TypeVariableName ->
+                                ParameterSpec.builder("p${index + remainingParameters}", typeVariableName)
+                                    .build()
+                            }
+                        )
+                        .addCode(
+                            buildString {
+                                append("return·%T($TARGET_ARGUMENT_NAME, $METHOD_NAME_ARGUMENT_NAME, arrayOf<Any?>(")
+
+                                for (index in (0..<typeVariables.size)) {
+                                    if (index != 0) append(",·")
+                                    append("p${index + remainingParameters}")
+                                }
+
+                                append(", *$BOUND_ARGS_ARGUMENT_NAME))")
+                            },
+                            boundMethodCallableClassName.parameterizedBy(listOf(returnTypeParameter) + bindInfo.genericTypes),
                         )
                         .build()
                 )
@@ -259,15 +342,17 @@ object CallableGenerationService : ICallableGenerationService {
                 ++remainingParameters
             }
 
+            callableFileSpec.addType(callableClassBuilder.build())
             containerFileSpec.addType(lambdaContainerClassBuilder.build())
             lambdaFileSpec.addType(lambdaCallableClassBuilder.build())
-            callableFileSpec.addType(callableClassBuilder.build())
+            methodFileSpec.addType(methodCallableClassBuilder.build())
+
 
             val variantMapperMember = MemberName(godotCorePackage, "variantMapper")
             lambdaFileSpec.addFunction(
                 FunSpec.builder(CALLABLE_FUNCTION_NAME + argCount)
-                    .addTypeVariables(genericParameters.map { it.copy(reified = true) })
                     .addTypeVariable(returnTypeParameter.copy(reified = true))
+                    .addTypeVariables(genericParameters.map { it.copy(reified = true) })
                     .addModifiers(KModifier.INLINE)
                     .addParameters(
                         listOf(
@@ -293,8 +378,8 @@ object CallableGenerationService : ICallableGenerationService {
                                 append(FUNCTION_PARAMETER_NAME)
                                 append("))")
                             },
-                            lambdaInfo.className.parameterizedBy(listOf(returnTypeParameter) + lambdaInfo.genericTypes),
-                            containerInfo.className.parameterizedBy(listOf(returnTypeParameter) + containerInfo.genericTypes),
+                            lambdaInfo.className.parameterizedBy(listOf(returnTypeParameter) + genericParameters),
+                            containerInfo.className.parameterizedBy(listOf(returnTypeParameter) + genericParameters),
                             variantMapperMember,
                             returnTypeParameter,
                             VARIANT_PARSER_NIL,
@@ -312,16 +397,45 @@ object CallableGenerationService : ICallableGenerationService {
                 .addFunction(
                     FunSpec
                         .builder(GodotFunctions.asCallable)
-                        .addTypeVariables(genericParameters.map { it.copy(reified = true) })
                         .addTypeVariable(returnTypeParameter.copy(reified = true))
+                        .addTypeVariables(genericParameters.map { it.copy(reified = true) })
                         .addModifiers(KModifier.INLINE)
                         .receiver(lambdaTypeName)
                         .addCode("return·$CALLABLE_FUNCTION_NAME$argCount(this)")
                         .build()
                 )
+
+            val objectGeneric = TypeVariableName("T", GODOT_OBJECT)
+            methodFileSpec
+                .addFunction(
+                    FunSpec.builder(CALLABLE_FUNCTION_NAME + argCount)
+                        .addTypeVariable(objectGeneric)
+                        .addTypeVariable(returnTypeParameter)
+                        .addTypeVariables(genericParameters)
+                        .receiver(objectGeneric)
+                        .addParameters(
+                            listOf(
+                                ParameterSpec
+                                    .builder(
+                                        CALLABLE_FUNCTION_NAME,
+                                        methodCallableInfo.toLambdaTypeName(returnType =returnTypeParameter, receiver = objectGeneric)
+                                    )
+                                    .build()
+                            )
+                        )
+                        .addCode(
+                            CodeBlock.of(
+                                "return·%T(this,·($CALLABLE_FUNCTION_NAME·as·%T<R>).name.%M())",
+                                methodCallableClassName.parameterizedBy(listOf(returnTypeParameter) + genericParameters),
+                                KCallable::class.asClassName(),
+                                TO_GODOT_NAME_UTIL_FUNCTION,
+                            )
+                        )
+                        .build()
+                )
         }
 
-        lambdaFileSpec
+        callableFileSpec
             .addAnnotation(
                 AnnotationSpec
                     .builder(ClassName("kotlin", "Suppress"))
@@ -343,7 +457,18 @@ object CallableGenerationService : ICallableGenerationService {
             .build()
             .writeTo(outputDir)
 
-        callableFileSpec
+        lambdaFileSpec
+            .addAnnotation(
+                AnnotationSpec
+                    .builder(ClassName("kotlin", "Suppress"))
+                    .addMember("\"PackageDirectoryMismatch\", \"UNCHECKED_CAST\"")
+                    .addMember("\"unused\"")
+                    .build()
+            )
+            .build()
+            .writeTo(outputDir)
+
+        methodFileSpec
             .addAnnotation(
                 AnnotationSpec
                     .builder(ClassName("kotlin", "Suppress"))

--- a/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/Callables.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/Callables.kt
@@ -1,0 +1,1740 @@
+@file:Suppress(
+  "PackageDirectoryMismatch", "UNCHECKED_CAST",
+  "unused",
+)
+
+package godot.core
+
+import kotlin.Suppress
+
+public interface Callable0<R> : Callable {
+  public fun call(): R = callUnsafe() as R
+
+  public fun callDeferred() = callDeferredUnsafe()
+
+  public operator fun invoke(): R = call()
+}
+
+public interface Callable1<R, P0> : Callable {
+  public fun call(p0: P0): R = callUnsafe(p0) as R
+
+  public fun callDeferred(p0: P0) = callDeferredUnsafe(p0)
+
+  public operator fun invoke(p0: P0): R = call(p0)
+
+  public fun bind(p0: P0): Callable0<R>
+}
+
+public interface Callable2<R, P0, P1> : Callable {
+  public fun call(p0: P0, p1: P1): R = callUnsafe(p0, p1) as R
+
+  public fun callDeferred(p0: P0, p1: P1) = callDeferredUnsafe(p0, p1)
+
+  public operator fun invoke(p0: P0, p1: P1): R = call(p0, p1)
+
+  public fun bind(p0: P0, p1: P1): Callable0<R>
+
+  public fun bind(p1: P1): Callable1<R, P0>
+}
+
+public interface Callable3<R, P0, P1, P2> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+  ): R = callUnsafe(p0, p1, p2) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+  ) = callDeferredUnsafe(p0, p1, p2)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+  ): R = call(p0, p1, p2)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+  ): Callable0<R>
+
+  public fun bind(p1: P1, p2: P2): Callable1<R, P0>
+
+  public fun bind(p2: P2): Callable2<R, P0, P1>
+}
+
+public interface Callable4<R, P0, P1, P2, P3> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+  ): R = callUnsafe(p0, p1, p2, p3) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+  ) = callDeferredUnsafe(p0, p1, p2, p3)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+  ): R = call(p0, p1, p2, p3)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+  ): Callable1<R, P0>
+
+  public fun bind(p2: P2, p3: P3): Callable2<R, P0, P1>
+
+  public fun bind(p3: P3): Callable3<R, P0, P1, P2>
+}
+
+public interface Callable5<R, P0, P1, P2, P3, P4> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ): R = callUnsafe(p0, p1, p2, p3, p4) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ): R = call(p0, p1, p2, p3, p4)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(p3: P3, p4: P4): Callable3<R, P0, P1, P2>
+
+  public fun bind(p4: P4): Callable4<R, P0, P1, P2, P3>
+}
+
+public interface Callable6<R, P0, P1, P2, P3, P4, P5> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ): R = call(p0, p1, p2, p3, p4, p5)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(p4: P4, p5: P5): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(p5: P5): Callable5<R, P0, P1, P2, P3, P4>
+}
+
+public interface Callable7<R, P0, P1, P2, P3, P4, P5, P6> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(p5: P5, p6: P6): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(p6: P6): Callable6<R, P0, P1, P2, P3, P4, P5>
+}
+
+public interface Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6, p7) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(p6: P6, p7: P7): Callable6<R, P0, P1, P2, P3, P4, P5>
+
+  public fun bind(p7: P7): Callable7<R, P0, P1, P2, P3, P4, P5, P6>
+}
+
+public interface Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ): Callable6<R, P0, P1, P2, P3, P4, P5>
+
+  public fun bind(p7: P7, p8: P8): Callable7<R, P0, P1, P2, P3, P4, P5, P6>
+
+  public fun bind(p8: P8): Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7>
+}
+
+public interface Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): Callable6<R, P0, P1, P2, P3, P4, P5>
+
+  public fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ): Callable7<R, P0, P1, P2, P3, P4, P5, P6>
+
+  public fun bind(p8: P8, p9: P9): Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7>
+
+  public fun bind(p9: P9): Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>
+}
+
+public interface Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): Callable6<R, P0, P1, P2, P3, P4, P5>
+
+  public fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): Callable7<R, P0, P1, P2, P3, P4, P5, P6>
+
+  public fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ): Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7>
+
+  public fun bind(p9: P9, p10: P10): Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>
+
+  public fun bind(p10: P10): Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>
+}
+
+public interface Callable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable6<R, P0, P1, P2, P3, P4, P5>
+
+  public fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable7<R, P0, P1, P2, P3, P4, P5, P6>
+
+  public fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7>
+
+  public fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ): Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>
+
+  public fun bind(p10: P10, p11: P11): Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>
+
+  public fun bind(p11: P11): Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>
+}
+
+public interface Callable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable6<R, P0, P1, P2, P3, P4, P5>
+
+  public fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable7<R, P0, P1, P2, P3, P4, P5, P6>
+
+  public fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7>
+
+  public fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>
+
+  public fun bind(
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ): Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>
+
+  public fun bind(p11: P11, p12: P12): Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>
+
+  public fun bind(p12: P12): Callable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>
+}
+
+public interface Callable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> :
+    Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable6<R, P0, P1, P2, P3, P4, P5>
+
+  public fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable7<R, P0, P1, P2, P3, P4, P5, P6>
+
+  public fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7>
+
+  public fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>
+
+  public fun bind(
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>
+
+  public fun bind(
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ): Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>
+
+  public fun bind(p12: P12, p13: P13):
+      Callable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>
+
+  public fun bind(p13: P13): Callable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>
+}
+
+public interface Callable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> :
+    Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable6<R, P0, P1, P2, P3, P4, P5>
+
+  public fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable7<R, P0, P1, P2, P3, P4, P5, P6>
+
+  public fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7>
+
+  public fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>
+
+  public fun bind(
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>
+
+  public fun bind(
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>
+
+  public fun bind(
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ): Callable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>
+
+  public fun bind(p13: P13, p14: P14):
+      Callable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>
+
+  public fun bind(p14: P14):
+      Callable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>
+}
+
+public interface Callable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
+    : Callable {
+  public fun call(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): R = callUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) as R
+
+  public fun callDeferred(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
+
+  public operator fun invoke(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
+
+  public fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable0<R>
+
+  public fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable1<R, P0>
+
+  public fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable2<R, P0, P1>
+
+  public fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable3<R, P0, P1, P2>
+
+  public fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable4<R, P0, P1, P2, P3>
+
+  public fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable5<R, P0, P1, P2, P3, P4>
+
+  public fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable6<R, P0, P1, P2, P3, P4, P5>
+
+  public fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable7<R, P0, P1, P2, P3, P4, P5, P6>
+
+  public fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7>
+
+  public fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>
+
+  public fun bind(
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>
+
+  public fun bind(
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>
+
+  public fun bind(
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>
+
+  public fun bind(
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ): Callable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>
+
+  public fun bind(p14: P14, p15: P15):
+      Callable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>
+
+  public fun bind(p15: P15):
+      Callable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>
+}

--- a/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/LambdaCallables.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/LambdaCallables.kt
@@ -14,7 +14,7 @@ import kotlin.Suppress
 public class LambdaCallable0<R> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable0<R>
+) : LambdaCallable<R>(container, boundArgs), Callable0<R>
 
 public inline fun <reified R> callable0(noinline function: () -> R) =
     LambdaCallable0<R>(LambdaContainer0<R>(variantMapper.getOrDefault(R::class, NIL), arrayOf(), function))
@@ -24,54 +24,58 @@ public inline fun <reified R> (() -> R).asCallable() = callable0(this)
 public class LambdaCallable1<R, P0> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable1<R, P0> {
-  public override fun bind(p0: P0) = LambdaCallable0<R>(container, arrayOf(p0))
+) : LambdaCallable<R>(container, boundArgs), Callable1<R, P0> {
+  public override fun bind(p0: P0) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, *boundArgs))
 }
 
-public inline fun <reified P0, reified R> callable1(noinline function: (p0: P0) -> R) =
+public inline fun <reified R, reified P0> callable1(noinline function: (p0: P0) -> R) =
     LambdaCallable1<R, P0>(LambdaContainer1<R, P0>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!), function))
 
-public inline fun <reified P0, reified R> ((p0: P0) -> R).asCallable() = callable1(this)
+public inline fun <reified R, reified P0> ((p0: P0) -> R).asCallable() = callable1(this)
 
 public class LambdaCallable2<R, P0, P1> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable2<R, P0, P1> {
-  public override fun bind(p0: P0, p1: P1) = LambdaCallable0<R>(container, arrayOf(p0, p1))
+) : LambdaCallable<R>(container, boundArgs), Callable2<R, P0, P1> {
+  public override fun bind(p0: P0, p1: P1) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1,
+      *boundArgs))
 
-  public override fun bind(p1: P1) = LambdaCallable1<R, P0>(container, arrayOf(p1))
+  public override fun bind(p1: P1) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1,
+      *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified R> callable2(noinline function: (p0: P0,
+public inline fun <reified R, reified P0, reified P1> callable2(noinline function: (p0: P0,
     p1: P1) -> R) =
     LambdaCallable2<R, P0, P1>(LambdaContainer2<R, P0, P1>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified R> ((p0: P0, p1: P1) -> R).asCallable() =
+public inline fun <reified R, reified P0, reified P1> ((p0: P0, p1: P1) -> R).asCallable() =
     callable2(this)
 
 public class LambdaCallable3<R, P0, P1, P2> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable3<R, P0, P1, P2> {
+) : LambdaCallable<R>(container, boundArgs), Callable3<R, P0, P1, P2> {
   public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, *boundArgs))
 
-  public override fun bind(p1: P1, p2: P2) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2))
+  public override fun bind(p1: P1, p2: P2) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2,
+      *boundArgs))
 
-  public override fun bind(p2: P2) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2))
+  public override fun bind(p2: P2) = LambdaCallable2<R, P0, P1>(container, arrayOf<Any?>(p2,
+      *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified R> callable3(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2> callable3(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
 ) -> R) =
     LambdaCallable3<R, P0, P1, P2>(LambdaContainer3<R, P0, P1, P2>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -80,26 +84,28 @@ public inline fun <reified P0, reified P1, reified P2, reified R> ((
 public class LambdaCallable4<R, P0, P1, P2, P3> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable4<R, P0, P1, P2, P3> {
+) : LambdaCallable<R>(container, boundArgs), Callable4<R, P0, P1, P2, P3> {
   public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
     p3: P3,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, p3, *boundArgs))
 
   public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3))
+  ) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2, p3, *boundArgs))
 
-  public override fun bind(p2: P2, p3: P3) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3))
+  public override fun bind(p2: P2, p3: P3) = LambdaCallable2<R, P0, P1>(container,
+      arrayOf<Any?>(p2, p3, *boundArgs))
 
-  public override fun bind(p3: P3) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3))
+  public override fun bind(p3: P3) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf<Any?>(p3,
+      *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified R> callable4(noinline
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3> callable4(noinline
     function: (
   p0: P0,
   p1: P1,
@@ -108,7 +114,7 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified R> ca
 ) -> R) =
     LambdaCallable4<R, P0, P1, P2, P3>(LambdaContainer4<R, P0, P1, P2, P3>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -118,35 +124,36 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified R> ((
 public class LambdaCallable5<R, P0, P1, P2, P3, P4> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable5<R, P0, P1, P2, P3, P4> {
+) : LambdaCallable<R>(container, boundArgs), Callable5<R, P0, P1, P2, P3, P4> {
   public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
     p3: P3,
     p4: P4,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, p3, p4, *boundArgs))
 
   public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
     p4: P4,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4))
+  ) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2, p3, p4, *boundArgs))
 
   public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
-  ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4))
+  ) = LambdaCallable2<R, P0, P1>(container, arrayOf<Any?>(p2, p3, p4, *boundArgs))
 
   public override fun bind(p3: P3, p4: P4) = LambdaCallable3<R, P0, P1, P2>(container,
-      arrayOf(p3, p4))
+      arrayOf<Any?>(p3, p4, *boundArgs))
 
-  public override fun bind(p4: P4) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4))
+  public override fun bind(p4: P4) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf<Any?>(p4,
+      *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified R>
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4>
     callable5(noinline function: (
   p0: P0,
   p1: P1,
@@ -156,7 +163,7 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable5<R, P0, P1, P2, P3, P4>(LambdaContainer5<R, P0, P1, P2, P3, P4>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -167,7 +174,7 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 public class LambdaCallable6<R, P0, P1, P2, P3, P4, P5> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable6<R, P0, P1, P2, P3, P4, P5> {
+) : LambdaCallable<R>(container, boundArgs), Callable6<R, P0, P1, P2, P3, P4, P5> {
   public override fun bind(
     p0: P0,
     p1: P1,
@@ -175,7 +182,7 @@ public class LambdaCallable6<R, P0, P1, P2, P3, P4, P5> @PublishedApi internal c
     p3: P3,
     p4: P4,
     p5: P5,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -183,29 +190,30 @@ public class LambdaCallable6<R, P0, P1, P2, P3, P4, P5> @PublishedApi internal c
     p3: P3,
     p4: P4,
     p5: P5,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5))
+  ) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2, p3, p4, p5, *boundArgs))
 
   public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
     p5: P5,
-  ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5))
+  ) = LambdaCallable2<R, P0, P1>(container, arrayOf<Any?>(p2, p3, p4, p5, *boundArgs))
 
   public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
-  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5))
+  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf<Any?>(p3, p4, p5, *boundArgs))
 
   public override fun bind(p4: P4, p5: P5) = LambdaCallable4<R, P0, P1, P2, P3>(container,
-      arrayOf(p4, p5))
+      arrayOf<Any?>(p4, p5, *boundArgs))
 
-  public override fun bind(p5: P5) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5))
+  public override fun bind(p5: P5) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
+      arrayOf<Any?>(p5, *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    R> callable6(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5> callable6(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -215,8 +223,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(LambdaContainer6<R, P0, P1, P2, P3, P4, P5>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -228,7 +236,7 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 public class LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable7<R, P0, P1, P2, P3, P4, P5, P6> {
+) : LambdaCallable<R>(container, boundArgs), Callable7<R, P0, P1, P2, P3, P4, P5, P6> {
   public override fun bind(
     p0: P0,
     p1: P1,
@@ -237,7 +245,7 @@ public class LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6> @PublishedApi intern
     p4: P4,
     p5: P5,
     p6: P6,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -246,7 +254,7 @@ public class LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6> @PublishedApi intern
     p4: P4,
     p5: P5,
     p6: P6,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6))
+  ) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -254,30 +262,30 @@ public class LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6> @PublishedApi intern
     p4: P4,
     p5: P5,
     p6: P6,
-  ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6))
+  ) = LambdaCallable2<R, P0, P1>(container, arrayOf<Any?>(p2, p3, p4, p5, p6, *boundArgs))
 
   public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
     p6: P6,
-  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6))
+  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf<Any?>(p3, p4, p5, p6, *boundArgs))
 
   public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
-  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6))
+  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf<Any?>(p4, p5, p6, *boundArgs))
 
   public override fun bind(p5: P5, p6: P6) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
-      arrayOf(p5, p6))
+      arrayOf<Any?>(p5, p6, *boundArgs))
 
   public override fun bind(p6: P6) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
-      arrayOf(p6))
+      arrayOf<Any?>(p6, *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified R> callable7(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6> callable7(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -288,8 +296,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(LambdaContainer7<R, P0, P1, P2, P3, P4, P5, P6>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -302,7 +310,7 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7> {
+) : LambdaCallable<R>(container, boundArgs), Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7> {
   public override fun bind(
     p0: P0,
     p1: P1,
@@ -312,7 +320,7 @@ public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi in
     p5: P5,
     p6: P6,
     p7: P7,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -322,7 +330,7 @@ public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi in
     p5: P5,
     p6: P6,
     p7: P7,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7))
+  ) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -331,7 +339,7 @@ public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi in
     p5: P5,
     p6: P6,
     p7: P7,
-  ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7))
+  ) = LambdaCallable2<R, P0, P1>(container, arrayOf<Any?>(p2, p3, p4, p5, p6, p7, *boundArgs))
 
   public override fun bind(
     p3: P3,
@@ -339,30 +347,30 @@ public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi in
     p5: P5,
     p6: P6,
     p7: P7,
-  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7))
+  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf<Any?>(p3, p4, p5, p6, p7, *boundArgs))
 
   public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
     p7: P7,
-  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7))
+  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf<Any?>(p4, p5, p6, p7, *boundArgs))
 
   public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
-  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7))
+  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf<Any?>(p5, p6, p7, *boundArgs))
 
   public override fun bind(p6: P6, p7: P7) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
-      arrayOf(p6, p7))
+      arrayOf<Any?>(p6, p7, *boundArgs))
 
   public override fun bind(p7: P7) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
-      arrayOf(p7))
+      arrayOf<Any?>(p7, *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified R> callable8(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7> callable8(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -374,8 +382,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(LambdaContainer8<R, P0, P1, P2, P3, P4, P5, P6, P7>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!, variantMapper[P7::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -390,7 +398,7 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> {
+) : LambdaCallable<R>(container, boundArgs), Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> {
   public override fun bind(
     p0: P0,
     p1: P1,
@@ -401,7 +409,7 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p6: P6,
     p7: P7,
     p8: P8,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -412,7 +420,7 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p6: P6,
     p7: P7,
     p8: P8,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8))
+  ) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -422,7 +430,7 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p6: P6,
     p7: P7,
     p8: P8,
-  ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8))
+  ) = LambdaCallable2<R, P0, P1>(container, arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, *boundArgs))
 
   public override fun bind(
     p3: P3,
@@ -431,7 +439,7 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p6: P6,
     p7: P7,
     p8: P8,
-  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8))
+  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf<Any?>(p3, p4, p5, p6, p7, p8, *boundArgs))
 
   public override fun bind(
     p4: P4,
@@ -439,30 +447,30 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p6: P6,
     p7: P7,
     p8: P8,
-  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8))
+  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf<Any?>(p4, p5, p6, p7, p8, *boundArgs))
 
   public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
     p8: P8,
-  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8))
+  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf<Any?>(p5, p6, p7, p8, *boundArgs))
 
   public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
-  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8))
+  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf<Any?>(p6, p7, p8, *boundArgs))
 
   public override fun bind(p7: P7, p8: P8) =
-      LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8))
+      LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf<Any?>(p7, p8, *boundArgs))
 
   public override fun bind(p8: P8) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
-      arrayOf(p8))
+      arrayOf<Any?>(p8, *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified R> callable9(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8> callable9(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -475,8 +483,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(LambdaContainer9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!, variantMapper[P7::class]!!, variantMapper[P8::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -492,7 +500,7 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> {
+) : LambdaCallable<R>(container, boundArgs), Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> {
   public override fun bind(
     p0: P0,
     p1: P1,
@@ -504,7 +512,8 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p7: P7,
     p8: P8,
     p9: P9,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9,
+      *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -516,7 +525,8 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p7: P7,
     p8: P8,
     p9: P9,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9))
+  ) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9,
+      *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -527,7 +537,8 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p7: P7,
     p8: P8,
     p9: P9,
-  ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8, p9))
+  ) = LambdaCallable2<R, P0, P1>(container, arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9,
+      *boundArgs))
 
   public override fun bind(
     p3: P3,
@@ -537,7 +548,8 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p7: P7,
     p8: P8,
     p9: P9,
-  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8, p9))
+  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9,
+      *boundArgs))
 
   public override fun bind(
     p4: P4,
@@ -546,7 +558,8 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p7: P7,
     p8: P8,
     p9: P9,
-  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8, p9))
+  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf<Any?>(p4, p5, p6, p7, p8, p9,
+      *boundArgs))
 
   public override fun bind(
     p5: P5,
@@ -554,30 +567,35 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p7: P7,
     p8: P8,
     p9: P9,
-  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8, p9))
+  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf<Any?>(p5, p6, p7, p8, p9,
+      *boundArgs))
 
   public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
     p9: P9,
-  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8, p9))
+  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf<Any?>(p6, p7, p8, p9,
+      *boundArgs))
 
   public override fun bind(
     p7: P7,
     p8: P8,
     p9: P9,
-  ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8, p9))
+  ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf<Any?>(p7, p8, p9,
+      *boundArgs))
 
   public override fun bind(p8: P8, p9: P9) =
-      LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf(p8, p9))
+      LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf<Any?>(p8, p9,
+      *boundArgs))
 
   public override fun bind(p9: P9) =
-      LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf(p9))
+      LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf<Any?>(p9,
+      *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified R> callable10(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9> callable10(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -591,8 +609,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(LambdaContainer10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!, variantMapper[P7::class]!!, variantMapper[P8::class]!!, variantMapper[P9::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -609,7 +627,8 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> {
+) : LambdaCallable<R>(container, boundArgs),
+    Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> {
   public override fun bind(
     p0: P0,
     p1: P1,
@@ -622,7 +641,8 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p8: P8,
     p9: P9,
     p10: P10,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10,
+      *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -635,7 +655,8 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p8: P8,
     p9: P9,
     p10: P10,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10))
+  ) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10,
+      *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -647,7 +668,8 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p8: P8,
     p9: P9,
     p10: P10,
-  ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10))
+  ) = LambdaCallable2<R, P0, P1>(container, arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10,
+      *boundArgs))
 
   public override fun bind(
     p3: P3,
@@ -658,7 +680,8 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p8: P8,
     p9: P9,
     p10: P10,
-  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8, p9, p10))
+  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10,
+      *boundArgs))
 
   public override fun bind(
     p4: P4,
@@ -668,7 +691,8 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p8: P8,
     p9: P9,
     p10: P10,
-  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8, p9, p10))
+  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10,
+      *boundArgs))
 
   public override fun bind(
     p5: P5,
@@ -677,7 +701,8 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p8: P8,
     p9: P9,
     p10: P10,
-  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8, p9, p10))
+  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf<Any?>(p5, p6, p7, p8, p9, p10,
+      *boundArgs))
 
   public override fun bind(
     p6: P6,
@@ -685,30 +710,35 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p8: P8,
     p9: P9,
     p10: P10,
-  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8, p9, p10))
+  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf<Any?>(p6, p7, p8, p9, p10,
+      *boundArgs))
 
   public override fun bind(
     p7: P7,
     p8: P8,
     p9: P9,
     p10: P10,
-  ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8, p9, p10))
+  ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf<Any?>(p7, p8, p9, p10,
+      *boundArgs))
 
   public override fun bind(
     p8: P8,
     p9: P9,
     p10: P10,
-  ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf(p8, p9, p10))
+  ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf<Any?>(p8, p9, p10,
+      *boundArgs))
 
   public override fun bind(p9: P9, p10: P10) =
-      LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf(p9, p10))
+      LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf<Any?>(p9, p10,
+      *boundArgs))
 
   public override fun bind(p10: P10) =
-      LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container, arrayOf(p10))
+      LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container, arrayOf<Any?>(p10,
+      *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified R> callable11(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10> callable11(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -723,8 +753,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(LambdaContainer11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!, variantMapper[P7::class]!!, variantMapper[P8::class]!!, variantMapper[P9::class]!!, variantMapper[P10::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -742,7 +772,8 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container), Callable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> {
+) : LambdaCallable<R>(container, boundArgs),
+    Callable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> {
   public override fun bind(
     p0: P0,
     p1: P1,
@@ -756,7 +787,8 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11))
+  ) = LambdaCallable0<R>(container, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -770,7 +802,8 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11))
+  ) = LambdaCallable1<R, P0>(container, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -783,7 +816,8 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11))
+  ) = LambdaCallable2<R, P0, P1>(container, arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(
     p3: P3,
@@ -795,7 +829,8 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11))
+  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(
     p4: P4,
@@ -806,7 +841,8 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8, p9, p10, p11))
+  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(
     p5: P5,
@@ -816,7 +852,8 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8, p9, p10, p11))
+  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(
     p6: P6,
@@ -825,7 +862,8 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8, p9, p10, p11))
+  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf<Any?>(p6, p7, p8, p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(
     p7: P7,
@@ -833,31 +871,36 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8, p9, p10, p11))
+  ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf<Any?>(p7, p8, p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(
     p8: P8,
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf(p8, p9, p10, p11))
+  ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf<Any?>(p8, p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(
     p9: P9,
     p10: P10,
     p11: P11,
-  ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf(p9, p10, p11))
+  ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf<Any?>(p9, p10, p11,
+      *boundArgs))
 
   public override fun bind(p10: P10, p11: P11) =
-      LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container, arrayOf(p10, p11))
+      LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container, arrayOf<Any?>(p10, p11,
+      *boundArgs))
 
   public override fun bind(p11: P11) =
-      LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container, arrayOf(p11))
+      LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container, arrayOf<Any?>(p11,
+      *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified R> callable12(noinline
-    function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11>
+    callable12(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -873,8 +916,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(LambdaContainer12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!, variantMapper[P7::class]!!, variantMapper[P8::class]!!, variantMapper[P9::class]!!, variantMapper[P10::class]!!, variantMapper[P11::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -893,7 +936,7 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container),
+) : LambdaCallable<R>(container, boundArgs),
     Callable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> {
   public override fun bind(
     p0: P0,
@@ -909,7 +952,8 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12))
+  ) = LambdaCallable0<R>(container,
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -924,7 +968,8 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12))
+  ) = LambdaCallable1<R, P0>(container,
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -938,7 +983,8 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12))
+  ) = LambdaCallable2<R, P0, P1>(container,
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p3: P3,
@@ -951,7 +997,8 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12))
+  ) = LambdaCallable3<R, P0, P1, P2>(container,
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p4: P4,
@@ -963,7 +1010,8 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8, p9, p10, p11, p12))
+  ) = LambdaCallable4<R, P0, P1, P2, P3>(container,
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p5: P5,
@@ -974,7 +1022,8 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8, p9, p10, p11, p12))
+  ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p6: P6,
@@ -984,7 +1033,8 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8, p9, p10, p11, p12))
+  ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
+      arrayOf<Any?>(p6, p7, p8, p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p7: P7,
@@ -993,7 +1043,8 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8, p9, p10, p11, p12))
+  ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
+      arrayOf<Any?>(p7, p8, p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p8: P8,
@@ -1001,30 +1052,35 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf(p8, p9, p10, p11, p12))
+  ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
+      arrayOf<Any?>(p8, p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p9: P9,
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf(p9, p10, p11, p12))
+  ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container,
+      arrayOf<Any?>(p9, p10, p11, p12, *boundArgs))
 
   public override fun bind(
     p10: P10,
     p11: P11,
     p12: P12,
-  ) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container, arrayOf(p10, p11, p12))
+  ) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container,
+      arrayOf<Any?>(p10, p11, p12, *boundArgs))
 
   public override fun bind(p11: P11, p12: P12) =
-      LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container, arrayOf(p11, p12))
+      LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container,
+      arrayOf<Any?>(p11, p12, *boundArgs))
 
   public override fun bind(p12: P12) =
-      LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(container, arrayOf(p12))
+      LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(container,
+      arrayOf<Any?>(p12, *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12, reified R>
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12>
     callable13(noinline function: (
   p0: P0,
   p1: P1,
@@ -1042,8 +1098,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(LambdaContainer13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!, variantMapper[P7::class]!!, variantMapper[P8::class]!!, variantMapper[P9::class]!!, variantMapper[P10::class]!!, variantMapper[P11::class]!!, variantMapper[P12::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -1063,7 +1119,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container),
+) : LambdaCallable<R>(container, boundArgs),
     Callable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> {
   public override fun bind(
     p0: P0,
@@ -1081,7 +1137,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable0<R>(container,
-      arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -1098,7 +1154,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable1<R, P0>(container,
-      arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -1114,7 +1170,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable2<R, P0, P1>(container,
-      arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p3: P3,
@@ -1129,7 +1185,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable3<R, P0, P1, P2>(container,
-      arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p4: P4,
@@ -1143,7 +1199,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container,
-      arrayOf(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p5: P5,
@@ -1156,7 +1212,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
-      arrayOf(p5, p6, p7, p8, p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p6: P6,
@@ -1168,7 +1224,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
-      arrayOf(p6, p7, p8, p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p7: P7,
@@ -1179,7 +1235,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
-      arrayOf(p7, p8, p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p7, p8, p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p8: P8,
@@ -1189,7 +1245,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
-      arrayOf(p8, p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p8, p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p9: P9,
@@ -1198,7 +1254,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container,
-      arrayOf(p9, p10, p11, p12, p13))
+      arrayOf<Any?>(p9, p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p10: P10,
@@ -1206,27 +1262,27 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
     p13: P13,
   ) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container,
-      arrayOf(p10, p11, p12, p13))
+      arrayOf<Any?>(p10, p11, p12, p13, *boundArgs))
 
   public override fun bind(
     p11: P11,
     p12: P12,
     p13: P13,
   ) = LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container,
-      arrayOf(p11, p12, p13))
+      arrayOf<Any?>(p11, p12, p13, *boundArgs))
 
   public override fun bind(p12: P12, p13: P13) =
       LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(container,
-      arrayOf(p12, p13))
+      arrayOf<Any?>(p12, p13, *boundArgs))
 
   public override fun bind(p13: P13) =
       LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(container,
-      arrayOf(p13))
+      arrayOf<Any?>(p13, *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12, reified P13,
-    reified R> callable14(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12,
+    reified P13> callable14(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -1244,9 +1300,9 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(LambdaContainer14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!, variantMapper[P7::class]!!, variantMapper[P8::class]!!, variantMapper[P9::class]!!, variantMapper[P10::class]!!, variantMapper[P11::class]!!, variantMapper[P12::class]!!, variantMapper[P13::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12, reified P13,
-    reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12,
+    reified P13> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -1267,7 +1323,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container),
+) : LambdaCallable<R>(container, boundArgs),
     Callable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> {
   public override fun bind(
     p0: P0,
@@ -1286,7 +1342,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable0<R>(container,
-      arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -1304,7 +1360,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable1<R, P0>(container,
-      arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -1321,7 +1377,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable2<R, P0, P1>(container,
-      arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p3: P3,
@@ -1337,7 +1393,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable3<R, P0, P1, P2>(container,
-      arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p4: P4,
@@ -1352,7 +1408,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container,
-      arrayOf(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p5: P5,
@@ -1366,7 +1422,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
-      arrayOf(p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p6: P6,
@@ -1379,7 +1435,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
-      arrayOf(p6, p7, p8, p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p7: P7,
@@ -1391,7 +1447,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
-      arrayOf(p7, p8, p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p8: P8,
@@ -1402,7 +1458,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
-      arrayOf(p8, p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p8, p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p9: P9,
@@ -1412,7 +1468,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container,
-      arrayOf(p9, p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p9, p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p10: P10,
@@ -1421,7 +1477,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container,
-      arrayOf(p10, p11, p12, p13, p14))
+      arrayOf<Any?>(p10, p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p11: P11,
@@ -1429,27 +1485,27 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p13: P13,
     p14: P14,
   ) = LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container,
-      arrayOf(p11, p12, p13, p14))
+      arrayOf<Any?>(p11, p12, p13, p14, *boundArgs))
 
   public override fun bind(
     p12: P12,
     p13: P13,
     p14: P14,
   ) = LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(container,
-      arrayOf(p12, p13, p14))
+      arrayOf<Any?>(p12, p13, p14, *boundArgs))
 
   public override fun bind(p13: P13, p14: P14) =
       LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(container,
-      arrayOf(p13, p14))
+      arrayOf<Any?>(p13, p14, *boundArgs))
 
   public override fun bind(p14: P14) =
       LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(container,
-      arrayOf(p14))
+      arrayOf<Any?>(p14, *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12, reified P13,
-    reified P14, reified R> callable15(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12,
+    reified P13, reified P14> callable15(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -1468,9 +1524,9 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>(LambdaContainer15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!, variantMapper[P7::class]!!, variantMapper[P8::class]!!, variantMapper[P9::class]!!, variantMapper[P10::class]!!, variantMapper[P11::class]!!, variantMapper[P12::class]!!, variantMapper[P13::class]!!, variantMapper[P14::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12, reified P13,
-    reified P14, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12,
+    reified P13, reified P14> ((
   p0: P0,
   p1: P1,
   p2: P2,
@@ -1492,7 +1548,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     P15> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container),
+) : LambdaCallable<R>(container, boundArgs),
     Callable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> {
   public override fun bind(
     p0: P0,
@@ -1512,7 +1568,8 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable0<R>(container,
-      arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15,
+      *boundArgs))
 
   public override fun bind(
     p1: P1,
@@ -1531,7 +1588,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable1<R, P0>(container,
-      arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p2: P2,
@@ -1549,7 +1606,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable2<R, P0, P1>(container,
-      arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p3: P3,
@@ -1566,7 +1623,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable3<R, P0, P1, P2>(container,
-      arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p4: P4,
@@ -1582,7 +1639,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container,
-      arrayOf(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p5: P5,
@@ -1597,7 +1654,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
-      arrayOf(p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p6: P6,
@@ -1611,7 +1668,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
-      arrayOf(p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p7: P7,
@@ -1624,7 +1681,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
-      arrayOf(p7, p8, p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p8: P8,
@@ -1636,7 +1693,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
-      arrayOf(p8, p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p9: P9,
@@ -1647,7 +1704,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container,
-      arrayOf(p9, p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p9, p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p10: P10,
@@ -1657,7 +1714,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container,
-      arrayOf(p10, p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p10, p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p11: P11,
@@ -1666,7 +1723,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container,
-      arrayOf(p11, p12, p13, p14, p15))
+      arrayOf<Any?>(p11, p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p12: P12,
@@ -1674,27 +1731,27 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p14: P14,
     p15: P15,
   ) = LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(container,
-      arrayOf(p12, p13, p14, p15))
+      arrayOf<Any?>(p12, p13, p14, p15, *boundArgs))
 
   public override fun bind(
     p13: P13,
     p14: P14,
     p15: P15,
   ) = LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(container,
-      arrayOf(p13, p14, p15))
+      arrayOf<Any?>(p13, p14, p15, *boundArgs))
 
   public override fun bind(p14: P14, p15: P15) =
       LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(container,
-      arrayOf(p14, p15))
+      arrayOf<Any?>(p14, p15, *boundArgs))
 
   public override fun bind(p15: P15) =
       LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>(container,
-      arrayOf(p15))
+      arrayOf<Any?>(p15, *boundArgs))
 }
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12, reified P13,
-    reified P14, reified P15, reified R> callable16(noinline function: (
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12,
+    reified P13, reified P14, reified P15> callable16(noinline function: (
   p0: P0,
   p1: P1,
   p2: P2,
@@ -1714,9 +1771,9 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 ) -> R) =
     LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>(LambdaContainer16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>(variantMapper.getOrDefault(R::class, NIL), arrayOf(variantMapper[P0::class]!!, variantMapper[P1::class]!!, variantMapper[P2::class]!!, variantMapper[P3::class]!!, variantMapper[P4::class]!!, variantMapper[P5::class]!!, variantMapper[P6::class]!!, variantMapper[P7::class]!!, variantMapper[P8::class]!!, variantMapper[P9::class]!!, variantMapper[P10::class]!!, variantMapper[P11::class]!!, variantMapper[P12::class]!!, variantMapper[P13::class]!!, variantMapper[P14::class]!!, variantMapper[P15::class]!!), function))
 
-public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
-    P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12, reified P13,
-    reified P14, reified P15, reified R> ((
+public inline fun <reified R, reified P0, reified P1, reified P2, reified P3, reified P4, reified
+    P5, reified P6, reified P7, reified P8, reified P9, reified P10, reified P11, reified P12,
+    reified P13, reified P14, reified P15> ((
   p0: P0,
   p1: P1,
   p2: P2,

--- a/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/LambdaCallables.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/LambdaCallables.kt
@@ -14,13 +14,7 @@ import kotlin.Suppress
 public class LambdaCallable0<R> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(): R = container.invokeUnsafe()
-
-  public fun callDeferred() = callDeferredUnsafe()
-
-  public operator fun invoke(): R = call()
-}
+) : LambdaCallable<R>(container), Callable0<R>
 
 public inline fun <reified R> callable0(noinline function: () -> R) =
     LambdaCallable0<R>(LambdaContainer0<R>(variantMapper.getOrDefault(R::class, NIL), arrayOf(), function))
@@ -30,14 +24,8 @@ public inline fun <reified R> (() -> R).asCallable() = callable0(this)
 public class LambdaCallable1<R, P0> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(p0: P0): R = container.invokeUnsafe(p0)
-
-  public fun callDeferred(p0: P0) = callDeferredUnsafe(p0)
-
-  public operator fun invoke(p0: P0): R = call(p0)
-
-  public fun bind(p0: P0) = LambdaCallable0<R>(container, arrayOf(p0))
+) : LambdaCallable<R>(container), Callable1<R, P0> {
+  public override fun bind(p0: P0) = LambdaCallable0<R>(container, arrayOf(p0))
 }
 
 public inline fun <reified P0, reified R> callable1(noinline function: (p0: P0) -> R) =
@@ -48,16 +36,10 @@ public inline fun <reified P0, reified R> ((p0: P0) -> R).asCallable() = callabl
 public class LambdaCallable2<R, P0, P1> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(p0: P0, p1: P1): R = container.invokeUnsafe(p0, p1)
+) : LambdaCallable<R>(container), Callable2<R, P0, P1> {
+  public override fun bind(p0: P0, p1: P1) = LambdaCallable0<R>(container, arrayOf(p0, p1))
 
-  public fun callDeferred(p0: P0, p1: P1) = callDeferredUnsafe(p0, p1)
-
-  public operator fun invoke(p0: P0, p1: P1): R = call(p0, p1)
-
-  public fun bind(p0: P0, p1: P1) = LambdaCallable0<R>(container, arrayOf(p0, p1))
-
-  public fun bind(p1: P1) = LambdaCallable1<R, P0>(container, arrayOf(p1))
+  public override fun bind(p1: P1) = LambdaCallable1<R, P0>(container, arrayOf(p1))
 }
 
 public inline fun <reified P0, reified P1, reified R> callable2(noinline function: (p0: P0,
@@ -70,34 +52,16 @@ public inline fun <reified P0, reified P1, reified R> ((p0: P0, p1: P1) -> R).as
 public class LambdaCallable3<R, P0, P1, P2> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-  ): R = container.invokeUnsafe(p0, p1, p2)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-  ) = callDeferredUnsafe(p0, p1, p2)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-  ): R = call(p0, p1, p2)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable3<R, P0, P1, P2> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2))
 
-  public fun bind(p1: P1, p2: P2) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2))
+  public override fun bind(p1: P1, p2: P2) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2))
 
-  public fun bind(p2: P2) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2))
+  public override fun bind(p2: P2) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2))
 }
 
 public inline fun <reified P0, reified P1, reified P2, reified R> callable3(noinline function: (
@@ -116,44 +80,23 @@ public inline fun <reified P0, reified P1, reified P2, reified R> ((
 public class LambdaCallable4<R, P0, P1, P2, P3> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-  ) = callDeferredUnsafe(p0, p1, p2, p3)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-  ): R = call(p0, p1, p2, p3)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable4<R, P0, P1, P2, P3> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
     p3: P3,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3))
 
-  public fun bind(p2: P2, p3: P3) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3))
+  public override fun bind(p2: P2, p3: P3) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3))
 
-  public fun bind(p3: P3) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3))
+  public override fun bind(p3: P3) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3))
 }
 
 public inline fun <reified P0, reified P1, reified P2, reified P3, reified R> callable4(noinline
@@ -175,32 +118,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified R> ((
 public class LambdaCallable5<R, P0, P1, P2, P3, P4> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-  ): R = call(p0, p1, p2, p3, p4)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable5<R, P0, P1, P2, P3, P4> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -208,22 +127,23 @@ public class LambdaCallable5<R, P0, P1, P2, P3, P4> @PublishedApi internal const
     p4: P4,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
     p4: P4,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
   ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4))
 
-  public fun bind(p3: P3, p4: P4) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4))
+  public override fun bind(p3: P3, p4: P4) = LambdaCallable3<R, P0, P1, P2>(container,
+      arrayOf(p3, p4))
 
-  public fun bind(p4: P4) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4))
+  public override fun bind(p4: P4) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4))
 }
 
 public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified R>
@@ -247,35 +167,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 public class LambdaCallable6<R, P0, P1, P2, P3, P4, P5> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-  ): R = call(p0, p1, p2, p3, p4, p5)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable6<R, P0, P1, P2, P3, P4, P5> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -284,7 +177,7 @@ public class LambdaCallable6<R, P0, P1, P2, P3, P4, P5> @PublishedApi internal c
     p5: P5,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -292,22 +185,23 @@ public class LambdaCallable6<R, P0, P1, P2, P3, P4, P5> @PublishedApi internal c
     p5: P5,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
     p5: P5,
   ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
   ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5))
 
-  public fun bind(p4: P4, p5: P5) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5))
+  public override fun bind(p4: P4, p5: P5) = LambdaCallable4<R, P0, P1, P2, P3>(container,
+      arrayOf(p4, p5))
 
-  public fun bind(p5: P5) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5))
+  public override fun bind(p5: P5) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5))
 }
 
 public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
@@ -334,38 +228,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 public class LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable7<R, P0, P1, P2, P3, P4, P5, P6> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -375,7 +239,7 @@ public class LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6> @PublishedApi intern
     p6: P6,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -384,7 +248,7 @@ public class LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6> @PublishedApi intern
     p6: P6,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -392,23 +256,24 @@ public class LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6> @PublishedApi intern
     p6: P6,
   ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
     p6: P6,
   ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6))
 
-  public fun bind(p5: P5, p6: P6) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
+  public override fun bind(p5: P5, p6: P6) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
       arrayOf(p5, p6))
 
-  public fun bind(p6: P6) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6))
+  public override fun bind(p6: P6) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
+      arrayOf(p6))
 }
 
 public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
@@ -437,41 +302,8 @@ public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, r
 public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6, p7)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -482,7 +314,7 @@ public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi in
     p7: P7,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -492,7 +324,7 @@ public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi in
     p7: P7,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -501,7 +333,7 @@ public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi in
     p7: P7,
   ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
@@ -509,23 +341,24 @@ public class LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi in
     p7: P7,
   ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
     p7: P7,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7))
 
-  public fun bind(
+  public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7))
 
-  public fun bind(p6: P6, p7: P7) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
+  public override fun bind(p6: P6, p7: P7) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
       arrayOf(p6, p7))
 
-  public fun bind(p7: P7) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7))
+  public override fun bind(p7: P7) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
+      arrayOf(p7))
 }
 
 public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
@@ -557,44 +390,8 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -606,7 +403,7 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p8: P8,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -617,7 +414,7 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p8: P8,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -627,7 +424,7 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p8: P8,
   ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
@@ -636,7 +433,7 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p8: P8,
   ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
@@ -644,23 +441,23 @@ public class LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedAp
     p8: P8,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8))
 
-  public fun bind(
+  public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
     p8: P8,
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8))
 
-  public fun bind(
+  public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8))
 
-  public fun bind(p7: P7, p8: P8) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
-      arrayOf(p7, p8))
+  public override fun bind(p7: P7, p8: P8) =
+      LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8))
 
-  public fun bind(p8: P8) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
+  public override fun bind(p8: P8) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
       arrayOf(p8))
 }
 
@@ -695,47 +492,8 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -748,7 +506,7 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p9: P9,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -760,7 +518,7 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p9: P9,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -771,7 +529,7 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p9: P9,
   ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8, p9))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
@@ -781,7 +539,7 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p9: P9,
   ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8, p9))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
@@ -790,7 +548,7 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p9: P9,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8, p9))
 
-  public fun bind(
+  public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
@@ -798,24 +556,24 @@ public class LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @Publis
     p9: P9,
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8, p9))
 
-  public fun bind(
+  public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
     p9: P9,
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8, p9))
 
-  public fun bind(
+  public override fun bind(
     p7: P7,
     p8: P8,
     p9: P9,
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8, p9))
 
-  public fun bind(p8: P8, p9: P9) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
-      arrayOf(p8, p9))
+  public override fun bind(p8: P8, p9: P9) =
+      LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf(p8, p9))
 
-  public fun bind(p9: P9) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container,
-      arrayOf(p9))
+  public override fun bind(p9: P9) =
+      LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf(p9))
 }
 
 public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
@@ -851,50 +609,8 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -908,7 +624,7 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p10: P10,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -921,7 +637,7 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p10: P10,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -933,7 +649,7 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p10: P10,
   ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
@@ -944,7 +660,7 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p10: P10,
   ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8, p9, p10))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
@@ -954,7 +670,7 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p10: P10,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8, p9, p10))
 
-  public fun bind(
+  public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
@@ -963,7 +679,7 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p10: P10,
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8, p9, p10))
 
-  public fun bind(
+  public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
@@ -971,24 +687,24 @@ public class LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @P
     p10: P10,
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8, p9, p10))
 
-  public fun bind(
+  public override fun bind(
     p7: P7,
     p8: P8,
     p9: P9,
     p10: P10,
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8, p9, p10))
 
-  public fun bind(
+  public override fun bind(
     p8: P8,
     p9: P9,
     p10: P10,
   ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf(p8, p9, p10))
 
-  public fun bind(p9: P9, p10: P10) =
+  public override fun bind(p9: P9, p10: P10) =
       LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf(p9, p10))
 
-  public fun bind(p10: P10) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container,
-      arrayOf(p10))
+  public override fun bind(p10: P10) =
+      LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container, arrayOf(p10))
 }
 
 public inline fun <reified P0, reified P1, reified P2, reified P3, reified P4, reified P5, reified
@@ -1026,53 +742,8 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
-
-  public fun bind(
+) : LambdaCallable<R>(container), Callable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -1087,7 +758,7 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p11: P11,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -1101,7 +772,7 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p11: P11,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -1114,7 +785,7 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p11: P11,
   ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
@@ -1126,7 +797,7 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p11: P11,
   ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
@@ -1137,7 +808,7 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p11: P11,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8, p9, p10, p11))
 
-  public fun bind(
+  public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
@@ -1147,7 +818,7 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p11: P11,
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8, p9, p10, p11))
 
-  public fun bind(
+  public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
@@ -1156,7 +827,7 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p11: P11,
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8, p9, p10, p11))
 
-  public fun bind(
+  public override fun bind(
     p7: P7,
     p8: P8,
     p9: P9,
@@ -1164,23 +835,23 @@ public class LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p11: P11,
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8, p9, p10, p11))
 
-  public fun bind(
+  public override fun bind(
     p8: P8,
     p9: P9,
     p10: P10,
     p11: P11,
   ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf(p8, p9, p10, p11))
 
-  public fun bind(
+  public override fun bind(
     p9: P9,
     p10: P10,
     p11: P11,
   ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf(p9, p10, p11))
 
-  public fun bind(p10: P10, p11: P11) =
+  public override fun bind(p10: P10, p11: P11) =
       LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container, arrayOf(p10, p11))
 
-  public fun bind(p11: P11) =
+  public override fun bind(p11: P11) =
       LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container, arrayOf(p11))
 }
 
@@ -1222,56 +893,9 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
-
-  public fun bind(
+) : LambdaCallable<R>(container),
+    Callable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -1287,7 +911,7 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
   ) = LambdaCallable0<R>(container, arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -1302,7 +926,7 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
   ) = LambdaCallable1<R, P0>(container, arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -1316,7 +940,7 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
   ) = LambdaCallable2<R, P0, P1>(container, arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
@@ -1329,7 +953,7 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
   ) = LambdaCallable3<R, P0, P1, P2>(container, arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
@@ -1341,7 +965,7 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container, arrayOf(p4, p5, p6, p7, p8, p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
@@ -1352,7 +976,7 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container, arrayOf(p5, p6, p7, p8, p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
@@ -1362,7 +986,7 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container, arrayOf(p6, p7, p8, p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p7: P7,
     p8: P8,
     p9: P9,
@@ -1371,7 +995,7 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container, arrayOf(p7, p8, p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p8: P8,
     p9: P9,
     p10: P10,
@@ -1379,23 +1003,23 @@ public class LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     p12: P12,
   ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container, arrayOf(p8, p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p9: P9,
     p10: P10,
     p11: P11,
     p12: P12,
   ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container, arrayOf(p9, p10, p11, p12))
 
-  public fun bind(
+  public override fun bind(
     p10: P10,
     p11: P11,
     p12: P12,
   ) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container, arrayOf(p10, p11, p12))
 
-  public fun bind(p11: P11, p12: P12) =
+  public override fun bind(p11: P11, p12: P12) =
       LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container, arrayOf(p11, p12))
 
-  public fun bind(p12: P12) =
+  public override fun bind(p12: P12) =
       LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(container, arrayOf(p12))
 }
 
@@ -1439,59 +1063,9 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-    p13: P13,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-    p13: P13,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-    p13: P13,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
-
-  public fun bind(
+) : LambdaCallable<R>(container),
+    Callable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -1509,7 +1083,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable0<R>(container,
       arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -1526,7 +1100,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable1<R, P0>(container,
       arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -1542,7 +1116,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable2<R, P0, P1>(container,
       arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
@@ -1557,7 +1131,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable3<R, P0, P1, P2>(container,
       arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
@@ -1571,7 +1145,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container,
       arrayOf(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
@@ -1584,7 +1158,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
       arrayOf(p5, p6, p7, p8, p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
@@ -1596,7 +1170,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
       arrayOf(p6, p7, p8, p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p7: P7,
     p8: P8,
     p9: P9,
@@ -1607,7 +1181,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
       arrayOf(p7, p8, p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p8: P8,
     p9: P9,
     p10: P10,
@@ -1617,7 +1191,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
       arrayOf(p8, p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p9: P9,
     p10: P10,
     p11: P11,
@@ -1626,7 +1200,7 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container,
       arrayOf(p9, p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p10: P10,
     p11: P11,
     p12: P12,
@@ -1634,18 +1208,18 @@ public class LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container,
       arrayOf(p10, p11, p12, p13))
 
-  public fun bind(
+  public override fun bind(
     p11: P11,
     p12: P12,
     p13: P13,
   ) = LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container,
       arrayOf(p11, p12, p13))
 
-  public fun bind(p12: P12, p13: P13) =
+  public override fun bind(p12: P12, p13: P13) =
       LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(container,
       arrayOf(p12, p13))
 
-  public fun bind(p13: P13) =
+  public override fun bind(p13: P13) =
       LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(container,
       arrayOf(p13))
 }
@@ -1693,62 +1267,9 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-    p13: P13,
-    p14: P14,
-  ): R = container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-    p13: P13,
-    p14: P14,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-    p13: P13,
-    p14: P14,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
-
-  public fun bind(
+) : LambdaCallable<R>(container),
+    Callable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -1767,7 +1288,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable0<R>(container,
       arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -1785,7 +1306,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable1<R, P0>(container,
       arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -1802,7 +1323,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable2<R, P0, P1>(container,
       arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
@@ -1818,7 +1339,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable3<R, P0, P1, P2>(container,
       arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
@@ -1833,7 +1354,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container,
       arrayOf(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
@@ -1847,7 +1368,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
       arrayOf(p5, p6, p7, p8, p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
@@ -1860,7 +1381,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
       arrayOf(p6, p7, p8, p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p7: P7,
     p8: P8,
     p9: P9,
@@ -1872,7 +1393,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
       arrayOf(p7, p8, p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p8: P8,
     p9: P9,
     p10: P10,
@@ -1883,7 +1404,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
       arrayOf(p8, p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p9: P9,
     p10: P10,
     p11: P11,
@@ -1893,7 +1414,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container,
       arrayOf(p9, p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p10: P10,
     p11: P11,
     p12: P12,
@@ -1902,7 +1423,7 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container,
       arrayOf(p10, p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p11: P11,
     p12: P12,
     p13: P13,
@@ -1910,18 +1431,18 @@ public class LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container,
       arrayOf(p11, p12, p13, p14))
 
-  public fun bind(
+  public override fun bind(
     p12: P12,
     p13: P13,
     p14: P14,
   ) = LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(container,
       arrayOf(p12, p13, p14))
 
-  public fun bind(p13: P13, p14: P14) =
+  public override fun bind(p13: P13, p14: P14) =
       LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(container,
       arrayOf(p13, p14))
 
-  public fun bind(p14: P14) =
+  public override fun bind(p14: P14) =
       LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(container,
       arrayOf(p14))
 }
@@ -1971,66 +1492,9 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
     P15> @PublishedApi internal constructor(
   container: LambdaContainer<R>,
   boundArgs: Array<Any?> = emptyArray(),
-) : LambdaCallable<R>(container) {
-  public fun call(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-    p13: P13,
-    p14: P14,
-    p15: P15,
-  ): R =
-      container.invokeUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
-
-  public fun callDeferred(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-    p13: P13,
-    p14: P14,
-    p15: P15,
-  ) = callDeferredUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
-
-  public operator fun invoke(
-    p0: P0,
-    p1: P1,
-    p2: P2,
-    p3: P3,
-    p4: P4,
-    p5: P5,
-    p6: P6,
-    p7: P7,
-    p8: P8,
-    p9: P9,
-    p10: P10,
-    p11: P11,
-    p12: P12,
-    p13: P13,
-    p14: P14,
-    p15: P15,
-  ): R = call(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
-
-  public fun bind(
+) : LambdaCallable<R>(container),
+    Callable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> {
+  public override fun bind(
     p0: P0,
     p1: P1,
     p2: P2,
@@ -2050,7 +1514,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable0<R>(container,
       arrayOf(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p1: P1,
     p2: P2,
     p3: P3,
@@ -2069,7 +1533,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable1<R, P0>(container,
       arrayOf(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p2: P2,
     p3: P3,
     p4: P4,
@@ -2087,7 +1551,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable2<R, P0, P1>(container,
       arrayOf(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p3: P3,
     p4: P4,
     p5: P5,
@@ -2104,7 +1568,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable3<R, P0, P1, P2>(container,
       arrayOf(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p4: P4,
     p5: P5,
     p6: P6,
@@ -2120,7 +1584,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable4<R, P0, P1, P2, P3>(container,
       arrayOf(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p5: P5,
     p6: P6,
     p7: P7,
@@ -2135,7 +1599,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable5<R, P0, P1, P2, P3, P4>(container,
       arrayOf(p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p6: P6,
     p7: P7,
     p8: P8,
@@ -2149,7 +1613,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable6<R, P0, P1, P2, P3, P4, P5>(container,
       arrayOf(p6, p7, p8, p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p7: P7,
     p8: P8,
     p9: P9,
@@ -2162,7 +1626,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable7<R, P0, P1, P2, P3, P4, P5, P6>(container,
       arrayOf(p7, p8, p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p8: P8,
     p9: P9,
     p10: P10,
@@ -2174,7 +1638,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(container,
       arrayOf(p8, p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p9: P9,
     p10: P10,
     p11: P11,
@@ -2185,7 +1649,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(container,
       arrayOf(p9, p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p10: P10,
     p11: P11,
     p12: P12,
@@ -2195,7 +1659,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(container,
       arrayOf(p10, p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p11: P11,
     p12: P12,
     p13: P13,
@@ -2204,7 +1668,7 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(container,
       arrayOf(p11, p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p12: P12,
     p13: P13,
     p14: P14,
@@ -2212,18 +1676,18 @@ public class LambdaCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P1
   ) = LambdaCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(container,
       arrayOf(p12, p13, p14, p15))
 
-  public fun bind(
+  public override fun bind(
     p13: P13,
     p14: P14,
     p15: P15,
   ) = LambdaCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(container,
       arrayOf(p13, p14, p15))
 
-  public fun bind(p14: P14, p15: P15) =
+  public override fun bind(p14: P14, p15: P15) =
       LambdaCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(container,
       arrayOf(p14, p15))
 
-  public fun bind(p15: P15) =
+  public override fun bind(p15: P15) =
       LambdaCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>(container,
       arrayOf(p15))
 }

--- a/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/MethodCallables.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/MethodCallables.kt
@@ -1,0 +1,1614 @@
+@file:Suppress(
+  "PackageDirectoryMismatch", "UNCHECKED_CAST",
+  "unused",
+)
+
+package godot.core
+
+import godot.api.Object
+import kotlin.Any
+import kotlin.Array
+import kotlin.PublishedApi
+import kotlin.Suppress
+import kotlin.reflect.KCallable
+
+public class MethodCallable0<R> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable0<R>
+
+public fun <T : Object, R> T.callable0(callable: T.() -> R) =
+    MethodCallable0<R>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable1<R, P0> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable1<R, P0> {
+  public override fun bind(p0: P0) = MethodCallable0<R>(target, methodName, arrayOf<Any?>(p0,
+      *boundArgs))
+}
+
+public fun <T : Object, R, P0> T.callable1(callable: T.(p0: P0) -> R) =
+    MethodCallable1<R, P0>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable2<R, P0, P1> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable2<R, P0, P1> {
+  public override fun bind(p0: P0, p1: P1) = MethodCallable0<R>(target, methodName,
+      arrayOf<Any?>(p0, p1, *boundArgs))
+
+  public override fun bind(p1: P1) = MethodCallable1<R, P0>(target, methodName, arrayOf<Any?>(p1,
+      *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1> T.callable2(callable: T.(p0: P0, p1: P1) -> R) =
+    MethodCallable2<R, P0, P1>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable3<R, P0, P1, P2> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable3<R, P0, P1, P2> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+  ) = MethodCallable0<R>(target, methodName, arrayOf<Any?>(p0, p1, p2, *boundArgs))
+
+  public override fun bind(p1: P1, p2: P2) = MethodCallable1<R, P0>(target, methodName,
+      arrayOf<Any?>(p1, p2, *boundArgs))
+
+  public override fun bind(p2: P2) = MethodCallable2<R, P0, P1>(target, methodName,
+      arrayOf<Any?>(p2, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2> T.callable3(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+) -> R) = MethodCallable3<R, P0, P1, P2>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable4<R, P0, P1, P2, P3> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable4<R, P0, P1, P2, P3> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+  ) = MethodCallable0<R>(target, methodName, arrayOf<Any?>(p0, p1, p2, p3, *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+  ) = MethodCallable1<R, P0>(target, methodName, arrayOf<Any?>(p1, p2, p3, *boundArgs))
+
+  public override fun bind(p2: P2, p3: P3) = MethodCallable2<R, P0, P1>(target, methodName,
+      arrayOf<Any?>(p2, p3, *boundArgs))
+
+  public override fun bind(p3: P3) = MethodCallable3<R, P0, P1, P2>(target, methodName,
+      arrayOf<Any?>(p3, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3> T.callable4(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+) -> R) = MethodCallable4<R, P0, P1, P2, P3>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable5<R, P0, P1, P2, P3, P4> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable5<R, P0, P1, P2, P3, P4> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ) = MethodCallable0<R>(target, methodName, arrayOf<Any?>(p0, p1, p2, p3, p4, *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ) = MethodCallable1<R, P0>(target, methodName, arrayOf<Any?>(p1, p2, p3, p4, *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+  ) = MethodCallable2<R, P0, P1>(target, methodName, arrayOf<Any?>(p2, p3, p4, *boundArgs))
+
+  public override fun bind(p3: P3, p4: P4) = MethodCallable3<R, P0, P1, P2>(target, methodName,
+      arrayOf<Any?>(p3, p4, *boundArgs))
+
+  public override fun bind(p4: P4) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName,
+      arrayOf<Any?>(p4, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4> T.callable5(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+) -> R) =
+    MethodCallable5<R, P0, P1, P2, P3, P4>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable6<R, P0, P1, P2, P3, P4, P5> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable6<R, P0, P1, P2, P3, P4, P5> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ) = MethodCallable0<R>(target, methodName, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ) = MethodCallable1<R, P0>(target, methodName, arrayOf<Any?>(p1, p2, p3, p4, p5, *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ) = MethodCallable2<R, P0, P1>(target, methodName, arrayOf<Any?>(p2, p3, p4, p5, *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName, arrayOf<Any?>(p3, p4, p5, *boundArgs))
+
+  public override fun bind(p4: P4, p5: P5) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName,
+      arrayOf<Any?>(p4, p5, *boundArgs))
+
+  public override fun bind(p5: P5) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName,
+      arrayOf<Any?>(p5, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5> T.callable6(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+) -> R) =
+    MethodCallable6<R, P0, P1, P2, P3, P4, P5>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable7<R, P0, P1, P2, P3, P4, P5, P6> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ) = MethodCallable0<R>(target, methodName, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ) = MethodCallable1<R, P0>(target, methodName, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ) = MethodCallable2<R, P0, P1>(target, methodName, arrayOf<Any?>(p2, p3, p4, p5, p6, *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName, arrayOf<Any?>(p3, p4, p5, p6, *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName, arrayOf<Any?>(p4, p5, p6, *boundArgs))
+
+  public override fun bind(p5: P5, p6: P6) = MethodCallable5<R, P0, P1, P2, P3, P4>(target,
+      methodName, arrayOf<Any?>(p5, p6, *boundArgs))
+
+  public override fun bind(p6: P6) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target, methodName,
+      arrayOf<Any?>(p6, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6> T.callable7(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+) -> R) =
+    MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable8<R, P0, P1, P2, P3, P4, P5, P6, P7> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ) = MethodCallable0<R>(target, methodName, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7,
+      *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ) = MethodCallable1<R, P0>(target, methodName, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7,
+      *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ) = MethodCallable2<R, P0, P1>(target, methodName, arrayOf<Any?>(p2, p3, p4, p5, p6, p7,
+      *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName, arrayOf<Any?>(p3, p4, p5, p6, p7,
+      *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName, arrayOf<Any?>(p4, p5, p6, p7,
+      *boundArgs))
+
+  public override fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+  ) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName, arrayOf<Any?>(p5, p6, p7,
+      *boundArgs))
+
+  public override fun bind(p6: P6, p7: P7) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target,
+      methodName, arrayOf<Any?>(p6, p7, *boundArgs))
+
+  public override fun bind(p7: P7) = MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(target,
+      methodName, arrayOf<Any?>(p7, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6, P7> T.callable8(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+  p7: P7,
+) -> R) =
+    MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedApi internal
+    constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs), Callable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>
+    {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ) = MethodCallable0<R>(target, methodName, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8,
+      *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ) = MethodCallable1<R, P0>(target, methodName, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8,
+      *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ) = MethodCallable2<R, P0, P1>(target, methodName, arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8,
+      *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName, arrayOf<Any?>(p3, p4, p5, p6, p7, p8,
+      *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName, arrayOf<Any?>(p4, p5, p6, p7, p8,
+      *boundArgs))
+
+  public override fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName, arrayOf<Any?>(p5, p6, p7, p8,
+      *boundArgs))
+
+  public override fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+  ) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target, methodName, arrayOf<Any?>(p6, p7, p8,
+      *boundArgs))
+
+  public override fun bind(p7: P7, p8: P8) = MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(target,
+      methodName, arrayOf<Any?>(p7, p8, *boundArgs))
+
+  public override fun bind(p8: P8) = MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(target,
+      methodName, arrayOf<Any?>(p8, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6, P7, P8> T.callable9(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+  p7: P7,
+  p8: P8,
+) -> R) =
+    MethodCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @PublishedApi internal
+    constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs),
+    Callable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ) = MethodCallable0<R>(target, methodName, arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9,
+      *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ) = MethodCallable1<R, P0>(target, methodName, arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9,
+      *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ) = MethodCallable2<R, P0, P1>(target, methodName, arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9,
+      *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName, arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9,
+      *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName, arrayOf<Any?>(p4, p5, p6, p7, p8, p9,
+      *boundArgs))
+
+  public override fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName, arrayOf<Any?>(p5, p6, p7, p8, p9,
+      *boundArgs))
+
+  public override fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target, methodName, arrayOf<Any?>(p6, p7, p8, p9,
+      *boundArgs))
+
+  public override fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+  ) = MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(target, methodName, arrayOf<Any?>(p7, p8, p9,
+      *boundArgs))
+
+  public override fun bind(p8: P8, p9: P9) =
+      MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(target, methodName, arrayOf<Any?>(p8, p9,
+      *boundArgs))
+
+  public override fun bind(p9: P9) = MethodCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(target,
+      methodName, arrayOf<Any?>(p9, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> T.callable10(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+  p7: P7,
+  p8: P8,
+  p9: P9,
+) -> R) =
+    MethodCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @PublishedApi internal
+    constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs),
+    Callable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = MethodCallable0<R>(target, methodName,
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = MethodCallable1<R, P0>(target, methodName,
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = MethodCallable2<R, P0, P1>(target, methodName,
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName,
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName,
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, *boundArgs))
+
+  public override fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName,
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, *boundArgs))
+
+  public override fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target, methodName,
+      arrayOf<Any?>(p6, p7, p8, p9, p10, *boundArgs))
+
+  public override fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(target, methodName,
+      arrayOf<Any?>(p7, p8, p9, p10, *boundArgs))
+
+  public override fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+  ) = MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(target, methodName,
+      arrayOf<Any?>(p8, p9, p10, *boundArgs))
+
+  public override fun bind(p9: P9, p10: P10) =
+      MethodCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(target, methodName,
+      arrayOf<Any?>(p9, p10, *boundArgs))
+
+  public override fun bind(p10: P10) =
+      MethodCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(target, methodName,
+      arrayOf<Any?>(p10, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> T.callable11(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+  p7: P7,
+  p8: P8,
+  p9: P9,
+  p10: P10,
+) -> R) =
+    MethodCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> @PublishedApi
+    internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs),
+    Callable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable0<R>(target, methodName,
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable1<R, P0>(target, methodName,
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable2<R, P0, P1>(target, methodName,
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName,
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11, *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName,
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11, *boundArgs))
+
+  public override fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName,
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11, *boundArgs))
+
+  public override fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target, methodName,
+      arrayOf<Any?>(p6, p7, p8, p9, p10, p11, *boundArgs))
+
+  public override fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(target, methodName,
+      arrayOf<Any?>(p7, p8, p9, p10, p11, *boundArgs))
+
+  public override fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(target, methodName,
+      arrayOf<Any?>(p8, p9, p10, p11, *boundArgs))
+
+  public override fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+  ) = MethodCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(target, methodName,
+      arrayOf<Any?>(p9, p10, p11, *boundArgs))
+
+  public override fun bind(p10: P10, p11: P11) =
+      MethodCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(target, methodName,
+      arrayOf<Any?>(p10, p11, *boundArgs))
+
+  public override fun bind(p11: P11) =
+      MethodCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(target, methodName,
+      arrayOf<Any?>(p11, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>
+    T.callable12(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+  p7: P7,
+  p8: P8,
+  p9: P9,
+  p10: P10,
+  p11: P11,
+) -> R) =
+    MethodCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>
+    @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs),
+    Callable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable0<R>(target, methodName,
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable1<R, P0>(target, methodName,
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable2<R, P0, P1>(target, methodName,
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName,
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName,
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName,
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target, methodName,
+      arrayOf<Any?>(p6, p7, p8, p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(target, methodName,
+      arrayOf<Any?>(p7, p8, p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(target, methodName,
+      arrayOf<Any?>(p8, p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(target, methodName,
+      arrayOf<Any?>(p9, p10, p11, p12, *boundArgs))
+
+  public override fun bind(
+    p10: P10,
+    p11: P11,
+    p12: P12,
+  ) = MethodCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(target, methodName,
+      arrayOf<Any?>(p10, p11, p12, *boundArgs))
+
+  public override fun bind(p11: P11, p12: P12) =
+      MethodCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(target, methodName,
+      arrayOf<Any?>(p11, p12, *boundArgs))
+
+  public override fun bind(p12: P12) =
+      MethodCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(target, methodName,
+      arrayOf<Any?>(p12, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>
+    T.callable13(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+  p7: P7,
+  p8: P8,
+  p9: P9,
+  p10: P10,
+  p11: P11,
+  p12: P12,
+) -> R) =
+    MethodCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>
+    @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs),
+    Callable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable0<R>(target, methodName,
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable1<R, P0>(target, methodName,
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable2<R, P0, P1>(target, methodName,
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName,
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName,
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName,
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target, methodName,
+      arrayOf<Any?>(p6, p7, p8, p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(target, methodName,
+      arrayOf<Any?>(p7, p8, p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(target, methodName,
+      arrayOf<Any?>(p8, p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(target, methodName,
+      arrayOf<Any?>(p9, p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(target, methodName,
+      arrayOf<Any?>(p10, p11, p12, p13, *boundArgs))
+
+  public override fun bind(
+    p11: P11,
+    p12: P12,
+    p13: P13,
+  ) = MethodCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(target, methodName,
+      arrayOf<Any?>(p11, p12, p13, *boundArgs))
+
+  public override fun bind(p12: P12, p13: P13) =
+      MethodCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(target, methodName,
+      arrayOf<Any?>(p12, p13, *boundArgs))
+
+  public override fun bind(p13: P13) =
+      MethodCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(target, methodName,
+      arrayOf<Any?>(p13, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>
+    T.callable14(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+  p7: P7,
+  p8: P8,
+  p9: P9,
+  p10: P10,
+  p11: P11,
+  p12: P12,
+  p13: P13,
+) -> R) =
+    MethodCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>
+    @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs),
+    Callable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable0<R>(target, methodName,
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable1<R, P0>(target, methodName,
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable2<R, P0, P1>(target, methodName,
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName,
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName,
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName,
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target, methodName,
+      arrayOf<Any?>(p6, p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(target, methodName,
+      arrayOf<Any?>(p7, p8, p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(target, methodName,
+      arrayOf<Any?>(p8, p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(target, methodName,
+      arrayOf<Any?>(p9, p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(target, methodName,
+      arrayOf<Any?>(p10, p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(target, methodName,
+      arrayOf<Any?>(p11, p12, p13, p14, *boundArgs))
+
+  public override fun bind(
+    p12: P12,
+    p13: P13,
+    p14: P14,
+  ) = MethodCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(target, methodName,
+      arrayOf<Any?>(p12, p13, p14, *boundArgs))
+
+  public override fun bind(p13: P13, p14: P14) =
+      MethodCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(target, methodName,
+      arrayOf<Any?>(p13, p14, *boundArgs))
+
+  public override fun bind(p14: P14) =
+      MethodCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(target,
+      methodName, arrayOf<Any?>(p14, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>
+    T.callable15(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+  p7: P7,
+  p8: P8,
+  p9: P9,
+  p10: P10,
+  p11: P11,
+  p12: P12,
+  p13: P13,
+  p14: P14,
+) -> R) =
+    MethodCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>(this, (callable as KCallable<R>).name.toGodotName())
+
+public class MethodCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14,
+    P15> @PublishedApi internal constructor(
+  target: Object,
+  methodName: StringName,
+  boundArgs: Array<Any?> = emptyArray(),
+) : MethodCallable(target, methodName, boundArgs),
+    Callable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> {
+  public override fun bind(
+    p0: P0,
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable0<R>(target, methodName,
+      arrayOf<Any?>(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15,
+      *boundArgs))
+
+  public override fun bind(
+    p1: P1,
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable1<R, P0>(target, methodName,
+      arrayOf<Any?>(p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p2: P2,
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable2<R, P0, P1>(target, methodName,
+      arrayOf<Any?>(p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p3: P3,
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable3<R, P0, P1, P2>(target, methodName,
+      arrayOf<Any?>(p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p4: P4,
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable4<R, P0, P1, P2, P3>(target, methodName,
+      arrayOf<Any?>(p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p5: P5,
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable5<R, P0, P1, P2, P3, P4>(target, methodName,
+      arrayOf<Any?>(p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p6: P6,
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable6<R, P0, P1, P2, P3, P4, P5>(target, methodName,
+      arrayOf<Any?>(p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p7: P7,
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable7<R, P0, P1, P2, P3, P4, P5, P6>(target, methodName,
+      arrayOf<Any?>(p7, p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p8: P8,
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable8<R, P0, P1, P2, P3, P4, P5, P6, P7>(target, methodName,
+      arrayOf<Any?>(p8, p9, p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p9: P9,
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable9<R, P0, P1, P2, P3, P4, P5, P6, P7, P8>(target, methodName,
+      arrayOf<Any?>(p9, p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p10: P10,
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable10<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(target, methodName,
+      arrayOf<Any?>(p10, p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p11: P11,
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable11<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(target, methodName,
+      arrayOf<Any?>(p11, p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p12: P12,
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable12<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(target, methodName,
+      arrayOf<Any?>(p12, p13, p14, p15, *boundArgs))
+
+  public override fun bind(
+    p13: P13,
+    p14: P14,
+    p15: P15,
+  ) = MethodCallable13<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(target, methodName,
+      arrayOf<Any?>(p13, p14, p15, *boundArgs))
+
+  public override fun bind(p14: P14, p15: P15) =
+      MethodCallable14<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(target,
+      methodName, arrayOf<Any?>(p14, p15, *boundArgs))
+
+  public override fun bind(p15: P15) =
+      MethodCallable15<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>(target,
+      methodName, arrayOf<Any?>(p15, *boundArgs))
+}
+
+public fun <T : Object, R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
+    T.callable16(callable: T.(
+  p0: P0,
+  p1: P1,
+  p2: P2,
+  p3: P3,
+  p4: P4,
+  p5: P5,
+  p6: P6,
+  p7: P7,
+  p8: P8,
+  p9: P9,
+  p10: P10,
+  p11: P11,
+  p12: P12,
+  p13: P13,
+  p14: P14,
+  p15: P15,
+) -> R) =
+    MethodCallable16<R, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>(this, (callable as KCallable<R>).name.toGodotName())

--- a/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/Signals.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/gen/godot/core/Signals.kt
@@ -18,10 +18,15 @@ import kotlin.reflect.KProperty
 
 public class Signal0 @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(): Unit {
         emitUnsafe()
+    }
+
+    public fun connect(connect: Callable0<*>, flags: Object.ConnectFlags =
+            Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
     }
 
     public companion object {
@@ -30,21 +35,26 @@ public class Signal0 @PublishedApi internal constructor(
                 ReadOnlyProperty { thisRef, property -> getValue(thisRef, property) }
 
         public inline operator fun getValue(thisRef: Object, `property`: KProperty<*>): Signal0 =
-                Signal0(thisRef, property.name)
+                Signal0(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
-public inline fun Object.Signal0(signalName: String) = Signal0(this, signalName)
+public inline fun Object.Signal0(signalName: String) = Signal0(this, signalName.toGodotName())
 
 public inline fun Object.signal0() = Signal0.delegate
 
 public class Signal1<P0> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(p0: P0): Unit {
         emitUnsafe(p0)
+    }
+
+    public fun connect(connect: Callable1<*, P0>, flags: Object.ConnectFlags =
+            Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
     }
 
     public companion object {
@@ -53,22 +63,28 @@ public class Signal1<P0> @PublishedApi internal constructor(
                 ReadOnlyProperty { thisRef, property -> getValue(thisRef, property) }
 
         public inline operator fun <P0> getValue(thisRef: Object, `property`: KProperty<*>):
-                Signal1<P0> = Signal1(thisRef, property.name)
+                Signal1<P0> = Signal1(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
-public inline fun <P0> Object.Signal1(signalName: String) = Signal1<P0>(this, signalName)
+public inline fun <P0> Object.Signal1(signalName: String) =
+        Signal1<P0>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0> Object.signal1() = Signal1.delegate as ReadOnlyProperty<Object, Signal1<P0>>
 
 public class Signal2<P0, P1> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(p0: P0, p1: P1): Unit {
         emitUnsafe(p0, p1)
+    }
+
+    public fun connect(connect: Callable2<*, P0, P1>, flags: Object.ConnectFlags =
+            Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
     }
 
     public companion object {
@@ -77,12 +93,13 @@ public class Signal2<P0, P1> @PublishedApi internal constructor(
                 ReadOnlyProperty { thisRef, property -> getValue(thisRef, property) }
 
         public inline operator fun <P0, P1> getValue(thisRef: Object, `property`: KProperty<*>):
-                Signal2<P0, P1> = Signal2(thisRef, property.name)
+                Signal2<P0, P1> = Signal2(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
-public inline fun <P0, P1> Object.Signal2(signalName: String) = Signal2<P0, P1>(this, signalName)
+public inline fun <P0, P1> Object.Signal2(signalName: String) =
+        Signal2<P0, P1>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1> Object.signal2() =
@@ -90,7 +107,7 @@ public inline fun <P0, P1> Object.signal2() =
 
 public class Signal3<P0, P1, P2> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -100,19 +117,24 @@ public class Signal3<P0, P1, P2> @PublishedApi internal constructor(
         emitUnsafe(p0, p1, p2)
     }
 
+    public fun connect(connect: Callable3<*, P0, P1, P2>, flags: Object.ConnectFlags =
+            Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`: ReadOnlyProperty<Object, Signal3<Any, Any, Any>> =
                 ReadOnlyProperty { thisRef, property -> getValue(thisRef, property) }
 
         public inline operator fun <P0, P1, P2> getValue(thisRef: Object, `property`: KProperty<*>):
-                Signal3<P0, P1, P2> = Signal3(thisRef, property.name)
+                Signal3<P0, P1, P2> = Signal3(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2> Object.Signal3(signalName: String) =
-        Signal3<P0, P1, P2>(this, signalName)
+        Signal3<P0, P1, P2>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2> Object.signal3() =
@@ -120,7 +142,7 @@ public inline fun <P0, P1, P2> Object.signal3() =
 
 public class Signal4<P0, P1, P2, P3> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -131,19 +153,25 @@ public class Signal4<P0, P1, P2, P3> @PublishedApi internal constructor(
         emitUnsafe(p0, p1, p2, p3)
     }
 
+    public fun connect(connect: Callable4<*, P0, P1, P2, P3>, flags: Object.ConnectFlags =
+            Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`: ReadOnlyProperty<Object, Signal4<Any, Any, Any, Any>> =
                 ReadOnlyProperty { thisRef, property -> getValue(thisRef, property) }
 
         public inline operator fun <P0, P1, P2, P3> getValue(thisRef: Object,
-                `property`: KProperty<*>): Signal4<P0, P1, P2, P3> = Signal4(thisRef, property.name)
+                `property`: KProperty<*>): Signal4<P0, P1, P2, P3> =
+                Signal4(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3> Object.Signal4(signalName: String) =
-        Signal4<P0, P1, P2, P3>(this, signalName)
+        Signal4<P0, P1, P2, P3>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3> Object.signal4() =
@@ -151,7 +179,7 @@ public inline fun <P0, P1, P2, P3> Object.signal4() =
 
 public class Signal5<P0, P1, P2, P3, P4> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -163,6 +191,11 @@ public class Signal5<P0, P1, P2, P3, P4> @PublishedApi internal constructor(
         emitUnsafe(p0, p1, p2, p3, p4)
     }
 
+    public fun connect(connect: Callable5<*, P0, P1, P2, P3, P4>, flags: Object.ConnectFlags =
+            Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`: ReadOnlyProperty<Object, Signal5<Any, Any, Any, Any, Any>> =
@@ -170,13 +203,13 @@ public class Signal5<P0, P1, P2, P3, P4> @PublishedApi internal constructor(
 
         public inline operator fun <P0, P1, P2, P3, P4> getValue(thisRef: Object,
                 `property`: KProperty<*>): Signal5<P0, P1, P2, P3, P4> =
-                Signal5(thisRef, property.name)
+                Signal5(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4> Object.Signal5(signalName: String) =
-        Signal5<P0, P1, P2, P3, P4>(this, signalName)
+        Signal5<P0, P1, P2, P3, P4>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4> Object.signal5() =
@@ -184,7 +217,7 @@ public inline fun <P0, P1, P2, P3, P4> Object.signal5() =
 
 public class Signal6<P0, P1, P2, P3, P4, P5> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -197,6 +230,11 @@ public class Signal6<P0, P1, P2, P3, P4, P5> @PublishedApi internal constructor(
         emitUnsafe(p0, p1, p2, p3, p4, p5)
     }
 
+    public fun connect(connect: Callable6<*, P0, P1, P2, P3, P4, P5>, flags: Object.ConnectFlags =
+            Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`: ReadOnlyProperty<Object, Signal6<Any, Any, Any, Any, Any, Any>> =
@@ -204,13 +242,13 @@ public class Signal6<P0, P1, P2, P3, P4, P5> @PublishedApi internal constructor(
 
         public inline operator fun <P0, P1, P2, P3, P4, P5> getValue(thisRef: Object,
                 `property`: KProperty<*>): Signal6<P0, P1, P2, P3, P4, P5> =
-                Signal6(thisRef, property.name)
+                Signal6(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5> Object.Signal6(signalName: String) =
-        Signal6<P0, P1, P2, P3, P4, P5>(this, signalName)
+        Signal6<P0, P1, P2, P3, P4, P5>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5> Object.signal6() =
@@ -218,7 +256,7 @@ public inline fun <P0, P1, P2, P3, P4, P5> Object.signal6() =
 
 public class Signal7<P0, P1, P2, P3, P4, P5, P6> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -232,6 +270,11 @@ public class Signal7<P0, P1, P2, P3, P4, P5, P6> @PublishedApi internal construc
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6)
     }
 
+    public fun connect(connect: Callable7<*, P0, P1, P2, P3, P4, P5, P6>, flags: Object.ConnectFlags
+            = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -240,13 +283,13 @@ public class Signal7<P0, P1, P2, P3, P4, P5, P6> @PublishedApi internal construc
 
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6> getValue(thisRef: Object,
                 `property`: KProperty<*>): Signal7<P0, P1, P2, P3, P4, P5, P6> =
-                Signal7(thisRef, property.name)
+                Signal7(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6> Object.Signal7(signalName: String) =
-        Signal7<P0, P1, P2, P3, P4, P5, P6>(this, signalName)
+        Signal7<P0, P1, P2, P3, P4, P5, P6>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6> Object.signal7() =
@@ -254,7 +297,7 @@ public inline fun <P0, P1, P2, P3, P4, P5, P6> Object.signal7() =
 
 public class Signal8<P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -269,6 +312,11 @@ public class Signal8<P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi internal cons
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6, p7)
     }
 
+    public fun connect(connect: Callable8<*, P0, P1, P2, P3, P4, P5, P6, P7>,
+            flags: Object.ConnectFlags = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -277,13 +325,13 @@ public class Signal8<P0, P1, P2, P3, P4, P5, P6, P7> @PublishedApi internal cons
 
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6, P7> getValue(thisRef: Object,
                 `property`: KProperty<*>): Signal8<P0, P1, P2, P3, P4, P5, P6, P7> =
-                Signal8(thisRef, property.name)
+                Signal8(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7> Object.Signal8(signalName: String) =
-        Signal8<P0, P1, P2, P3, P4, P5, P6, P7>(this, signalName)
+        Signal8<P0, P1, P2, P3, P4, P5, P6, P7>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7> Object.signal8() =
@@ -291,7 +339,7 @@ public inline fun <P0, P1, P2, P3, P4, P5, P6, P7> Object.signal8() =
 
 public class Signal9<P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -307,6 +355,11 @@ public class Signal9<P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedApi internal 
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8)
     }
 
+    public fun connect(connect: Callable9<*, P0, P1, P2, P3, P4, P5, P6, P7, P8>,
+            flags: Object.ConnectFlags = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -315,13 +368,13 @@ public class Signal9<P0, P1, P2, P3, P4, P5, P6, P7, P8> @PublishedApi internal 
 
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6, P7, P8> getValue(thisRef: Object,
                 `property`: KProperty<*>): Signal9<P0, P1, P2, P3, P4, P5, P6, P7, P8> =
-                Signal9(thisRef, property.name)
+                Signal9(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8> Object.Signal9(signalName: String) =
-        Signal9<P0, P1, P2, P3, P4, P5, P6, P7, P8>(this, signalName)
+        Signal9<P0, P1, P2, P3, P4, P5, P6, P7, P8>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8> Object.signal9() =
@@ -329,7 +382,7 @@ public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8> Object.signal9() =
 
 public class Signal10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -346,6 +399,11 @@ public class Signal10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @PublishedApi inte
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9)
     }
 
+    public fun connect(connect: Callable10<*, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>,
+            flags: Object.ConnectFlags = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -354,13 +412,14 @@ public class Signal10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> @PublishedApi inte
 
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>
                 getValue(thisRef: Object, `property`: KProperty<*>):
-                Signal10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> = Signal10(thisRef, property.name)
+                Signal10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> =
+                Signal10(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> Object.Signal10(signalName: String) =
-        Signal10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(this, signalName)
+        Signal10<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> Object.signal10() =
@@ -369,7 +428,7 @@ public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9> Object.signal10() =
 public class Signal11<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @PublishedApi internal
         constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -387,6 +446,11 @@ public class Signal11<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @PublishedApi
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
     }
 
+    public fun connect(connect: Callable11<*, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>,
+            flags: Object.ConnectFlags = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -396,13 +460,13 @@ public class Signal11<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> @PublishedApi
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>
                 getValue(thisRef: Object, `property`: KProperty<*>):
                 Signal11<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> =
-                Signal11(thisRef, property.name)
+                Signal11(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> Object.Signal11(signalName: String)
-        = Signal11<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(this, signalName)
+        = Signal11<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> Object.signal11() =
@@ -411,7 +475,7 @@ public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10> Object.signal11(
 public class Signal12<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> @PublishedApi internal
         constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -430,6 +494,11 @@ public class Signal12<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> @Publish
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
     }
 
+    public fun connect(connect: Callable12<*, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>,
+            flags: Object.ConnectFlags = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -439,14 +508,14 @@ public class Signal12<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> @Publish
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>
                 getValue(thisRef: Object, `property`: KProperty<*>):
                 Signal12<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> =
-                Signal12(thisRef, property.name)
+                Signal12(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>
         Object.Signal12(signalName: String) =
-        Signal12<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(this, signalName)
+        Signal12<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> Object.signal12() =
@@ -455,7 +524,7 @@ public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11> Object.sign
 public class Signal13<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> @PublishedApi internal
         constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -475,6 +544,12 @@ public class Signal13<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> @Pu
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
     }
 
+    public
+            fun connect(connect: Callable13<*, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>,
+            flags: Object.ConnectFlags = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -484,14 +559,14 @@ public class Signal13<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> @Pu
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>
                 getValue(thisRef: Object, `property`: KProperty<*>):
                 Signal13<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> =
-                Signal13(thisRef, property.name)
+                Signal13(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>
         Object.Signal13(signalName: String) =
-        Signal13<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(this, signalName)
+        Signal13<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> Object.signal13() =
@@ -500,7 +575,7 @@ public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12> Object
 public class Signal14<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> @PublishedApi
         internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -521,6 +596,12 @@ public class Signal14<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
     }
 
+    public
+            fun connect(connect: Callable14<*, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>,
+            flags: Object.ConnectFlags = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -530,14 +611,14 @@ public class Signal14<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>
                 getValue(thisRef: Object, `property`: KProperty<*>):
                 Signal14<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> =
-                Signal14(thisRef, property.name)
+                Signal14(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>
         Object.Signal14(signalName: String) =
-        Signal14<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(this, signalName)
+        Signal14<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> Object.signal14() =
@@ -546,7 +627,7 @@ public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13> O
 public class Signal15<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> @PublishedApi
         internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -568,6 +649,12 @@ public class Signal15<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
     }
 
+    public
+            fun connect(connect: Callable15<*, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>,
+            flags: Object.ConnectFlags = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -577,14 +664,14 @@ public class Signal15<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>
                 getValue(thisRef: Object, `property`: KProperty<*>):
                 Signal15<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14> =
-                Signal15(thisRef, property.name)
+                Signal15(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>
         Object.Signal15(signalName: String) =
-        Signal15<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>(this, signalName)
+        Signal15<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14>
@@ -594,7 +681,7 @@ public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P
 public class Signal16<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
         @PublishedApi internal constructor(
     instance: Object,
-    name: String,
+    name: StringName,
 ) : Signal(instance, name) {
     public fun emit(
         p0: P0,
@@ -617,6 +704,12 @@ public class Signal16<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13
         emitUnsafe(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
     }
 
+    public
+            fun connect(connect: Callable16<*, P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>,
+            flags: Object.ConnectFlags = Object.ConnectFlags.DEFAULT): Unit {
+        connectUnsafe(connect, flags)
+    }
+
     public companion object {
         @PublishedApi
         internal val `delegate`:
@@ -626,14 +719,14 @@ public class Signal16<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13
         public inline operator fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14,
                 P15> getValue(thisRef: Object, `property`: KProperty<*>):
                 Signal16<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15> =
-                Signal16(thisRef, property.name)
+                Signal16(thisRef, property.toGodotName())
     }
 }
 
 @Suppress("FUNCTION_NAME")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>
         Object.Signal16(signalName: String) =
-        Signal16<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>(this, signalName)
+        Signal16<P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>(this, signalName.toGodotName())
 
 @Suppress("UNCHECKED_CAST")
 public inline fun <P0, P1, P2, P3, P4, P5, P6, P7, P8, P9, P10, P11, P12, P13, P14, P15>

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/Variant.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/Variant.kt
@@ -5,7 +5,6 @@ import godot.common.interop.ObjectID
 import godot.common.interop.VariantConverter
 import godot.common.interop.nullptr
 import godot.common.util.toRealT
-import godot.core.Signal
 import godot.internal.memory.LongStringQueue
 import java.nio.ByteBuffer
 
@@ -373,14 +372,9 @@ enum class VariantParser(override val id: Int) : VariantConverter {
     CALLABLE(25) {
         override fun toUnsafeKotlin(buffer: ByteBuffer) = VariantCallable(buffer.long)
         override fun toUnsafeGodot(buffer: ByteBuffer, any: Any?) {
-            if (any is VariantCallable) {
-                buffer.putLong(any.ptr)
-            } else {
-                require(any is LambdaCallable<*> || any is MethodCallable)
-                // Be careful that ::toNativeCallable doesn't itself use the shared buffer.
-                val ptr = any.toNativeCallable().ptr
-                buffer.putLong(ptr)
-            }
+            require(any is Callable)
+            // Be careful that ::toNativeCallable doesn't itself use the shared buffer.
+            buffer.putLong(any.toNativeCallable().ptr)
         }
     },
     SIGNAL(26) {

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/LambdaCallable.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/LambdaCallable.kt
@@ -10,7 +10,7 @@ import godot.internal.memory.TransferContext
 
 open class LambdaCallable<R> internal constructor(
     protected val container: LambdaContainer<R>,
-    private var boundArgs: Array<Any?> = emptyArray()
+    protected var boundArgs: Array<out Any?> = emptyArray()
 ) : Callable {
 
     override fun getBoundArguments() = boundArgs.toList()

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/MethodCallable.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/MethodCallable.kt
@@ -9,8 +9,10 @@ import godot.internal.memory.MemoryManager
 class MethodCallable internal constructor(
     private val target: Object,
     private val methodName: StringName,
-    private var boundArgs: Array<Any?> = emptyArray()
+    private var boundArgs: Array<Any?>
 ) : Callable {
+
+    constructor(target: Object, methodName: StringName) : this(target, methodName, emptyArray())
 
     override fun getBoundArguments() = boundArgs.toList()
     override fun getBoundArgumentCount() = boundArgs.size
@@ -38,11 +40,5 @@ class MethodCallable internal constructor(
             return unbound.bindUnsafe(*boundArgs)
         }
         return unbound
-    }
-
-    companion object {
-        @JvmStatic
-        @JvmName("create")
-        operator fun invoke(target: Object, methodName: StringName) = MethodCallable(target, methodName)
     }
 }

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/MethodCallable.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/MethodCallable.kt
@@ -6,10 +6,10 @@ import godot.api.Object
 import godot.core.Callable.Bridge
 import godot.internal.memory.MemoryManager
 
-class MethodCallable internal constructor(
-    private val target: Object,
-    private val methodName: StringName,
-    private var boundArgs: Array<Any?>
+open class MethodCallable internal constructor(
+    protected val target: Object,
+    protected val methodName: StringName,
+    protected var boundArgs: Array<out Any?> = emptyArray()
 ) : Callable {
 
     constructor(target: Object, methodName: StringName) : this(target, methodName, emptyArray())

--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/Signal.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/core/callback/Signal.kt
@@ -12,11 +12,6 @@ open class Signal internal constructor(
     val name: StringName
 ) : CoreType {
 
-    internal constructor(instance: Object, jvmName: String) : this(
-        instance,
-        jvmName.convertToSnakeCase().asStringName()
-    )
-
     fun emitUnsafe(vararg args: Any?) {
         godotObject.emitSignal(name, *args)
     }

--- a/kt/tools-common/src/main/kotlin/godot/tools/common/constants/Classes.kt
+++ b/kt/tools-common/src/main/kotlin/godot/tools/common/constants/Classes.kt
@@ -255,6 +255,7 @@ val GODOT_LAMBDA_CALLABLE = ClassName(godotCorePackage, GodotKotlinJvmTypes.lamb
 val GODOT_DICTIONARY = ClassName(godotCorePackage, GodotKotlinJvmTypes.dictionary)
 val GODOT_OBJECT = ClassName(godotApiPackage, GodotKotlinJvmTypes.obj)
 val KT_OBJECT = ClassName(godotCorePackage, GodotKotlinJvmTypes.ktObject)
+val STRING_NAME = ClassName(godotCorePackage, GodotKotlinJvmTypes.stringName)
 
 val VARIANT_PARSER_NIL = ClassName(variantParserPackage, "NIL")
 val VARIANT_PARSER_BOOL = ClassName(variantParserPackage, "BOOL")


### PR DESCRIPTION
Depends on #803 

Add numbered typed MethodCallableX classes, which now shared a common CallableX interface with LambdaCallableX.
SIgnalX also now use this interface for typ safe connection instead of only `unsafeConnect`