### PR TITLE
Add build action to patch macos engine build host

### DIFF
--- a/.github/actions/mac-host-patches/action.yml
+++ b/.github/actions/mac-host-patches/action.yml
@@ -1,0 +1,16 @@
+name: Apply common macos patches
+description: Action to apply macos patches if needed (they are quite frequently needed hence a dedicated action to apply all or none to all our macos build host runs)
+
+runs:
+  using: composite
+  steps:
+    - name: Info
+      shell: sh
+      run: echo "Applying macos patches"
+
+    # Add any necessary patches for macos hosts below:
+
+    # Required for new moltenvk builds. keep until 'macos-latest' points to macos15 instead of 14: https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+    - name: Select Xcode 16
+      shell: sh
+      run: sudo xcode-select -s /Applications/Xcode_16.2.app

--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -79,6 +79,9 @@ jobs:
         with:
           path: modules/kotlin_jvm
 
+      - name: Apply common macos host patches
+        uses: ./modules/kotlin_jvm/.github/actions/mac-host-patches
+
       - name: Setup Godot build cache
         uses: ./modules/kotlin_jvm/.github/actions/scons-cache
         with:


### PR DESCRIPTION
This creates a dedicated github action to patch the macos host everytime we need it (like currently for moltenvk).

The idea is, that we keep this action and just have to make edits to it when we need to patch macos in the future again instead of searching in our action files for the correct location.

Currently this is needed for moltenvk, as moltenvk now requires xcode 16 which is not the default on `macos-latest` as that still used macos 14 instead of 15: https://github.com/actions/runner-images?tab=readme-ov-file#available-images)