### PR TITLE
Normalize newlines to '\n' when generating templates

### DIFF
--- a/generate_templates.py
+++ b/generate_templates.py
@@ -8,6 +8,7 @@ def encode_file_to_base64(file_path):
     """Encode the content of a file to a Base64 string."""
     with open(file_path, 'rb') as file:
         file_content = file.read()
+        file_content = file_content.replace(b'\r\n', b'\n').replace(b'\r', b'\n')
         encoded_content = base64.b64encode(file_content).decode('utf-8')
     return encoded_content
 


### PR DESCRIPTION
It looks like these templates were previously generated on Windows as they've got `\r\n` line endings. These get encoded into base64 when generating the templates, which makes the diffs messy, similar to #852. Running the script with no changes on macOS currently shows a diff, even though there are no changes.
This normalizes it by replacing newlines with `\n` when encoding base64, so now Windows and non-Windows should generate the same output.