### PR TITLE
GH-842 Fix thread context classloader

### DIFF
--- a/kt/godot-library/godot-core-library/src/main/kotlin/godot/runtime/Bootstrap.kt
+++ b/kt/godot-library/godot-core-library/src/main/kotlin/godot/runtime/Bootstrap.kt
@@ -33,7 +33,6 @@ internal class Bootstrap {
     }
 
     fun finish() {
-        Thread.currentThread().contextClassLoader = null
         clearClassesCache()
         serviceLoader.reload()
     }

--- a/src/gd_kotlin.cpp
+++ b/src/gd_kotlin.cpp
@@ -251,6 +251,8 @@ bool GDKotlin::load_bootstrap() {
 
         JVM_LOG_VERBOSE("Loading bootstrap jar: %s", bootstrap_jar);
         bootstrap_class_loader = ClassLoader::create_instance(env, bootstrap_jar, jni::JObject(nullptr));
+
+        // set context classloader to bootstrap initially
         bootstrap_class_loader->set_as_context_loader(env);
     }
 
@@ -318,6 +320,9 @@ bool GDKotlin::load_user_code() {
           bootstrap_class_loader->get_wrapped()
         );
 
+        // update context classloader to use usercode jar
+        user_class_loader->set_as_context_loader(env);
+
         bootstrap->init_jar(env, user_class_loader->get_wrapped());
         delete user_class_loader;
         return FileAccess::exists(user_code_path);
@@ -326,6 +331,10 @@ bool GDKotlin::load_user_code() {
 
 void GDKotlin::unload_user_code() {
     jni::Env env {jni::Jvm::current_env()};
+
+    // reset context classloader to bootstrap
+    bootstrap_class_loader->set_as_context_loader(env);
+
     bootstrap->finish(env);
     TypeManager::get_instance().clear();
     jar.unref();


### PR DESCRIPTION
Resolves #842

With the cpp reloading changes, we set the bootstrap classloader as thread context classloader instead of the usercode. Assitionally, when cleaning up the bootstrap later, we did not remove the "unset" of the context classloader so after a reload (which finalizes up to but not including bootstrap) we set the thread context classloader to null but never back to something (as that was happing in the setup of the bootstrap phase which is never called again).

This now set's the correct thread context classloader depending on the load state:
\>= bootstrap -> bootstrap
\>= usercode -> usercode

upon teardown of the usercode, the bootstrap classloader is set as context classloader again until the state is >= usercode again.