### PR TITLE
Use stable file ordering when generating templates

### DIFF
--- a/generate_templates.py
+++ b/generate_templates.py
@@ -27,8 +27,9 @@ def generate_header_from_files(directory, header_file):
         header.write("#ifndef FILE_CONTENTS_H\n")
         header.write("#define FILE_CONTENTS_H\n\n")
 
-        for root, _, files in os.walk(directory):
-            for file_name in files:
+        for root, dirs, files in os.walk(directory):
+            dirs.sort()
+            for file_name in sorted(files):
                 # Only process files with .template or .godot_template extensions
                 if not(file_name.endswith('.template')) and not(file_name.endswith('.godot_template')):
                     continue


### PR DESCRIPTION
When working on the Gradle template, I found that running generate_templates.py changed the order of the files in templates.h, not just their contents. There's apparently no guaranteed order for `os.walk`, so the diff was messy: 
<img width="600" src="https://github.com/user-attachments/assets/d65bb32c-ffa9-479c-9a9c-a601b4b3fa8a" />

This cleans that up by iterating in a stable order, taken from [this stackoverflow answer](https://stackoverflow.com/a/18282401).

Clean diff now!
<img width="600" src="https://github.com/user-attachments/assets/611c5261-73ff-4630-826e-70133584543c" />
