### PR TITLE
Add Dummy Implementation of abstract API class

### DIFF
--- a/kt/api-generator/src/main/kotlin/godot/codegen/generation/rule/ClassRule.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/generation/rule/ClassRule.kt
@@ -1,16 +1,20 @@
 package godot.codegen.generation.rule
 
+import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.UNIT
 import godot.codegen.generation.GenerationContext
+import godot.codegen.generation.task.AbstractClassDummyTask
 import godot.codegen.generation.task.EnrichedClassTask
 import godot.codegen.generation.task.EnrichedConstantTask
 import godot.codegen.generation.task.EnrichedEnumTask
 import godot.codegen.generation.task.EnrichedMethodTask
 import godot.codegen.generation.task.EnrichedPropertyTask
 import godot.codegen.generation.task.SignalTask
+import godot.codegen.models.enriched.EnrichedClass
 import godot.codegen.models.enriched.EnrichedMethod
 import godot.codegen.models.traits.addKdoc
 import godot.tools.common.constants.GODOT_BASE_TYPE
@@ -128,6 +132,60 @@ class MemberRule : GodotApiRule<EnrichedClassTask>() {
         return this
     }
 
+}
+
+class AbstractClassDummyRule : GodotApiRule<AbstractClassDummyTask>() {
+    override fun apply(task: AbstractClassDummyTask, context: GenerationContext) = configure(task.builder) {
+        val clazz = task.clazz
+        addModifiers(KModifier.INTERNAL)
+        superclass(clazz.className)
+
+        clazz.methods
+            .filter { it.isAbstract }
+            .filter { canGenerateMethod(context, it) }
+            .forEach { method ->
+                addFunction(method.toDummyOverride(clazz))
+            }
+    }
+
+    private fun canGenerateMethod(context: GenerationContext, method: EnrichedMethod): Boolean {
+        if (context.isNativeStructure(method.type.identifier)) {
+            return false
+        }
+        for (argument in method.arguments) {
+            if (context.isNativeStructure(argument.type.identifier)) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun EnrichedMethod.toDummyOverride(clazz: EnrichedClass): FunSpec {
+        val builder = FunSpec.builder(name)
+            .addModifiers(KModifier.OVERRIDE)
+
+        val returnType = getCastedType()
+        if (returnType != UNIT) {
+            builder.returns(returnType)
+        }
+
+        arguments.forEach { argument ->
+            builder.addParameter(argument.name, argument.getCastedType())
+        }
+
+        if (isVararg) {
+            builder.addParameter("args", ANY.copy(nullable = true), KModifier.VARARG)
+        }
+
+        builder.addStatement(
+            "%L·%T(%S)",
+            "throw",
+            NotImplementedError::class,
+            "${clazz.identifier}::${name} is only implemented by non-JVM code."
+        )
+
+        return builder.build()
+    }
 }
 
 class BindingRule : GodotApiRule<EnrichedClassTask>() {

--- a/kt/api-generator/src/main/kotlin/godot/codegen/generation/rule/FileRule.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/generation/rule/FileRule.kt
@@ -3,6 +3,7 @@ package godot.codegen.generation.rule
 import com.squareup.kotlinpoet.AnnotationSpec
 import com.squareup.kotlinpoet.ClassName
 import godot.codegen.generation.GenerationContext
+import godot.codegen.generation.task.AbstractClassDummyTask
 import godot.codegen.generation.task.ApiTask
 import godot.codegen.generation.task.EnrichedClassTask
 import godot.codegen.generation.task.EnrichedEnumTask
@@ -17,6 +18,9 @@ class FileRule : GodotApiRule<FileTask>() {
         val type = task.type
         if (type is EnrichedClass) {
             task.classes += EnrichedClassTask(type)
+            if (type.isAbstract) {
+                task.abstractDummyClasses += AbstractClassDummyTask(type)
+            }
         } else if (type is EnrichedEnum) {
             task.enums += EnrichedEnumTask(type)
         }

--- a/kt/api-generator/src/main/kotlin/godot/codegen/generation/rule/RegistrationRule.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/generation/rule/RegistrationRule.kt
@@ -57,12 +57,13 @@ class RegistrationRule() : GodotApiRule<ApiTask>() {
             )
         } else {
             if(clazz.isAbstract) {
-                formatString = "%T.registerEngineType(%S,·%T::class,·null)"
+                formatString = "%T.registerEngineType(%S,·%T::class,·::%T)"
                 engineTypes.addStatement(
                     formatString,
                     TYPE_MANAGER,
                     clazz.identifier,
                     clazz.className,
+                    clazz.abstractDummyClassName,
                 )
             } else {
                 formatString = "%T.registerEngineType(%S,·%T::class,·::%T)"

--- a/kt/api-generator/src/main/kotlin/godot/codegen/generation/task/AbstractClassDummyTask.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/generation/task/AbstractClassDummyTask.kt
@@ -1,0 +1,13 @@
+package godot.codegen.generation.task
+
+import com.squareup.kotlinpoet.TypeSpec
+import godot.codegen.models.enriched.EnrichedClass
+
+class AbstractClassDummyTask(
+    val clazz: EnrichedClass
+) : ClassTask() {
+
+    override val builder = TypeSpec.classBuilder(clazz.abstractDummyClassName)
+
+    override fun executeSingle(): TypeSpec = builder.build()
+}

--- a/kt/api-generator/src/main/kotlin/godot/codegen/generation/task/FileTask.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/generation/task/FileTask.kt
@@ -13,6 +13,7 @@ class FileTask(
     }
 
     val classes = subTask<EnrichedClassTask, _> { output -> builder.addType(output) }
+    val abstractDummyClasses = subTask<AbstractClassDummyTask, _> { output -> builder.addType(output) }
     val enums = subTask<EnrichedEnumTask, _> { output -> builder.addType(output) }
 
     override fun executeSingle() = builder.build()

--- a/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedClass.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/models/enriched/EnrichedClass.kt
@@ -31,6 +31,8 @@ class EnrichedClass(model: Class) : TypeGenerationTrait, DocumentedGenerationTra
     val methods = model.methods?.toEnriched() ?: listOf()
 
     val isAbstract = methods.any { it.isAbstract }
+    val abstractDummyClassName: ClassName
+        get() = ClassName(className.packageName, "${identifier}Dummy")
     val isInstantiable = model.isInstantiable
 
     override var description = model.description

--- a/kt/api-generator/src/main/kotlin/godot/codegen/services/impl/ApiGenerationService.kt
+++ b/kt/api-generator/src/main/kotlin/godot/codegen/services/impl/ApiGenerationService.kt
@@ -2,6 +2,7 @@ package godot.codegen.services.impl
 
 import godot.codegen.generation.GenerationContext
 import godot.codegen.generation.rule.ApiRule
+import godot.codegen.generation.rule.AbstractClassDummyRule
 import godot.codegen.generation.rule.BindingRule
 import godot.codegen.generation.rule.BitfieldExtensionRule
 import godot.codegen.generation.rule.ConstantRule
@@ -67,6 +68,7 @@ class ApiGenerationService(
                     rule(::BindingRule)
                     rule(::LocalCopyHelperRule)
                 }
+                subRule(FileTask::abstractDummyClasses, ::AbstractClassDummyRule)
                 subRule(FileTask::enums, ::EnumRule)
                 rule(::StaticRule)
                 rule(::BitfieldExtensionRule)

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/RegisterEngineTypes.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/RegisterEngineTypes.kt
@@ -25,6 +25,7 @@ import godot.api.AnimationNodeBlendSpace1D
 import godot.api.AnimationNodeBlendSpace2D
 import godot.api.AnimationNodeBlendTree
 import godot.api.AnimationNodeExtension
+import godot.api.AnimationNodeExtensionDummy
 import godot.api.AnimationNodeOneShot
 import godot.api.AnimationNodeOutput
 import godot.api.AnimationNodeStateMachine
@@ -54,6 +55,7 @@ import godot.api.AudioEffectChorus
 import godot.api.AudioEffectCompressor
 import godot.api.AudioEffectDelay
 import godot.api.AudioEffectDistortion
+import godot.api.AudioEffectDummy
 import godot.api.AudioEffectEQ
 import godot.api.AudioEffectEQ10
 import godot.api.AudioEffectEQ21
@@ -63,6 +65,7 @@ import godot.api.AudioEffectHardLimiter
 import godot.api.AudioEffectHighPassFilter
 import godot.api.AudioEffectHighShelfFilter
 import godot.api.AudioEffectInstance
+import godot.api.AudioEffectInstanceDummy
 import godot.api.AudioEffectLimiter
 import godot.api.AudioEffectLowPassFilter
 import godot.api.AudioEffectLowShelfFilter
@@ -81,6 +84,7 @@ import godot.api.AudioSample
 import godot.api.AudioSamplePlayback
 import godot.api.AudioServer
 import godot.api.AudioStream
+import godot.api.AudioStreamDummy
 import godot.api.AudioStreamGenerator
 import godot.api.AudioStreamGeneratorPlayback
 import godot.api.AudioStreamInteractive
@@ -88,11 +92,13 @@ import godot.api.AudioStreamMP3
 import godot.api.AudioStreamMicrophone
 import godot.api.AudioStreamOggVorbis
 import godot.api.AudioStreamPlayback
+import godot.api.AudioStreamPlaybackDummy
 import godot.api.AudioStreamPlaybackInteractive
 import godot.api.AudioStreamPlaybackOggVorbis
 import godot.api.AudioStreamPlaybackPlaylist
 import godot.api.AudioStreamPlaybackPolyphonic
 import godot.api.AudioStreamPlaybackResampled
+import godot.api.AudioStreamPlaybackResampledDummy
 import godot.api.AudioStreamPlaybackSynchronized
 import godot.api.AudioStreamPlayer
 import godot.api.AudioStreamPlayer2D
@@ -363,11 +369,13 @@ import godot.api.Marker2D
 import godot.api.Marker3D
 import godot.api.Marshalls
 import godot.api.Material
+import godot.api.MaterialDummy
 import godot.api.MenuBar
 import godot.api.MenuButton
 import godot.api.Mesh
 import godot.api.MeshConvexDecompositionSettings
 import godot.api.MeshDataTool
+import godot.api.MeshDummy
 import godot.api.MeshInstance2D
 import godot.api.MeshInstance3D
 import godot.api.MeshLibrary
@@ -378,6 +386,7 @@ import godot.api.MissingResource
 import godot.api.MobileVRInterface
 import godot.api.ModifierBoneTarget3D
 import godot.api.MovieWriter
+import godot.api.MovieWriterDummy
 import godot.api.MultiMesh
 import godot.api.MultiMeshInstance2D
 import godot.api.MultiMeshInstance3D
@@ -385,6 +394,7 @@ import godot.api.MultiplayerAPI
 import godot.api.MultiplayerAPIExtension
 import godot.api.MultiplayerPeer
 import godot.api.MultiplayerPeerExtension
+import godot.api.MultiplayerPeerExtensionDummy
 import godot.api.MultiplayerSpawner
 import godot.api.MultiplayerSynchronizer
 import godot.api.Mutex
@@ -437,6 +447,7 @@ import godot.api.OpenXRAnalogThresholdModifier
 import godot.api.OpenXRAnchorTracker
 import godot.api.OpenXRAndroidThreadSettingsExtension
 import godot.api.OpenXRBindingModifier
+import godot.api.OpenXRBindingModifierDummy
 import godot.api.OpenXRCompositionLayer
 import godot.api.OpenXRCompositionLayerCylinder
 import godot.api.OpenXRCompositionLayerEquirect
@@ -497,6 +508,7 @@ import godot.api.PackedScene
 import godot.api.PacketPeer
 import godot.api.PacketPeerDTLS
 import godot.api.PacketPeerExtension
+import godot.api.PacketPeerExtensionDummy
 import godot.api.PacketPeerStream
 import godot.api.PacketPeerUDP
 import godot.api.Panel
@@ -519,12 +531,16 @@ import godot.api.PhysicsBody2D
 import godot.api.PhysicsBody3D
 import godot.api.PhysicsDirectBodyState2D
 import godot.api.PhysicsDirectBodyState2DExtension
+import godot.api.PhysicsDirectBodyState2DExtensionDummy
 import godot.api.PhysicsDirectBodyState3D
 import godot.api.PhysicsDirectBodyState3DExtension
+import godot.api.PhysicsDirectBodyState3DExtensionDummy
 import godot.api.PhysicsDirectSpaceState2D
 import godot.api.PhysicsDirectSpaceState2DExtension
+import godot.api.PhysicsDirectSpaceState2DExtensionDummy
 import godot.api.PhysicsDirectSpaceState3D
 import godot.api.PhysicsDirectSpaceState3DExtension
+import godot.api.PhysicsDirectSpaceState3DExtensionDummy
 import godot.api.PhysicsMaterial
 import godot.api.PhysicsPointQueryParameters2D
 import godot.api.PhysicsPointQueryParameters3D
@@ -535,6 +551,7 @@ import godot.api.PhysicsServer2DManager
 import godot.api.PhysicsServer3D
 import godot.api.PhysicsServer3DManager
 import godot.api.PhysicsServer3DRenderingServerHandler
+import godot.api.PhysicsServer3DRenderingServerHandlerDummy
 import godot.api.PhysicsShapeQueryParameters2D
 import godot.api.PhysicsShapeQueryParameters3D
 import godot.api.PhysicsTestMotionParameters2D
@@ -611,6 +628,7 @@ import godot.api.RenderingDevice
 import godot.api.RenderingServer
 import godot.api.Resource
 import godot.api.ResourceFormatLoader
+import godot.api.ResourceFormatLoaderDummy
 import godot.api.ResourceFormatSaver
 import godot.api.ResourceImporter
 import godot.api.ResourceLoader
@@ -632,8 +650,10 @@ import godot.api.SceneTreeTimer
 import godot.api.Script
 import godot.api.ScriptBacktrace
 import godot.api.ScriptExtension
+import godot.api.ScriptExtensionDummy
 import godot.api.ScriptLanguage
 import godot.api.ScriptLanguageExtension
+import godot.api.ScriptLanguageExtensionDummy
 import godot.api.ScrollBar
 import godot.api.ScrollContainer
 import godot.api.SegmentShape2D
@@ -697,12 +717,14 @@ import godot.api.StatusIndicator
 import godot.api.StreamPeer
 import godot.api.StreamPeerBuffer
 import godot.api.StreamPeerExtension
+import godot.api.StreamPeerExtensionDummy
 import godot.api.StreamPeerGZIP
 import godot.api.StreamPeerSocket
 import godot.api.StreamPeerTCP
 import godot.api.StreamPeerTLS
 import godot.api.StreamPeerUDS
 import godot.api.StyleBox
+import godot.api.StyleBoxDummy
 import godot.api.StyleBoxEmpty
 import godot.api.StyleBoxFlat
 import godot.api.StyleBoxLine
@@ -725,18 +747,22 @@ import godot.api.TextServer
 import godot.api.TextServerAdvanced
 import godot.api.TextServerDummy
 import godot.api.TextServerExtension
+import godot.api.TextServerExtensionDummy
 import godot.api.TextServerManager
 import godot.api.Texture
 import godot.api.Texture2D
 import godot.api.Texture2DArray
 import godot.api.Texture2DArrayRD
+import godot.api.Texture2DDummy
 import godot.api.Texture2DRD
 import godot.api.Texture3D
+import godot.api.Texture3DDummy
 import godot.api.Texture3DRD
 import godot.api.TextureButton
 import godot.api.TextureCubemapArrayRD
 import godot.api.TextureCubemapRD
 import godot.api.TextureLayered
+import godot.api.TextureLayeredDummy
 import godot.api.TextureLayeredRD
 import godot.api.TextureProgressBar
 import godot.api.TextureRect
@@ -780,7 +806,9 @@ import godot.api.VSplitContainer
 import godot.api.VehicleBody3D
 import godot.api.VehicleWheel3D
 import godot.api.VideoStream
+import godot.api.VideoStreamDummy
 import godot.api.VideoStreamPlayback
+import godot.api.VideoStreamPlaybackDummy
 import godot.api.VideoStreamPlayer
 import godot.api.VideoStreamTheora
 import godot.api.Viewport
@@ -907,9 +935,11 @@ import godot.api.VoxelGIData
 import godot.api.WeakRef
 import godot.api.WebRTCDataChannel
 import godot.api.WebRTCDataChannelExtension
+import godot.api.WebRTCDataChannelExtensionDummy
 import godot.api.WebRTCMultiplayerPeer
 import godot.api.WebRTCPeerConnection
 import godot.api.WebRTCPeerConnectionExtension
+import godot.api.WebRTCPeerConnectionExtensionDummy
 import godot.api.WebSocketMultiplayerPeer
 import godot.api.WebSocketPeer
 import godot.api.WebXRInterface
@@ -2863,7 +2893,7 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("AnimationNodeBlendSpace1D", AnimationNodeBlendSpace1D::class, ::AnimationNodeBlendSpace1D)
   TypeManager.registerEngineType("AnimationNodeBlendSpace2D", AnimationNodeBlendSpace2D::class, ::AnimationNodeBlendSpace2D)
   TypeManager.registerEngineType("AnimationNodeBlendTree", AnimationNodeBlendTree::class, ::AnimationNodeBlendTree)
-  TypeManager.registerEngineType("AnimationNodeExtension", AnimationNodeExtension::class, null)
+  TypeManager.registerEngineType("AnimationNodeExtension", AnimationNodeExtension::class, ::AnimationNodeExtensionDummy)
   TypeManager.registerEngineType("AnimationNodeOneShot", AnimationNodeOneShot::class, ::AnimationNodeOneShot)
   TypeManager.registerEngineType("AnimationNodeOutput", AnimationNodeOutput::class, ::AnimationNodeOutput)
   TypeManager.registerEngineType("AnimationNodeStateMachine", AnimationNodeStateMachine::class, ::AnimationNodeStateMachine)
@@ -2884,7 +2914,7 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("AspectRatioContainer", AspectRatioContainer::class, ::AspectRatioContainer)
   TypeManager.registerEngineType("AtlasTexture", AtlasTexture::class, ::AtlasTexture)
   TypeManager.registerEngineType("AudioBusLayout", AudioBusLayout::class, ::AudioBusLayout)
-  TypeManager.registerEngineType("AudioEffect", AudioEffect::class, null)
+  TypeManager.registerEngineType("AudioEffect", AudioEffect::class, ::AudioEffectDummy)
   TypeManager.registerEngineType("AudioEffectAmplify", AudioEffectAmplify::class, ::AudioEffectAmplify)
   TypeManager.registerEngineType("AudioEffectBandLimitFilter", AudioEffectBandLimitFilter::class, ::AudioEffectBandLimitFilter)
   TypeManager.registerEngineType("AudioEffectBandPassFilter", AudioEffectBandPassFilter::class, ::AudioEffectBandPassFilter)
@@ -2901,7 +2931,7 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("AudioEffectHardLimiter", AudioEffectHardLimiter::class, ::AudioEffectHardLimiter)
   TypeManager.registerEngineType("AudioEffectHighPassFilter", AudioEffectHighPassFilter::class, ::AudioEffectHighPassFilter)
   TypeManager.registerEngineType("AudioEffectHighShelfFilter", AudioEffectHighShelfFilter::class, ::AudioEffectHighShelfFilter)
-  TypeManager.registerEngineType("AudioEffectInstance", AudioEffectInstance::class, null)
+  TypeManager.registerEngineType("AudioEffectInstance", AudioEffectInstance::class, ::AudioEffectInstanceDummy)
   TypeManager.registerEngineType("AudioEffectLimiter", AudioEffectLimiter::class, ::AudioEffectLimiter)
   TypeManager.registerEngineType("AudioEffectLowPassFilter", AudioEffectLowPassFilter::class, ::AudioEffectLowPassFilter)
   TypeManager.registerEngineType("AudioEffectLowShelfFilter", AudioEffectLowShelfFilter::class, ::AudioEffectLowShelfFilter)
@@ -2920,19 +2950,19 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("AudioSamplePlayback", AudioSamplePlayback::class, ::AudioSamplePlayback)
   TypeManager.registerSingleton("AudioServer") { AudioServer }
   TypeManager.registerEngineType("AudioServer", AudioServer::class) { AudioServer }
-  TypeManager.registerEngineType("AudioStream", AudioStream::class, null)
+  TypeManager.registerEngineType("AudioStream", AudioStream::class, ::AudioStreamDummy)
   TypeManager.registerEngineType("AudioStreamGenerator", AudioStreamGenerator::class, ::AudioStreamGenerator)
   TypeManager.registerEngineType("AudioStreamGeneratorPlayback", AudioStreamGeneratorPlayback::class, ::AudioStreamGeneratorPlayback)
   TypeManager.registerEngineType("AudioStreamInteractive", AudioStreamInteractive::class, ::AudioStreamInteractive)
   TypeManager.registerEngineType("AudioStreamMP3", AudioStreamMP3::class, ::AudioStreamMP3)
   TypeManager.registerEngineType("AudioStreamMicrophone", AudioStreamMicrophone::class, ::AudioStreamMicrophone)
   TypeManager.registerEngineType("AudioStreamOggVorbis", AudioStreamOggVorbis::class, ::AudioStreamOggVorbis)
-  TypeManager.registerEngineType("AudioStreamPlayback", AudioStreamPlayback::class, null)
+  TypeManager.registerEngineType("AudioStreamPlayback", AudioStreamPlayback::class, ::AudioStreamPlaybackDummy)
   TypeManager.registerEngineType("AudioStreamPlaybackInteractive", AudioStreamPlaybackInteractive::class, ::AudioStreamPlaybackInteractive)
   TypeManager.registerEngineType("AudioStreamPlaybackOggVorbis", AudioStreamPlaybackOggVorbis::class, ::AudioStreamPlaybackOggVorbis)
   TypeManager.registerEngineType("AudioStreamPlaybackPlaylist", AudioStreamPlaybackPlaylist::class, ::AudioStreamPlaybackPlaylist)
   TypeManager.registerEngineType("AudioStreamPlaybackPolyphonic", AudioStreamPlaybackPolyphonic::class, ::AudioStreamPlaybackPolyphonic)
-  TypeManager.registerEngineType("AudioStreamPlaybackResampled", AudioStreamPlaybackResampled::class, null)
+  TypeManager.registerEngineType("AudioStreamPlaybackResampled", AudioStreamPlaybackResampled::class, ::AudioStreamPlaybackResampledDummy)
   TypeManager.registerEngineType("AudioStreamPlaybackSynchronized", AudioStreamPlaybackSynchronized::class, ::AudioStreamPlaybackSynchronized)
   TypeManager.registerEngineType("AudioStreamPlayer", AudioStreamPlayer::class, ::AudioStreamPlayer)
   TypeManager.registerEngineType("AudioStreamPlayer2D", AudioStreamPlayer2D::class, ::AudioStreamPlayer2D)
@@ -3216,10 +3246,10 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("Marker3D", Marker3D::class, ::Marker3D)
   TypeManager.registerSingleton("Marshalls") { Marshalls }
   TypeManager.registerEngineType("Marshalls", Marshalls::class) { Marshalls }
-  TypeManager.registerEngineType("Material", Material::class, null)
+  TypeManager.registerEngineType("Material", Material::class, ::MaterialDummy)
   TypeManager.registerEngineType("MenuBar", MenuBar::class, ::MenuBar)
   TypeManager.registerEngineType("MenuButton", MenuButton::class, ::MenuButton)
-  TypeManager.registerEngineType("Mesh", Mesh::class, null)
+  TypeManager.registerEngineType("Mesh", Mesh::class, ::MeshDummy)
   TypeManager.registerEngineType("MeshConvexDecompositionSettings", MeshConvexDecompositionSettings::class, ::MeshConvexDecompositionSettings)
   TypeManager.registerEngineType("MeshDataTool", MeshDataTool::class, ::MeshDataTool)
   TypeManager.registerEngineType("MeshInstance2D", MeshInstance2D::class, ::MeshInstance2D)
@@ -3231,14 +3261,14 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("MissingResource", MissingResource::class, ::MissingResource)
   TypeManager.registerEngineType("MobileVRInterface", MobileVRInterface::class, ::MobileVRInterface)
   TypeManager.registerEngineType("ModifierBoneTarget3D", ModifierBoneTarget3D::class, ::ModifierBoneTarget3D)
-  TypeManager.registerEngineType("MovieWriter", MovieWriter::class, null)
+  TypeManager.registerEngineType("MovieWriter", MovieWriter::class, ::MovieWriterDummy)
   TypeManager.registerEngineType("MultiMesh", MultiMesh::class, ::MultiMesh)
   TypeManager.registerEngineType("MultiMeshInstance2D", MultiMeshInstance2D::class, ::MultiMeshInstance2D)
   TypeManager.registerEngineType("MultiMeshInstance3D", MultiMeshInstance3D::class, ::MultiMeshInstance3D)
   TypeManager.registerEngineType("MultiplayerAPI", MultiplayerAPI::class, ::MultiplayerAPI)
   TypeManager.registerEngineType("MultiplayerAPIExtension", MultiplayerAPIExtension::class, ::MultiplayerAPIExtension)
   TypeManager.registerEngineType("MultiplayerPeer", MultiplayerPeer::class, ::MultiplayerPeer)
-  TypeManager.registerEngineType("MultiplayerPeerExtension", MultiplayerPeerExtension::class, null)
+  TypeManager.registerEngineType("MultiplayerPeerExtension", MultiplayerPeerExtension::class, ::MultiplayerPeerExtensionDummy)
   TypeManager.registerEngineType("MultiplayerSpawner", MultiplayerSpawner::class, ::MultiplayerSpawner)
   TypeManager.registerEngineType("MultiplayerSynchronizer", MultiplayerSynchronizer::class, ::MultiplayerSynchronizer)
   TypeManager.registerEngineType("Mutex", Mutex::class, ::Mutex)
@@ -3296,7 +3326,7 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("OpenXRAnalogThresholdModifier", OpenXRAnalogThresholdModifier::class, ::OpenXRAnalogThresholdModifier)
   TypeManager.registerEngineType("OpenXRAnchorTracker", OpenXRAnchorTracker::class, ::OpenXRAnchorTracker)
   TypeManager.registerEngineType("OpenXRAndroidThreadSettingsExtension", OpenXRAndroidThreadSettingsExtension::class, ::OpenXRAndroidThreadSettingsExtension)
-  TypeManager.registerEngineType("OpenXRBindingModifier", OpenXRBindingModifier::class, null)
+  TypeManager.registerEngineType("OpenXRBindingModifier", OpenXRBindingModifier::class, ::OpenXRBindingModifierDummy)
   TypeManager.registerEngineType("OpenXRCompositionLayer", OpenXRCompositionLayer::class, ::OpenXRCompositionLayer)
   TypeManager.registerEngineType("OpenXRCompositionLayerCylinder", OpenXRCompositionLayerCylinder::class, ::OpenXRCompositionLayerCylinder)
   TypeManager.registerEngineType("OpenXRCompositionLayerEquirect", OpenXRCompositionLayerEquirect::class, ::OpenXRCompositionLayerEquirect)
@@ -3356,7 +3386,7 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("PackedScene", PackedScene::class, ::PackedScene)
   TypeManager.registerEngineType("PacketPeer", PacketPeer::class, ::PacketPeer)
   TypeManager.registerEngineType("PacketPeerDTLS", PacketPeerDTLS::class, ::PacketPeerDTLS)
-  TypeManager.registerEngineType("PacketPeerExtension", PacketPeerExtension::class, null)
+  TypeManager.registerEngineType("PacketPeerExtension", PacketPeerExtension::class, ::PacketPeerExtensionDummy)
   TypeManager.registerEngineType("PacketPeerStream", PacketPeerStream::class, ::PacketPeerStream)
   TypeManager.registerEngineType("PacketPeerUDP", PacketPeerUDP::class, ::PacketPeerUDP)
   TypeManager.registerEngineType("Panel", Panel::class, ::Panel)
@@ -3379,13 +3409,13 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("PhysicsBody2D", PhysicsBody2D::class, ::PhysicsBody2D)
   TypeManager.registerEngineType("PhysicsBody3D", PhysicsBody3D::class, ::PhysicsBody3D)
   TypeManager.registerEngineType("PhysicsDirectBodyState2D", PhysicsDirectBodyState2D::class, ::PhysicsDirectBodyState2D)
-  TypeManager.registerEngineType("PhysicsDirectBodyState2DExtension", PhysicsDirectBodyState2DExtension::class, null)
+  TypeManager.registerEngineType("PhysicsDirectBodyState2DExtension", PhysicsDirectBodyState2DExtension::class, ::PhysicsDirectBodyState2DExtensionDummy)
   TypeManager.registerEngineType("PhysicsDirectBodyState3D", PhysicsDirectBodyState3D::class, ::PhysicsDirectBodyState3D)
-  TypeManager.registerEngineType("PhysicsDirectBodyState3DExtension", PhysicsDirectBodyState3DExtension::class, null)
+  TypeManager.registerEngineType("PhysicsDirectBodyState3DExtension", PhysicsDirectBodyState3DExtension::class, ::PhysicsDirectBodyState3DExtensionDummy)
   TypeManager.registerEngineType("PhysicsDirectSpaceState2D", PhysicsDirectSpaceState2D::class, ::PhysicsDirectSpaceState2D)
-  TypeManager.registerEngineType("PhysicsDirectSpaceState2DExtension", PhysicsDirectSpaceState2DExtension::class, null)
+  TypeManager.registerEngineType("PhysicsDirectSpaceState2DExtension", PhysicsDirectSpaceState2DExtension::class, ::PhysicsDirectSpaceState2DExtensionDummy)
   TypeManager.registerEngineType("PhysicsDirectSpaceState3D", PhysicsDirectSpaceState3D::class, ::PhysicsDirectSpaceState3D)
-  TypeManager.registerEngineType("PhysicsDirectSpaceState3DExtension", PhysicsDirectSpaceState3DExtension::class, null)
+  TypeManager.registerEngineType("PhysicsDirectSpaceState3DExtension", PhysicsDirectSpaceState3DExtension::class, ::PhysicsDirectSpaceState3DExtensionDummy)
   TypeManager.registerEngineType("PhysicsMaterial", PhysicsMaterial::class, ::PhysicsMaterial)
   TypeManager.registerEngineType("PhysicsPointQueryParameters2D", PhysicsPointQueryParameters2D::class, ::PhysicsPointQueryParameters2D)
   TypeManager.registerEngineType("PhysicsPointQueryParameters3D", PhysicsPointQueryParameters3D::class, ::PhysicsPointQueryParameters3D)
@@ -3399,7 +3429,7 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("PhysicsServer3D", PhysicsServer3D::class) { PhysicsServer3D }
   TypeManager.registerSingleton("PhysicsServer3DManager") { PhysicsServer3DManager }
   TypeManager.registerEngineType("PhysicsServer3DManager", PhysicsServer3DManager::class) { PhysicsServer3DManager }
-  TypeManager.registerEngineType("PhysicsServer3DRenderingServerHandler", PhysicsServer3DRenderingServerHandler::class, null)
+  TypeManager.registerEngineType("PhysicsServer3DRenderingServerHandler", PhysicsServer3DRenderingServerHandler::class, ::PhysicsServer3DRenderingServerHandlerDummy)
   TypeManager.registerEngineType("PhysicsShapeQueryParameters2D", PhysicsShapeQueryParameters2D::class, ::PhysicsShapeQueryParameters2D)
   TypeManager.registerEngineType("PhysicsShapeQueryParameters3D", PhysicsShapeQueryParameters3D::class, ::PhysicsShapeQueryParameters3D)
   TypeManager.registerEngineType("PhysicsTestMotionParameters2D", PhysicsTestMotionParameters2D::class, ::PhysicsTestMotionParameters2D)
@@ -3476,7 +3506,7 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerSingleton("RenderingServer") { RenderingServer }
   TypeManager.registerEngineType("RenderingServer", RenderingServer::class) { RenderingServer }
   TypeManager.registerEngineType("Resource", Resource::class, ::Resource)
-  TypeManager.registerEngineType("ResourceFormatLoader", ResourceFormatLoader::class, null)
+  TypeManager.registerEngineType("ResourceFormatLoader", ResourceFormatLoader::class, ::ResourceFormatLoaderDummy)
   TypeManager.registerEngineType("ResourceFormatSaver", ResourceFormatSaver::class, ::ResourceFormatSaver)
   TypeManager.registerEngineType("ResourceImporter", ResourceImporter::class, ::ResourceImporter)
   TypeManager.registerSingleton("ResourceLoader") { ResourceLoader }
@@ -3500,9 +3530,9 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("SceneTreeTimer", SceneTreeTimer::class, ::SceneTreeTimer)
   TypeManager.registerEngineType("Script", Script::class, ::Script)
   TypeManager.registerEngineType("ScriptBacktrace", ScriptBacktrace::class, ::ScriptBacktrace)
-  TypeManager.registerEngineType("ScriptExtension", ScriptExtension::class, null)
+  TypeManager.registerEngineType("ScriptExtension", ScriptExtension::class, ::ScriptExtensionDummy)
   TypeManager.registerEngineType("ScriptLanguage", ScriptLanguage::class, ::ScriptLanguage)
-  TypeManager.registerEngineType("ScriptLanguageExtension", ScriptLanguageExtension::class, null)
+  TypeManager.registerEngineType("ScriptLanguageExtension", ScriptLanguageExtension::class, ::ScriptLanguageExtensionDummy)
   TypeManager.registerEngineType("ScrollBar", ScrollBar::class, ::ScrollBar)
   TypeManager.registerEngineType("ScrollContainer", ScrollContainer::class, ::ScrollContainer)
   TypeManager.registerEngineType("SegmentShape2D", SegmentShape2D::class, ::SegmentShape2D)
@@ -3565,13 +3595,13 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("StatusIndicator", StatusIndicator::class, ::StatusIndicator)
   TypeManager.registerEngineType("StreamPeer", StreamPeer::class, ::StreamPeer)
   TypeManager.registerEngineType("StreamPeerBuffer", StreamPeerBuffer::class, ::StreamPeerBuffer)
-  TypeManager.registerEngineType("StreamPeerExtension", StreamPeerExtension::class, null)
+  TypeManager.registerEngineType("StreamPeerExtension", StreamPeerExtension::class, ::StreamPeerExtensionDummy)
   TypeManager.registerEngineType("StreamPeerGZIP", StreamPeerGZIP::class, ::StreamPeerGZIP)
   TypeManager.registerEngineType("StreamPeerSocket", StreamPeerSocket::class, ::StreamPeerSocket)
   TypeManager.registerEngineType("StreamPeerTCP", StreamPeerTCP::class, ::StreamPeerTCP)
   TypeManager.registerEngineType("StreamPeerTLS", StreamPeerTLS::class, ::StreamPeerTLS)
   TypeManager.registerEngineType("StreamPeerUDS", StreamPeerUDS::class, ::StreamPeerUDS)
-  TypeManager.registerEngineType("StyleBox", StyleBox::class, null)
+  TypeManager.registerEngineType("StyleBox", StyleBox::class, ::StyleBoxDummy)
   TypeManager.registerEngineType("StyleBoxEmpty", StyleBoxEmpty::class, ::StyleBoxEmpty)
   TypeManager.registerEngineType("StyleBoxFlat", StyleBoxFlat::class, ::StyleBoxFlat)
   TypeManager.registerEngineType("StyleBoxLine", StyleBoxLine::class, ::StyleBoxLine)
@@ -3593,20 +3623,20 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("TextServer", TextServer::class, ::TextServer)
   TypeManager.registerEngineType("TextServerAdvanced", TextServerAdvanced::class, ::TextServerAdvanced)
   TypeManager.registerEngineType("TextServerDummy", TextServerDummy::class, ::TextServerDummy)
-  TypeManager.registerEngineType("TextServerExtension", TextServerExtension::class, null)
+  TypeManager.registerEngineType("TextServerExtension", TextServerExtension::class, ::TextServerExtensionDummy)
   TypeManager.registerSingleton("TextServerManager") { TextServerManager }
   TypeManager.registerEngineType("TextServerManager", TextServerManager::class) { TextServerManager }
   TypeManager.registerEngineType("Texture", Texture::class, ::Texture)
-  TypeManager.registerEngineType("Texture2D", Texture2D::class, null)
+  TypeManager.registerEngineType("Texture2D", Texture2D::class, ::Texture2DDummy)
   TypeManager.registerEngineType("Texture2DArray", Texture2DArray::class, ::Texture2DArray)
   TypeManager.registerEngineType("Texture2DArrayRD", Texture2DArrayRD::class, ::Texture2DArrayRD)
   TypeManager.registerEngineType("Texture2DRD", Texture2DRD::class, ::Texture2DRD)
-  TypeManager.registerEngineType("Texture3D", Texture3D::class, null)
+  TypeManager.registerEngineType("Texture3D", Texture3D::class, ::Texture3DDummy)
   TypeManager.registerEngineType("Texture3DRD", Texture3DRD::class, ::Texture3DRD)
   TypeManager.registerEngineType("TextureButton", TextureButton::class, ::TextureButton)
   TypeManager.registerEngineType("TextureCubemapArrayRD", TextureCubemapArrayRD::class, ::TextureCubemapArrayRD)
   TypeManager.registerEngineType("TextureCubemapRD", TextureCubemapRD::class, ::TextureCubemapRD)
-  TypeManager.registerEngineType("TextureLayered", TextureLayered::class, null)
+  TypeManager.registerEngineType("TextureLayered", TextureLayered::class, ::TextureLayeredDummy)
   TypeManager.registerEngineType("TextureLayeredRD", TextureLayeredRD::class, ::TextureLayeredRD)
   TypeManager.registerEngineType("TextureProgressBar", TextureProgressBar::class, ::TextureProgressBar)
   TypeManager.registerEngineType("TextureRect", TextureRect::class, ::TextureRect)
@@ -3652,8 +3682,8 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("VSplitContainer", VSplitContainer::class, ::VSplitContainer)
   TypeManager.registerEngineType("VehicleBody3D", VehicleBody3D::class, ::VehicleBody3D)
   TypeManager.registerEngineType("VehicleWheel3D", VehicleWheel3D::class, ::VehicleWheel3D)
-  TypeManager.registerEngineType("VideoStream", VideoStream::class, null)
-  TypeManager.registerEngineType("VideoStreamPlayback", VideoStreamPlayback::class, null)
+  TypeManager.registerEngineType("VideoStream", VideoStream::class, ::VideoStreamDummy)
+  TypeManager.registerEngineType("VideoStreamPlayback", VideoStreamPlayback::class, ::VideoStreamPlaybackDummy)
   TypeManager.registerEngineType("VideoStreamPlayer", VideoStreamPlayer::class, ::VideoStreamPlayer)
   TypeManager.registerEngineType("VideoStreamTheora", VideoStreamTheora::class, ::VideoStreamTheora)
   TypeManager.registerEngineType("Viewport", Viewport::class, ::Viewport)
@@ -3779,10 +3809,10 @@ public fun registerEngineTypes(): Unit {
   TypeManager.registerEngineType("VoxelGIData", VoxelGIData::class, ::VoxelGIData)
   TypeManager.registerEngineType("WeakRef", WeakRef::class, ::WeakRef)
   TypeManager.registerEngineType("WebRTCDataChannel", WebRTCDataChannel::class, ::WebRTCDataChannel)
-  TypeManager.registerEngineType("WebRTCDataChannelExtension", WebRTCDataChannelExtension::class, null)
+  TypeManager.registerEngineType("WebRTCDataChannelExtension", WebRTCDataChannelExtension::class, ::WebRTCDataChannelExtensionDummy)
   TypeManager.registerEngineType("WebRTCMultiplayerPeer", WebRTCMultiplayerPeer::class, ::WebRTCMultiplayerPeer)
   TypeManager.registerEngineType("WebRTCPeerConnection", WebRTCPeerConnection::class, ::WebRTCPeerConnection)
-  TypeManager.registerEngineType("WebRTCPeerConnectionExtension", WebRTCPeerConnectionExtension::class, null)
+  TypeManager.registerEngineType("WebRTCPeerConnectionExtension", WebRTCPeerConnectionExtension::class, ::WebRTCPeerConnectionExtensionDummy)
   TypeManager.registerEngineType("WebSocketMultiplayerPeer", WebSocketMultiplayerPeer::class, ::WebSocketMultiplayerPeer)
   TypeManager.registerEngineType("WebSocketPeer", WebSocketPeer::class, ::WebSocketPeer)
   TypeManager.registerEngineType("WebXRInterface", WebXRInterface::class, ::WebXRInterface)

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AnimationNodeExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AnimationNodeExtension.kt
@@ -17,6 +17,7 @@ import godot.core.VariantParser.DOUBLE
 import godot.core.VariantParser.PACKED_FLOAT_32_ARRAY
 import kotlin.Boolean
 import kotlin.Double
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 import kotlin.jvm.JvmStatic
@@ -81,5 +82,12 @@ public abstract class AnimationNodeExtension : AnimationNode() {
 
     internal val getRemainingTimePtr: VoidPtr =
         TypeManager.getMethodBindPtr("AnimationNodeExtension", "get_remaining_time", 2851904656)
+  }
+}
+
+internal class AnimationNodeExtensionDummy : AnimationNodeExtension() {
+  public override fun _processAnimationNode(playbackInfo: PackedFloat64Array, testOnly: Boolean):
+      PackedFloat32Array {
+    throw NotImplementedError("AnimationNodeExtension::_processAnimationNode is only implemented by non-JVM code.")
   }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioEffect.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioEffect.kt
@@ -8,6 +8,7 @@ package godot.api
 
 import godot.`annotation`.GodotBaseType
 import godot.common.interop.VoidPtr
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -52,4 +53,10 @@ public abstract class AudioEffect : Resource() {
   public companion object
 
   public object MethodBindings
+}
+
+internal class AudioEffectDummy : AudioEffect() {
+  public override fun _instantiate(): AudioEffectInstance? {
+    throw NotImplementedError("AudioEffect::_instantiate is only implemented by non-JVM code.")
+  }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioEffectInstance.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioEffectInstance.kt
@@ -39,3 +39,5 @@ public abstract class AudioEffectInstance : RefCounted() {
 
   public object MethodBindings
 }
+
+internal class AudioEffectInstanceDummy : AudioEffectInstance()

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioStream.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioStream.kt
@@ -207,3 +207,9 @@ public abstract class AudioStream : Resource() {
         TypeManager.getMethodBindPtr("AudioStream", "is_meta_stream", 36873697)
   }
 }
+
+internal class AudioStreamDummy : AudioStream() {
+  public override fun _instantiatePlayback(): AudioStreamPlayback? {
+    throw NotImplementedError("AudioStream::_instantiatePlayback is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioStreamPlayback.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioStreamPlayback.kt
@@ -220,3 +220,21 @@ public abstract class AudioStreamPlayback : RefCounted() {
         TypeManager.getMethodBindPtr("AudioStreamPlayback", "is_playing", 36873697)
   }
 }
+
+internal class AudioStreamPlaybackDummy : AudioStreamPlayback() {
+  public override fun _start(fromPos: Double): Unit {
+    throw NotImplementedError("AudioStreamPlayback::_start is only implemented by non-JVM code.")
+  }
+
+  public override fun _stop(): Unit {
+    throw NotImplementedError("AudioStreamPlayback::_stop is only implemented by non-JVM code.")
+  }
+
+  public override fun _isPlaying(): Boolean {
+    throw NotImplementedError("AudioStreamPlayback::_isPlaying is only implemented by non-JVM code.")
+  }
+
+  public override fun _getPlaybackPosition(): Double {
+    throw NotImplementedError("AudioStreamPlayback::_getPlaybackPosition is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioStreamPlaybackResampled.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/AudioStreamPlaybackResampled.kt
@@ -66,3 +66,9 @@ public abstract class AudioStreamPlaybackResampled : AudioStreamPlayback() {
         TypeManager.getMethodBindPtr("AudioStreamPlaybackResampled", "begin_resample", 3218959716)
   }
 }
+
+internal class AudioStreamPlaybackResampledDummy : AudioStreamPlaybackResampled() {
+  public override fun _getStreamSamplingRate(): Float {
+    throw NotImplementedError("AudioStreamPlaybackResampled::_getStreamSamplingRate is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/Material.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/Material.kt
@@ -174,3 +174,13 @@ public abstract class Material : Resource() {
         TypeManager.getMethodBindPtr("Material", "create_placeholder", 121922552)
   }
 }
+
+internal class MaterialDummy : Material() {
+  public override fun _getShaderRid(): RID {
+    throw NotImplementedError("Material::_getShaderRid is only implemented by non-JVM code.")
+  }
+
+  public override fun _getShaderMode(): Shader.Mode {
+    throw NotImplementedError("Material::_getShaderMode is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/Mesh.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/Mesh.kt
@@ -32,6 +32,7 @@ import kotlin.Boolean
 import kotlin.Float
 import kotlin.Int
 import kotlin.Long
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 import kotlin.jvm.JvmField
@@ -772,5 +773,63 @@ public abstract class Mesh : Resource() {
 
     internal val generateTriangleMeshPtr: VoidPtr =
         TypeManager.getMethodBindPtr("Mesh", "generate_triangle_mesh", 3476533166)
+  }
+}
+
+internal class MeshDummy : Mesh() {
+  public override fun _getSurfaceCount(): Int {
+    throw NotImplementedError("Mesh::_getSurfaceCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _surfaceGetArrayLen(index: Int): Int {
+    throw NotImplementedError("Mesh::_surfaceGetArrayLen is only implemented by non-JVM code.")
+  }
+
+  public override fun _surfaceGetArrayIndexLen(index: Int): Int {
+    throw NotImplementedError("Mesh::_surfaceGetArrayIndexLen is only implemented by non-JVM code.")
+  }
+
+  public override fun _surfaceGetArrays(index: Int): VariantArray<Any?> {
+    throw NotImplementedError("Mesh::_surfaceGetArrays is only implemented by non-JVM code.")
+  }
+
+  public override fun _surfaceGetBlendShapeArrays(index: Int): VariantArray<VariantArray<Any?>> {
+    throw NotImplementedError("Mesh::_surfaceGetBlendShapeArrays is only implemented by non-JVM code.")
+  }
+
+  public override fun _surfaceGetLods(index: Int): Dictionary<Any?, Any?> {
+    throw NotImplementedError("Mesh::_surfaceGetLods is only implemented by non-JVM code.")
+  }
+
+  public override fun _surfaceGetFormat(index: Int): Long {
+    throw NotImplementedError("Mesh::_surfaceGetFormat is only implemented by non-JVM code.")
+  }
+
+  public override fun _surfaceGetPrimitiveType(index: Int): Long {
+    throw NotImplementedError("Mesh::_surfaceGetPrimitiveType is only implemented by non-JVM code.")
+  }
+
+  public override fun _surfaceSetMaterial(index: Int, material: Material?): Unit {
+    throw NotImplementedError("Mesh::_surfaceSetMaterial is only implemented by non-JVM code.")
+  }
+
+  public override fun _surfaceGetMaterial(index: Int): Material? {
+    throw NotImplementedError("Mesh::_surfaceGetMaterial is only implemented by non-JVM code.")
+  }
+
+  public override fun _getBlendShapeCount(): Int {
+    throw NotImplementedError("Mesh::_getBlendShapeCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _getBlendShapeName(index: Int): StringName {
+    throw NotImplementedError("Mesh::_getBlendShapeName is only implemented by non-JVM code.")
+  }
+
+  public override fun _setBlendShapeName(index: Int, name: StringName): Unit {
+    throw NotImplementedError("Mesh::_setBlendShapeName is only implemented by non-JVM code.")
+  }
+
+  public override fun _getAabb(): AABB {
+    throw NotImplementedError("Mesh::_getAabb is only implemented by non-JVM code.")
   }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/MovieWriter.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/MovieWriter.kt
@@ -17,6 +17,7 @@ import godot.core.VariantParser.OBJECT
 import godot.core.Vector2i
 import kotlin.Boolean
 import kotlin.Long
+import kotlin.NotImplementedError
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -152,5 +153,35 @@ public abstract class MovieWriter : Object() {
   public object MethodBindings {
     internal val addWriterPtr: VoidPtr =
         TypeManager.getMethodBindPtr("MovieWriter", "add_writer", 4023702871)
+  }
+}
+
+internal class MovieWriterDummy : MovieWriter() {
+  public override fun _getAudioMixRate(): Long {
+    throw NotImplementedError("MovieWriter::_getAudioMixRate is only implemented by non-JVM code.")
+  }
+
+  public override fun _getAudioSpeakerMode(): AudioServer.SpeakerMode {
+    throw NotImplementedError("MovieWriter::_getAudioSpeakerMode is only implemented by non-JVM code.")
+  }
+
+  public override fun _handlesFile(path: String): Boolean {
+    throw NotImplementedError("MovieWriter::_handlesFile is only implemented by non-JVM code.")
+  }
+
+  public override fun _getSupportedExtensions(): PackedStringArray {
+    throw NotImplementedError("MovieWriter::_getSupportedExtensions is only implemented by non-JVM code.")
+  }
+
+  public override fun _writeBegin(
+    movieSize: Vector2i,
+    fps: Long,
+    basePath: String,
+  ): Error {
+    throw NotImplementedError("MovieWriter::_writeBegin is only implemented by non-JVM code.")
+  }
+
+  public override fun _writeEnd(): Unit {
+    throw NotImplementedError("MovieWriter::_writeEnd is only implemented by non-JVM code.")
   }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/MultiplayerPeerExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/MultiplayerPeerExtension.kt
@@ -163,3 +163,69 @@ public abstract class MultiplayerPeerExtension : MultiplayerPeer() {
 
   public object MethodBindings
 }
+
+internal class MultiplayerPeerExtensionDummy : MultiplayerPeerExtension() {
+  public override fun _getAvailablePacketCount(): Int {
+    throw NotImplementedError("MultiplayerPeerExtension::_getAvailablePacketCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _getMaxPacketSize(): Int {
+    throw NotImplementedError("MultiplayerPeerExtension::_getMaxPacketSize is only implemented by non-JVM code.")
+  }
+
+  public override fun _getPacketChannel(): Int {
+    throw NotImplementedError("MultiplayerPeerExtension::_getPacketChannel is only implemented by non-JVM code.")
+  }
+
+  public override fun _getPacketMode(): MultiplayerPeer.TransferMode {
+    throw NotImplementedError("MultiplayerPeerExtension::_getPacketMode is only implemented by non-JVM code.")
+  }
+
+  public override fun _setTransferChannel(pChannel: Int): Unit {
+    throw NotImplementedError("MultiplayerPeerExtension::_setTransferChannel is only implemented by non-JVM code.")
+  }
+
+  public override fun _getTransferChannel(): Int {
+    throw NotImplementedError("MultiplayerPeerExtension::_getTransferChannel is only implemented by non-JVM code.")
+  }
+
+  public override fun _setTransferMode(pMode: MultiplayerPeer.TransferMode): Unit {
+    throw NotImplementedError("MultiplayerPeerExtension::_setTransferMode is only implemented by non-JVM code.")
+  }
+
+  public override fun _getTransferMode(): MultiplayerPeer.TransferMode {
+    throw NotImplementedError("MultiplayerPeerExtension::_getTransferMode is only implemented by non-JVM code.")
+  }
+
+  public override fun _setTargetPeer(pPeer: Int): Unit {
+    throw NotImplementedError("MultiplayerPeerExtension::_setTargetPeer is only implemented by non-JVM code.")
+  }
+
+  public override fun _getPacketPeer(): Int {
+    throw NotImplementedError("MultiplayerPeerExtension::_getPacketPeer is only implemented by non-JVM code.")
+  }
+
+  public override fun _isServer(): Boolean {
+    throw NotImplementedError("MultiplayerPeerExtension::_isServer is only implemented by non-JVM code.")
+  }
+
+  public override fun _poll(): Unit {
+    throw NotImplementedError("MultiplayerPeerExtension::_poll is only implemented by non-JVM code.")
+  }
+
+  public override fun _close(): Unit {
+    throw NotImplementedError("MultiplayerPeerExtension::_close is only implemented by non-JVM code.")
+  }
+
+  public override fun _disconnectPeer(pPeer: Int, pForce: Boolean): Unit {
+    throw NotImplementedError("MultiplayerPeerExtension::_disconnectPeer is only implemented by non-JVM code.")
+  }
+
+  public override fun _getUniqueId(): Int {
+    throw NotImplementedError("MultiplayerPeerExtension::_getUniqueId is only implemented by non-JVM code.")
+  }
+
+  public override fun _getConnectionStatus(): MultiplayerPeer.ConnectionStatus {
+    throw NotImplementedError("MultiplayerPeerExtension::_getConnectionStatus is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/OpenXRBindingModifier.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/OpenXRBindingModifier.kt
@@ -9,6 +9,7 @@ package godot.api
 import godot.`annotation`.GodotBaseType
 import godot.common.interop.VoidPtr
 import godot.core.PackedByteArray
+import kotlin.NotImplementedError
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -40,4 +41,14 @@ public abstract class OpenXRBindingModifier : Resource() {
   public companion object
 
   public object MethodBindings
+}
+
+internal class OpenXRBindingModifierDummy : OpenXRBindingModifier() {
+  public override fun _getDescription(): String {
+    throw NotImplementedError("OpenXRBindingModifier::_getDescription is only implemented by non-JVM code.")
+  }
+
+  public override fun _getIpModification(): PackedByteArray {
+    throw NotImplementedError("OpenXRBindingModifier::_getIpModification is only implemented by non-JVM code.")
+  }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PacketPeerExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PacketPeerExtension.kt
@@ -9,6 +9,7 @@ package godot.api
 import godot.`annotation`.GodotBaseType
 import godot.common.interop.VoidPtr
 import kotlin.Int
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -25,4 +26,14 @@ public abstract class PacketPeerExtension : PacketPeer() {
   public companion object
 
   public object MethodBindings
+}
+
+internal class PacketPeerExtensionDummy : PacketPeerExtension() {
+  public override fun _getAvailablePacketCount(): Int {
+    throw NotImplementedError("PacketPeerExtension::_getAvailablePacketCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _getMaxPacketSize(): Int {
+    throw NotImplementedError("PacketPeerExtension::_getMaxPacketSize is only implemented by non-JVM code.")
+  }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsDirectBodyState2DExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsDirectBodyState2DExtension.kt
@@ -15,6 +15,7 @@ import kotlin.Boolean
 import kotlin.Float
 import kotlin.Int
 import kotlin.Long
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -278,4 +279,198 @@ public abstract class PhysicsDirectBodyState2DExtension : PhysicsDirectBodyState
   public companion object
 
   public object MethodBindings
+}
+
+internal class PhysicsDirectBodyState2DExtensionDummy : PhysicsDirectBodyState2DExtension() {
+  public override fun _getTotalGravity(): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getTotalGravity is only implemented by non-JVM code.")
+  }
+
+  public override fun _getTotalLinearDamp(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getTotalLinearDamp is only implemented by non-JVM code.")
+  }
+
+  public override fun _getTotalAngularDamp(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getTotalAngularDamp is only implemented by non-JVM code.")
+  }
+
+  public override fun _getCenterOfMass(): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getCenterOfMass is only implemented by non-JVM code.")
+  }
+
+  public override fun _getCenterOfMassLocal(): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getCenterOfMassLocal is only implemented by non-JVM code.")
+  }
+
+  public override fun _getInverseMass(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getInverseMass is only implemented by non-JVM code.")
+  }
+
+  public override fun _getInverseInertia(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getInverseInertia is only implemented by non-JVM code.")
+  }
+
+  public override fun _setLinearVelocity(velocity: Vector2): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_setLinearVelocity is only implemented by non-JVM code.")
+  }
+
+  public override fun _getLinearVelocity(): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getLinearVelocity is only implemented by non-JVM code.")
+  }
+
+  public override fun _setAngularVelocity(velocity: Float): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_setAngularVelocity is only implemented by non-JVM code.")
+  }
+
+  public override fun _getAngularVelocity(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getAngularVelocity is only implemented by non-JVM code.")
+  }
+
+  public override fun _setTransform(transform: Transform2D): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_setTransform is only implemented by non-JVM code.")
+  }
+
+  public override fun _getTransform(): Transform2D {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getTransform is only implemented by non-JVM code.")
+  }
+
+  public override fun _getVelocityAtLocalPosition(localPosition: Vector2): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getVelocityAtLocalPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyCentralImpulse(impulse: Vector2): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_applyCentralImpulse is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyImpulse(impulse: Vector2, position: Vector2): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_applyImpulse is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyTorqueImpulse(impulse: Float): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_applyTorqueImpulse is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyCentralForce(force: Vector2): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_applyCentralForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyForce(force: Vector2, position: Vector2): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_applyForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyTorque(torque: Float): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_applyTorque is only implemented by non-JVM code.")
+  }
+
+  public override fun _addConstantCentralForce(force: Vector2): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_addConstantCentralForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _addConstantForce(force: Vector2, position: Vector2): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_addConstantForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _addConstantTorque(torque: Float): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_addConstantTorque is only implemented by non-JVM code.")
+  }
+
+  public override fun _setConstantForce(force: Vector2): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_setConstantForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _getConstantForce(): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getConstantForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _setConstantTorque(torque: Float): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_setConstantTorque is only implemented by non-JVM code.")
+  }
+
+  public override fun _getConstantTorque(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getConstantTorque is only implemented by non-JVM code.")
+  }
+
+  public override fun _setSleepState(enabled: Boolean): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_setSleepState is only implemented by non-JVM code.")
+  }
+
+  public override fun _isSleeping(): Boolean {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_isSleeping is only implemented by non-JVM code.")
+  }
+
+  public override fun _setCollisionLayer(layer: Long): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_setCollisionLayer is only implemented by non-JVM code.")
+  }
+
+  public override fun _getCollisionLayer(): Long {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getCollisionLayer is only implemented by non-JVM code.")
+  }
+
+  public override fun _setCollisionMask(mask: Long): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_setCollisionMask is only implemented by non-JVM code.")
+  }
+
+  public override fun _getCollisionMask(): Long {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getCollisionMask is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactCount(): Int {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactLocalPosition(contactIdx: Int): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactLocalPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactLocalNormal(contactIdx: Int): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactLocalNormal is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactLocalShape(contactIdx: Int): Int {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactLocalShape is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactLocalVelocityAtPosition(contactIdx: Int): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactLocalVelocityAtPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactCollider(contactIdx: Int): RID {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactCollider is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderPosition(contactIdx: Int): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactColliderPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderId(contactIdx: Int): Long {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactColliderId is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderObject(contactIdx: Int): Object? {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactColliderObject is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderShape(contactIdx: Int): Int {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactColliderShape is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderVelocityAtPosition(contactIdx: Int): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactColliderVelocityAtPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactImpulse(contactIdx: Int): Vector2 {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getContactImpulse is only implemented by non-JVM code.")
+  }
+
+  public override fun _getStep(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getStep is only implemented by non-JVM code.")
+  }
+
+  public override fun _integrateForces(): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_integrateForces is only implemented by non-JVM code.")
+  }
+
+  public override fun _getSpaceState(): PhysicsDirectSpaceState2D {
+    throw NotImplementedError("PhysicsDirectBodyState2DExtension::_getSpaceState is only implemented by non-JVM code.")
+  }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsDirectBodyState3DExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsDirectBodyState3DExtension.kt
@@ -16,6 +16,7 @@ import kotlin.Boolean
 import kotlin.Float
 import kotlin.Int
 import kotlin.Long
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -135,4 +136,206 @@ public abstract class PhysicsDirectBodyState3DExtension : PhysicsDirectBodyState
   public companion object
 
   public object MethodBindings
+}
+
+internal class PhysicsDirectBodyState3DExtensionDummy : PhysicsDirectBodyState3DExtension() {
+  public override fun _getTotalGravity(): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getTotalGravity is only implemented by non-JVM code.")
+  }
+
+  public override fun _getTotalLinearDamp(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getTotalLinearDamp is only implemented by non-JVM code.")
+  }
+
+  public override fun _getTotalAngularDamp(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getTotalAngularDamp is only implemented by non-JVM code.")
+  }
+
+  public override fun _getCenterOfMass(): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getCenterOfMass is only implemented by non-JVM code.")
+  }
+
+  public override fun _getCenterOfMassLocal(): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getCenterOfMassLocal is only implemented by non-JVM code.")
+  }
+
+  public override fun _getPrincipalInertiaAxes(): Basis {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getPrincipalInertiaAxes is only implemented by non-JVM code.")
+  }
+
+  public override fun _getInverseMass(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getInverseMass is only implemented by non-JVM code.")
+  }
+
+  public override fun _getInverseInertia(): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getInverseInertia is only implemented by non-JVM code.")
+  }
+
+  public override fun _getInverseInertiaTensor(): Basis {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getInverseInertiaTensor is only implemented by non-JVM code.")
+  }
+
+  public override fun _setLinearVelocity(velocity: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_setLinearVelocity is only implemented by non-JVM code.")
+  }
+
+  public override fun _getLinearVelocity(): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getLinearVelocity is only implemented by non-JVM code.")
+  }
+
+  public override fun _setAngularVelocity(velocity: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_setAngularVelocity is only implemented by non-JVM code.")
+  }
+
+  public override fun _getAngularVelocity(): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getAngularVelocity is only implemented by non-JVM code.")
+  }
+
+  public override fun _setTransform(transform: Transform3D): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_setTransform is only implemented by non-JVM code.")
+  }
+
+  public override fun _getTransform(): Transform3D {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getTransform is only implemented by non-JVM code.")
+  }
+
+  public override fun _getVelocityAtLocalPosition(localPosition: Vector3): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getVelocityAtLocalPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyCentralImpulse(impulse: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_applyCentralImpulse is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyImpulse(impulse: Vector3, position: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_applyImpulse is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyTorqueImpulse(impulse: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_applyTorqueImpulse is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyCentralForce(force: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_applyCentralForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyForce(force: Vector3, position: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_applyForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _applyTorque(torque: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_applyTorque is only implemented by non-JVM code.")
+  }
+
+  public override fun _addConstantCentralForce(force: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_addConstantCentralForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _addConstantForce(force: Vector3, position: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_addConstantForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _addConstantTorque(torque: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_addConstantTorque is only implemented by non-JVM code.")
+  }
+
+  public override fun _setConstantForce(force: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_setConstantForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _getConstantForce(): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getConstantForce is only implemented by non-JVM code.")
+  }
+
+  public override fun _setConstantTorque(torque: Vector3): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_setConstantTorque is only implemented by non-JVM code.")
+  }
+
+  public override fun _getConstantTorque(): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getConstantTorque is only implemented by non-JVM code.")
+  }
+
+  public override fun _setSleepState(enabled: Boolean): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_setSleepState is only implemented by non-JVM code.")
+  }
+
+  public override fun _isSleeping(): Boolean {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_isSleeping is only implemented by non-JVM code.")
+  }
+
+  public override fun _setCollisionLayer(layer: Long): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_setCollisionLayer is only implemented by non-JVM code.")
+  }
+
+  public override fun _getCollisionLayer(): Long {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getCollisionLayer is only implemented by non-JVM code.")
+  }
+
+  public override fun _setCollisionMask(mask: Long): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_setCollisionMask is only implemented by non-JVM code.")
+  }
+
+  public override fun _getCollisionMask(): Long {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getCollisionMask is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactCount(): Int {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactLocalPosition(contactIdx: Int): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactLocalPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactLocalNormal(contactIdx: Int): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactLocalNormal is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactImpulse(contactIdx: Int): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactImpulse is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactLocalShape(contactIdx: Int): Int {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactLocalShape is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactLocalVelocityAtPosition(contactIdx: Int): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactLocalVelocityAtPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactCollider(contactIdx: Int): RID {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactCollider is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderPosition(contactIdx: Int): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactColliderPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderId(contactIdx: Int): Long {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactColliderId is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderObject(contactIdx: Int): Object? {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactColliderObject is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderShape(contactIdx: Int): Int {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactColliderShape is only implemented by non-JVM code.")
+  }
+
+  public override fun _getContactColliderVelocityAtPosition(contactIdx: Int): Vector3 {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getContactColliderVelocityAtPosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _getStep(): Float {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getStep is only implemented by non-JVM code.")
+  }
+
+  public override fun _integrateForces(): Unit {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_integrateForces is only implemented by non-JVM code.")
+  }
+
+  public override fun _getSpaceState(): PhysicsDirectSpaceState3D {
+    throw NotImplementedError("PhysicsDirectBodyState3DExtension::_getSpaceState is only implemented by non-JVM code.")
+  }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsDirectSpaceState2DExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsDirectSpaceState2DExtension.kt
@@ -44,3 +44,5 @@ public abstract class PhysicsDirectSpaceState2DExtension : PhysicsDirectSpaceSta
         TypeManager.getMethodBindPtr("PhysicsDirectSpaceState2DExtension", "is_body_excluded_from_query", 4155700596)
   }
 }
+
+internal class PhysicsDirectSpaceState2DExtensionDummy : PhysicsDirectSpaceState2DExtension()

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsDirectSpaceState3DExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsDirectSpaceState3DExtension.kt
@@ -15,6 +15,7 @@ import godot.core.VariantParser.BOOL
 import godot.core.VariantParser._RID
 import godot.core.Vector3
 import kotlin.Boolean
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -45,5 +46,11 @@ public abstract class PhysicsDirectSpaceState3DExtension : PhysicsDirectSpaceSta
   public object MethodBindings {
     internal val isBodyExcludedFromQueryPtr: VoidPtr =
         TypeManager.getMethodBindPtr("PhysicsDirectSpaceState3DExtension", "is_body_excluded_from_query", 4155700596)
+  }
+}
+
+internal class PhysicsDirectSpaceState3DExtensionDummy : PhysicsDirectSpaceState3DExtension() {
+  public override fun _getClosestPointToObjectVolume(`object`: RID, point: Vector3): Vector3 {
+    throw NotImplementedError("PhysicsDirectSpaceState3DExtension::_getClosestPointToObjectVolume is only implemented by non-JVM code.")
   }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsServer3DRenderingServerHandler.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/PhysicsServer3DRenderingServerHandler.kt
@@ -16,6 +16,7 @@ import godot.core.VariantParser.NIL
 import godot.core.VariantParser.VECTOR3
 import godot.core.Vector3
 import kotlin.Int
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -81,5 +82,20 @@ public abstract class PhysicsServer3DRenderingServerHandler : Object() {
 
     internal val setAabbPtr: VoidPtr =
         TypeManager.getMethodBindPtr("PhysicsServer3DRenderingServerHandler", "set_aabb", 259215842)
+  }
+}
+
+internal class PhysicsServer3DRenderingServerHandlerDummy : PhysicsServer3DRenderingServerHandler()
+    {
+  public override fun _setVertex(vertexId: Int, vertex: Vector3): Unit {
+    throw NotImplementedError("PhysicsServer3DRenderingServerHandler::_setVertex is only implemented by non-JVM code.")
+  }
+
+  public override fun _setNormal(vertexId: Int, normal: Vector3): Unit {
+    throw NotImplementedError("PhysicsServer3DRenderingServerHandler::_setNormal is only implemented by non-JVM code.")
+  }
+
+  public override fun _setAabb(aabb: AABB): Unit {
+    throw NotImplementedError("PhysicsServer3DRenderingServerHandler::_setAabb is only implemented by non-JVM code.")
   }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/ResourceFormatLoader.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/ResourceFormatLoader.kt
@@ -212,3 +212,14 @@ public abstract class ResourceFormatLoader : RefCounted() {
 
   public object MethodBindings
 }
+
+internal class ResourceFormatLoaderDummy : ResourceFormatLoader() {
+  public override fun _load(
+    path: String,
+    originalPath: String,
+    useSubThreads: Boolean,
+    cacheMode: Int,
+  ): Any? {
+    throw NotImplementedError("ResourceFormatLoader::_load is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/ScriptExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/ScriptExtension.kt
@@ -114,3 +114,129 @@ public abstract class ScriptExtension : Script() {
 
   public object MethodBindings
 }
+
+internal class ScriptExtensionDummy : ScriptExtension() {
+  public override fun _editorCanReloadFromFile(): Boolean {
+    throw NotImplementedError("ScriptExtension::_editorCanReloadFromFile is only implemented by non-JVM code.")
+  }
+
+  public override fun _canInstantiate(): Boolean {
+    throw NotImplementedError("ScriptExtension::_canInstantiate is only implemented by non-JVM code.")
+  }
+
+  public override fun _getBaseScript(): Script? {
+    throw NotImplementedError("ScriptExtension::_getBaseScript is only implemented by non-JVM code.")
+  }
+
+  public override fun _getGlobalName(): StringName {
+    throw NotImplementedError("ScriptExtension::_getGlobalName is only implemented by non-JVM code.")
+  }
+
+  public override fun _inheritsScript(script: Script?): Boolean {
+    throw NotImplementedError("ScriptExtension::_inheritsScript is only implemented by non-JVM code.")
+  }
+
+  public override fun _getInstanceBaseType(): StringName {
+    throw NotImplementedError("ScriptExtension::_getInstanceBaseType is only implemented by non-JVM code.")
+  }
+
+  public override fun _instanceHas(`object`: Object?): Boolean {
+    throw NotImplementedError("ScriptExtension::_instanceHas is only implemented by non-JVM code.")
+  }
+
+  public override fun _hasSourceCode(): Boolean {
+    throw NotImplementedError("ScriptExtension::_hasSourceCode is only implemented by non-JVM code.")
+  }
+
+  public override fun _getSourceCode(): String {
+    throw NotImplementedError("ScriptExtension::_getSourceCode is only implemented by non-JVM code.")
+  }
+
+  public override fun _setSourceCode(code: String): Unit {
+    throw NotImplementedError("ScriptExtension::_setSourceCode is only implemented by non-JVM code.")
+  }
+
+  public override fun _reload(keepState: Boolean): Error {
+    throw NotImplementedError("ScriptExtension::_reload is only implemented by non-JVM code.")
+  }
+
+  public override fun _getDocClassName(): StringName {
+    throw NotImplementedError("ScriptExtension::_getDocClassName is only implemented by non-JVM code.")
+  }
+
+  public override fun _getDocumentation(): VariantArray<Dictionary<Any?, Any?>> {
+    throw NotImplementedError("ScriptExtension::_getDocumentation is only implemented by non-JVM code.")
+  }
+
+  public override fun _hasMethod(method: StringName): Boolean {
+    throw NotImplementedError("ScriptExtension::_hasMethod is only implemented by non-JVM code.")
+  }
+
+  public override fun _hasStaticMethod(method: StringName): Boolean {
+    throw NotImplementedError("ScriptExtension::_hasStaticMethod is only implemented by non-JVM code.")
+  }
+
+  public override fun _getMethodInfo(method: StringName): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptExtension::_getMethodInfo is only implemented by non-JVM code.")
+  }
+
+  public override fun _isTool(): Boolean {
+    throw NotImplementedError("ScriptExtension::_isTool is only implemented by non-JVM code.")
+  }
+
+  public override fun _isValid(): Boolean {
+    throw NotImplementedError("ScriptExtension::_isValid is only implemented by non-JVM code.")
+  }
+
+  public override fun _getLanguage(): ScriptLanguage? {
+    throw NotImplementedError("ScriptExtension::_getLanguage is only implemented by non-JVM code.")
+  }
+
+  public override fun _hasScriptSignal(signal: StringName): Boolean {
+    throw NotImplementedError("ScriptExtension::_hasScriptSignal is only implemented by non-JVM code.")
+  }
+
+  public override fun _getScriptSignalList(): VariantArray<Dictionary<Any?, Any?>> {
+    throw NotImplementedError("ScriptExtension::_getScriptSignalList is only implemented by non-JVM code.")
+  }
+
+  public override fun _hasPropertyDefaultValue(`property`: StringName): Boolean {
+    throw NotImplementedError("ScriptExtension::_hasPropertyDefaultValue is only implemented by non-JVM code.")
+  }
+
+  public override fun _getPropertyDefaultValue(`property`: StringName): Any? {
+    throw NotImplementedError("ScriptExtension::_getPropertyDefaultValue is only implemented by non-JVM code.")
+  }
+
+  public override fun _updateExports(): Unit {
+    throw NotImplementedError("ScriptExtension::_updateExports is only implemented by non-JVM code.")
+  }
+
+  public override fun _getScriptMethodList(): VariantArray<Dictionary<Any?, Any?>> {
+    throw NotImplementedError("ScriptExtension::_getScriptMethodList is only implemented by non-JVM code.")
+  }
+
+  public override fun _getScriptPropertyList(): VariantArray<Dictionary<Any?, Any?>> {
+    throw NotImplementedError("ScriptExtension::_getScriptPropertyList is only implemented by non-JVM code.")
+  }
+
+  public override fun _getMemberLine(member: StringName): Int {
+    throw NotImplementedError("ScriptExtension::_getMemberLine is only implemented by non-JVM code.")
+  }
+
+  public override fun _getConstants(): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptExtension::_getConstants is only implemented by non-JVM code.")
+  }
+
+  public override fun _getMembers(): VariantArray<StringName> {
+    throw NotImplementedError("ScriptExtension::_getMembers is only implemented by non-JVM code.")
+  }
+
+  public override fun _isPlaceholderFallbackEnabled(): Boolean {
+    throw NotImplementedError("ScriptExtension::_isPlaceholderFallbackEnabled is only implemented by non-JVM code.")
+  }
+
+  public override fun _getRpcConfig(): Any? {
+    throw NotImplementedError("ScriptExtension::_getRpcConfig is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/ScriptLanguageExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/ScriptLanguageExtension.kt
@@ -298,3 +298,267 @@ public abstract class ScriptLanguageExtension : ScriptLanguage() {
 
   public object MethodBindings
 }
+
+internal class ScriptLanguageExtensionDummy : ScriptLanguageExtension() {
+  public override fun _getName(): String {
+    throw NotImplementedError("ScriptLanguageExtension::_getName is only implemented by non-JVM code.")
+  }
+
+  public override fun _init(): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_init is only implemented by non-JVM code.")
+  }
+
+  public override fun _getType(): String {
+    throw NotImplementedError("ScriptLanguageExtension::_getType is only implemented by non-JVM code.")
+  }
+
+  public override fun _getExtension(): String {
+    throw NotImplementedError("ScriptLanguageExtension::_getExtension is only implemented by non-JVM code.")
+  }
+
+  public override fun _finish(): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_finish is only implemented by non-JVM code.")
+  }
+
+  public override fun _getReservedWords(): PackedStringArray {
+    throw NotImplementedError("ScriptLanguageExtension::_getReservedWords is only implemented by non-JVM code.")
+  }
+
+  public override fun _isControlFlowKeyword(keyword: String): Boolean {
+    throw NotImplementedError("ScriptLanguageExtension::_isControlFlowKeyword is only implemented by non-JVM code.")
+  }
+
+  public override fun _getCommentDelimiters(): PackedStringArray {
+    throw NotImplementedError("ScriptLanguageExtension::_getCommentDelimiters is only implemented by non-JVM code.")
+  }
+
+  public override fun _getStringDelimiters(): PackedStringArray {
+    throw NotImplementedError("ScriptLanguageExtension::_getStringDelimiters is only implemented by non-JVM code.")
+  }
+
+  public override fun _makeTemplate(
+    template: String,
+    className: String,
+    baseClassName: String,
+  ): Script? {
+    throw NotImplementedError("ScriptLanguageExtension::_makeTemplate is only implemented by non-JVM code.")
+  }
+
+  public override fun _getBuiltInTemplates(`object`: StringName):
+      VariantArray<Dictionary<Any?, Any?>> {
+    throw NotImplementedError("ScriptLanguageExtension::_getBuiltInTemplates is only implemented by non-JVM code.")
+  }
+
+  public override fun _isUsingTemplates(): Boolean {
+    throw NotImplementedError("ScriptLanguageExtension::_isUsingTemplates is only implemented by non-JVM code.")
+  }
+
+  public override fun _validate(
+    script: String,
+    path: String,
+    validateFunctions: Boolean,
+    validateErrors: Boolean,
+    validateWarnings: Boolean,
+    validateSafeLines: Boolean,
+  ): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptLanguageExtension::_validate is only implemented by non-JVM code.")
+  }
+
+  public override fun _validatePath(path: String): String {
+    throw NotImplementedError("ScriptLanguageExtension::_validatePath is only implemented by non-JVM code.")
+  }
+
+  public override fun _createScript(): Object? {
+    throw NotImplementedError("ScriptLanguageExtension::_createScript is only implemented by non-JVM code.")
+  }
+
+  public override fun _supportsBuiltinMode(): Boolean {
+    throw NotImplementedError("ScriptLanguageExtension::_supportsBuiltinMode is only implemented by non-JVM code.")
+  }
+
+  public override fun _supportsDocumentation(): Boolean {
+    throw NotImplementedError("ScriptLanguageExtension::_supportsDocumentation is only implemented by non-JVM code.")
+  }
+
+  public override fun _canInheritFromFile(): Boolean {
+    throw NotImplementedError("ScriptLanguageExtension::_canInheritFromFile is only implemented by non-JVM code.")
+  }
+
+  public override fun _findFunction(function: String, code: String): Int {
+    throw NotImplementedError("ScriptLanguageExtension::_findFunction is only implemented by non-JVM code.")
+  }
+
+  public override fun _makeFunction(
+    className: String,
+    functionName: String,
+    functionArgs: PackedStringArray,
+  ): String {
+    throw NotImplementedError("ScriptLanguageExtension::_makeFunction is only implemented by non-JVM code.")
+  }
+
+  public override fun _canMakeFunction(): Boolean {
+    throw NotImplementedError("ScriptLanguageExtension::_canMakeFunction is only implemented by non-JVM code.")
+  }
+
+  public override fun _openInExternalEditor(
+    script: Script?,
+    line: Int,
+    column: Int,
+  ): Error {
+    throw NotImplementedError("ScriptLanguageExtension::_openInExternalEditor is only implemented by non-JVM code.")
+  }
+
+  public override fun _overridesExternalEditor(): Boolean {
+    throw NotImplementedError("ScriptLanguageExtension::_overridesExternalEditor is only implemented by non-JVM code.")
+  }
+
+  public override fun _completeCode(
+    code: String,
+    path: String,
+    owner: Object?,
+  ): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptLanguageExtension::_completeCode is only implemented by non-JVM code.")
+  }
+
+  public override fun _lookupCode(
+    code: String,
+    symbol: String,
+    path: String,
+    owner: Object?,
+  ): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptLanguageExtension::_lookupCode is only implemented by non-JVM code.")
+  }
+
+  public override fun _autoIndentCode(
+    code: String,
+    fromLine: Int,
+    toLine: Int,
+  ): String {
+    throw NotImplementedError("ScriptLanguageExtension::_autoIndentCode is only implemented by non-JVM code.")
+  }
+
+  public override fun _addGlobalConstant(name: StringName, `value`: Any?): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_addGlobalConstant is only implemented by non-JVM code.")
+  }
+
+  public override fun _addNamedGlobalConstant(name: StringName, `value`: Any?): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_addNamedGlobalConstant is only implemented by non-JVM code.")
+  }
+
+  public override fun _removeNamedGlobalConstant(name: StringName): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_removeNamedGlobalConstant is only implemented by non-JVM code.")
+  }
+
+  public override fun _threadEnter(): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_threadEnter is only implemented by non-JVM code.")
+  }
+
+  public override fun _threadExit(): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_threadExit is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugGetError(): String {
+    throw NotImplementedError("ScriptLanguageExtension::_debugGetError is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugGetStackLevelCount(): Int {
+    throw NotImplementedError("ScriptLanguageExtension::_debugGetStackLevelCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugGetStackLevelLine(level: Int): Int {
+    throw NotImplementedError("ScriptLanguageExtension::_debugGetStackLevelLine is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugGetStackLevelFunction(level: Int): String {
+    throw NotImplementedError("ScriptLanguageExtension::_debugGetStackLevelFunction is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugGetStackLevelSource(level: Int): String {
+    throw NotImplementedError("ScriptLanguageExtension::_debugGetStackLevelSource is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugGetStackLevelLocals(
+    level: Int,
+    maxSubitems: Int,
+    maxDepth: Int,
+  ): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptLanguageExtension::_debugGetStackLevelLocals is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugGetStackLevelMembers(
+    level: Int,
+    maxSubitems: Int,
+    maxDepth: Int,
+  ): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptLanguageExtension::_debugGetStackLevelMembers is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugGetGlobals(maxSubitems: Int, maxDepth: Int): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptLanguageExtension::_debugGetGlobals is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugParseStackLevelExpression(
+    level: Int,
+    expression: String,
+    maxSubitems: Int,
+    maxDepth: Int,
+  ): String {
+    throw NotImplementedError("ScriptLanguageExtension::_debugParseStackLevelExpression is only implemented by non-JVM code.")
+  }
+
+  public override fun _debugGetCurrentStackInfo(): VariantArray<Dictionary<Any?, Any?>> {
+    throw NotImplementedError("ScriptLanguageExtension::_debugGetCurrentStackInfo is only implemented by non-JVM code.")
+  }
+
+  public override fun _reloadAllScripts(): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_reloadAllScripts is only implemented by non-JVM code.")
+  }
+
+  public override fun _reloadScripts(scripts: VariantArray<Any?>, softReload: Boolean): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_reloadScripts is only implemented by non-JVM code.")
+  }
+
+  public override fun _reloadToolScript(script: Script?, softReload: Boolean): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_reloadToolScript is only implemented by non-JVM code.")
+  }
+
+  public override fun _getRecognizedExtensions(): PackedStringArray {
+    throw NotImplementedError("ScriptLanguageExtension::_getRecognizedExtensions is only implemented by non-JVM code.")
+  }
+
+  public override fun _getPublicFunctions(): VariantArray<Dictionary<Any?, Any?>> {
+    throw NotImplementedError("ScriptLanguageExtension::_getPublicFunctions is only implemented by non-JVM code.")
+  }
+
+  public override fun _getPublicConstants(): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptLanguageExtension::_getPublicConstants is only implemented by non-JVM code.")
+  }
+
+  public override fun _getPublicAnnotations(): VariantArray<Dictionary<Any?, Any?>> {
+    throw NotImplementedError("ScriptLanguageExtension::_getPublicAnnotations is only implemented by non-JVM code.")
+  }
+
+  public override fun _profilingStart(): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_profilingStart is only implemented by non-JVM code.")
+  }
+
+  public override fun _profilingStop(): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_profilingStop is only implemented by non-JVM code.")
+  }
+
+  public override fun _profilingSetSaveNativeCalls(enable: Boolean): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_profilingSetSaveNativeCalls is only implemented by non-JVM code.")
+  }
+
+  public override fun _frame(): Unit {
+    throw NotImplementedError("ScriptLanguageExtension::_frame is only implemented by non-JVM code.")
+  }
+
+  public override fun _handlesGlobalClassType(type: String): Boolean {
+    throw NotImplementedError("ScriptLanguageExtension::_handlesGlobalClassType is only implemented by non-JVM code.")
+  }
+
+  public override fun _getGlobalClassName(path: String): Dictionary<Any?, Any?> {
+    throw NotImplementedError("ScriptLanguageExtension::_getGlobalClassName is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/StreamPeerExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/StreamPeerExtension.kt
@@ -9,6 +9,7 @@ package godot.api
 import godot.`annotation`.GodotBaseType
 import godot.common.interop.VoidPtr
 import kotlin.Int
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -23,4 +24,10 @@ public abstract class StreamPeerExtension : StreamPeer() {
   public companion object
 
   public object MethodBindings
+}
+
+internal class StreamPeerExtensionDummy : StreamPeerExtension() {
+  public override fun _getAvailableBytes(): Int {
+    throw NotImplementedError("StreamPeerExtension::_getAvailableBytes is only implemented by non-JVM code.")
+  }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/StyleBox.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/StyleBox.kt
@@ -245,3 +245,9 @@ public abstract class StyleBox : Resource() {
         TypeManager.getMethodBindPtr("StyleBox", "test_mask", 3735564539)
   }
 }
+
+internal class StyleBoxDummy : StyleBox() {
+  public override fun _draw(toCanvasItem: RID, rect: Rect2): Unit {
+    throw NotImplementedError("StyleBox::_draw is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/TextServerExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/TextServerExtension.kt
@@ -1878,3 +1878,486 @@ public abstract class TextServerExtension : TextServer() {
 
   public object MethodBindings
 }
+
+internal class TextServerExtensionDummy : TextServerExtension() {
+  public override fun _hasFeature(feature: TextServer.Feature): Boolean {
+    throw NotImplementedError("TextServerExtension::_hasFeature is only implemented by non-JVM code.")
+  }
+
+  public override fun _getName(): String {
+    throw NotImplementedError("TextServerExtension::_getName is only implemented by non-JVM code.")
+  }
+
+  public override fun _getFeatures(): Long {
+    throw NotImplementedError("TextServerExtension::_getFeatures is only implemented by non-JVM code.")
+  }
+
+  public override fun _freeRid(rid: RID): Unit {
+    throw NotImplementedError("TextServerExtension::_freeRid is only implemented by non-JVM code.")
+  }
+
+  public override fun _has(rid: RID): Boolean {
+    throw NotImplementedError("TextServerExtension::_has is only implemented by non-JVM code.")
+  }
+
+  public override fun _createFont(): RID {
+    throw NotImplementedError("TextServerExtension::_createFont is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetFixedSize(fontRid: RID, fixedSize: Long): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetFixedSize is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetFixedSize(fontRid: RID): Long {
+    throw NotImplementedError("TextServerExtension::_fontGetFixedSize is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetFixedSizeScaleMode(fontRid: RID,
+      fixedSizeScaleMode: TextServer.FixedSizeScaleMode): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetFixedSizeScaleMode is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetFixedSizeScaleMode(fontRid: RID): TextServer.FixedSizeScaleMode {
+    throw NotImplementedError("TextServerExtension::_fontGetFixedSizeScaleMode is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetSizeCacheList(fontRid: RID): VariantArray<Vector2i> {
+    throw NotImplementedError("TextServerExtension::_fontGetSizeCacheList is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontClearSizeCache(fontRid: RID): Unit {
+    throw NotImplementedError("TextServerExtension::_fontClearSizeCache is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontRemoveSizeCache(fontRid: RID, size: Vector2i): Unit {
+    throw NotImplementedError("TextServerExtension::_fontRemoveSizeCache is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetAscent(
+    fontRid: RID,
+    size: Long,
+    ascent: Double,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetAscent is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetAscent(fontRid: RID, size: Long): Double {
+    throw NotImplementedError("TextServerExtension::_fontGetAscent is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetDescent(
+    fontRid: RID,
+    size: Long,
+    descent: Double,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetDescent is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetDescent(fontRid: RID, size: Long): Double {
+    throw NotImplementedError("TextServerExtension::_fontGetDescent is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetUnderlinePosition(
+    fontRid: RID,
+    size: Long,
+    underlinePosition: Double,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetUnderlinePosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetUnderlinePosition(fontRid: RID, size: Long): Double {
+    throw NotImplementedError("TextServerExtension::_fontGetUnderlinePosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetUnderlineThickness(
+    fontRid: RID,
+    size: Long,
+    underlineThickness: Double,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetUnderlineThickness is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetUnderlineThickness(fontRid: RID, size: Long): Double {
+    throw NotImplementedError("TextServerExtension::_fontGetUnderlineThickness is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetScale(
+    fontRid: RID,
+    size: Long,
+    scale: Double,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetScale is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetScale(fontRid: RID, size: Long): Double {
+    throw NotImplementedError("TextServerExtension::_fontGetScale is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetTextureCount(fontRid: RID, size: Vector2i): Long {
+    throw NotImplementedError("TextServerExtension::_fontGetTextureCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontClearTextures(fontRid: RID, size: Vector2i): Unit {
+    throw NotImplementedError("TextServerExtension::_fontClearTextures is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontRemoveTexture(
+    fontRid: RID,
+    size: Vector2i,
+    textureIndex: Long,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontRemoveTexture is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetTextureImage(
+    fontRid: RID,
+    size: Vector2i,
+    textureIndex: Long,
+    image: Image?,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetTextureImage is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetTextureImage(
+    fontRid: RID,
+    size: Vector2i,
+    textureIndex: Long,
+  ): Image? {
+    throw NotImplementedError("TextServerExtension::_fontGetTextureImage is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetGlyphList(fontRid: RID, size: Vector2i): PackedInt32Array {
+    throw NotImplementedError("TextServerExtension::_fontGetGlyphList is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontClearGlyphs(fontRid: RID, size: Vector2i): Unit {
+    throw NotImplementedError("TextServerExtension::_fontClearGlyphs is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontRemoveGlyph(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontRemoveGlyph is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetGlyphAdvance(
+    fontRid: RID,
+    size: Long,
+    glyph: Long,
+  ): Vector2 {
+    throw NotImplementedError("TextServerExtension::_fontGetGlyphAdvance is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetGlyphAdvance(
+    fontRid: RID,
+    size: Long,
+    glyph: Long,
+    advance: Vector2,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetGlyphAdvance is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetGlyphOffset(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+  ): Vector2 {
+    throw NotImplementedError("TextServerExtension::_fontGetGlyphOffset is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetGlyphOffset(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+    offset: Vector2,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetGlyphOffset is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetGlyphSize(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+  ): Vector2 {
+    throw NotImplementedError("TextServerExtension::_fontGetGlyphSize is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetGlyphSize(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+    glSize: Vector2,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetGlyphSize is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetGlyphUvRect(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+  ): Rect2 {
+    throw NotImplementedError("TextServerExtension::_fontGetGlyphUvRect is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetGlyphUvRect(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+    uvRect: Rect2,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetGlyphUvRect is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetGlyphTextureIdx(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+  ): Long {
+    throw NotImplementedError("TextServerExtension::_fontGetGlyphTextureIdx is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontSetGlyphTextureIdx(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+    textureIdx: Long,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontSetGlyphTextureIdx is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetGlyphTextureRid(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+  ): RID {
+    throw NotImplementedError("TextServerExtension::_fontGetGlyphTextureRid is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetGlyphTextureSize(
+    fontRid: RID,
+    size: Vector2i,
+    glyph: Long,
+  ): Vector2 {
+    throw NotImplementedError("TextServerExtension::_fontGetGlyphTextureSize is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetGlyphIndex(
+    fontRid: RID,
+    size: Long,
+    char: Long,
+    variationSelector: Long,
+  ): Long {
+    throw NotImplementedError("TextServerExtension::_fontGetGlyphIndex is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetCharFromGlyphIndex(
+    fontRid: RID,
+    size: Long,
+    glyphIndex: Long,
+  ): Long {
+    throw NotImplementedError("TextServerExtension::_fontGetCharFromGlyphIndex is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontHasChar(fontRid: RID, char: Long): Boolean {
+    throw NotImplementedError("TextServerExtension::_fontHasChar is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetSupportedChars(fontRid: RID): String {
+    throw NotImplementedError("TextServerExtension::_fontGetSupportedChars is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontGetSupportedGlyphs(fontRid: RID): PackedInt32Array {
+    throw NotImplementedError("TextServerExtension::_fontGetSupportedGlyphs is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontDrawGlyph(
+    fontRid: RID,
+    canvas: RID,
+    size: Long,
+    pos: Vector2,
+    index: Long,
+    color: Color,
+    oversampling: Float,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontDrawGlyph is only implemented by non-JVM code.")
+  }
+
+  public override fun _fontDrawGlyphOutline(
+    fontRid: RID,
+    canvas: RID,
+    size: Long,
+    outlineSize: Long,
+    pos: Vector2,
+    index: Long,
+    color: Color,
+    oversampling: Float,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_fontDrawGlyphOutline is only implemented by non-JVM code.")
+  }
+
+  public override fun _createShapedText(direction: TextServer.Direction,
+      orientation: TextServer.Orientation): RID {
+    throw NotImplementedError("TextServerExtension::_createShapedText is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextClear(shaped: RID): Unit {
+    throw NotImplementedError("TextServerExtension::_shapedTextClear is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextDuplicate(shaped: RID): RID {
+    throw NotImplementedError("TextServerExtension::_shapedTextDuplicate is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextAddString(
+    shaped: RID,
+    text: String,
+    fonts: VariantArray<RID>,
+    size: Long,
+    opentypeFeatures: Dictionary<Any?, Any?>,
+    language: String,
+    meta: Any?,
+  ): Boolean {
+    throw NotImplementedError("TextServerExtension::_shapedTextAddString is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextAddObject(
+    shaped: RID,
+    key: Any?,
+    size: Vector2,
+    inlineAlign: InlineAlignment,
+    length: Long,
+    baseline: Double,
+  ): Boolean {
+    throw NotImplementedError("TextServerExtension::_shapedTextAddObject is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextResizeObject(
+    shaped: RID,
+    key: Any?,
+    size: Vector2,
+    inlineAlign: InlineAlignment,
+    baseline: Double,
+  ): Boolean {
+    throw NotImplementedError("TextServerExtension::_shapedTextResizeObject is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextHasObject(shaped: RID, key: Any?): Boolean {
+    throw NotImplementedError("TextServerExtension::_shapedTextHasObject is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedGetText(shaped: RID): String {
+    throw NotImplementedError("TextServerExtension::_shapedGetText is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedGetSpanCount(shaped: RID): Long {
+    throw NotImplementedError("TextServerExtension::_shapedGetSpanCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedGetSpanMeta(shaped: RID, index: Long): Any? {
+    throw NotImplementedError("TextServerExtension::_shapedGetSpanMeta is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedGetSpanEmbeddedObject(shaped: RID, index: Long): Any? {
+    throw NotImplementedError("TextServerExtension::_shapedGetSpanEmbeddedObject is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedGetSpanText(shaped: RID, index: Long): String {
+    throw NotImplementedError("TextServerExtension::_shapedGetSpanText is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedGetSpanObject(shaped: RID, index: Long): Any? {
+    throw NotImplementedError("TextServerExtension::_shapedGetSpanObject is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedSetSpanUpdateFont(
+    shaped: RID,
+    index: Long,
+    fonts: VariantArray<RID>,
+    size: Long,
+    opentypeFeatures: Dictionary<Any?, Any?>,
+  ): Unit {
+    throw NotImplementedError("TextServerExtension::_shapedSetSpanUpdateFont is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextSubstr(
+    shaped: RID,
+    start: Long,
+    length: Long,
+  ): RID {
+    throw NotImplementedError("TextServerExtension::_shapedTextSubstr is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetParent(shaped: RID): RID {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetParent is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextShape(shaped: RID): Boolean {
+    throw NotImplementedError("TextServerExtension::_shapedTextShape is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextIsReady(shaped: RID): Boolean {
+    throw NotImplementedError("TextServerExtension::_shapedTextIsReady is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetGlyphCount(shaped: RID): Long {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetGlyphCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetRange(shaped: RID): Vector2i {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetRange is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetTrimPos(shaped: RID): Long {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetTrimPos is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetEllipsisPos(shaped: RID): Long {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetEllipsisPos is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetEllipsisGlyphCount(shaped: RID): Long {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetEllipsisGlyphCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetObjects(shaped: RID): VariantArray<Any?> {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetObjects is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetObjectRect(shaped: RID, key: Any?): Rect2 {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetObjectRect is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetObjectRange(shaped: RID, key: Any?): Vector2i {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetObjectRange is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetObjectGlyph(shaped: RID, key: Any?): Long {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetObjectGlyph is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetSize(shaped: RID): Vector2 {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetSize is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetAscent(shaped: RID): Double {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetAscent is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetDescent(shaped: RID): Double {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetDescent is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetWidth(shaped: RID): Double {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetWidth is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetUnderlinePosition(shaped: RID): Double {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetUnderlinePosition is only implemented by non-JVM code.")
+  }
+
+  public override fun _shapedTextGetUnderlineThickness(shaped: RID): Double {
+    throw NotImplementedError("TextServerExtension::_shapedTextGetUnderlineThickness is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/Texture2D.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/Texture2D.kt
@@ -262,3 +262,13 @@ public abstract class Texture2D : Texture() {
         TypeManager.getMethodBindPtr("Texture2D", "create_placeholder", 121922552)
   }
 }
+
+internal class Texture2DDummy : Texture2D() {
+  public override fun _getWidth(): Int {
+    throw NotImplementedError("Texture2D::_getWidth is only implemented by non-JVM code.")
+  }
+
+  public override fun _getHeight(): Int {
+    throw NotImplementedError("Texture2D::_getHeight is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/Texture3D.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/Texture3D.kt
@@ -18,6 +18,7 @@ import godot.core.VariantParser.OBJECT
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.Long
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -155,5 +156,31 @@ public abstract class Texture3D : Texture() {
 
     internal val createPlaceholderPtr: VoidPtr =
         TypeManager.getMethodBindPtr("Texture3D", "create_placeholder", 121922552)
+  }
+}
+
+internal class Texture3DDummy : Texture3D() {
+  public override fun _getFormat(): Image.Format {
+    throw NotImplementedError("Texture3D::_getFormat is only implemented by non-JVM code.")
+  }
+
+  public override fun _getWidth(): Int {
+    throw NotImplementedError("Texture3D::_getWidth is only implemented by non-JVM code.")
+  }
+
+  public override fun _getHeight(): Int {
+    throw NotImplementedError("Texture3D::_getHeight is only implemented by non-JVM code.")
+  }
+
+  public override fun _getDepth(): Int {
+    throw NotImplementedError("Texture3D::_getDepth is only implemented by non-JVM code.")
+  }
+
+  public override fun _hasMipmaps(): Boolean {
+    throw NotImplementedError("Texture3D::_hasMipmaps is only implemented by non-JVM code.")
+  }
+
+  public override fun _getData(): VariantArray<Image> {
+    throw NotImplementedError("Texture3D::_getData is only implemented by non-JVM code.")
   }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/TextureLayered.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/TextureLayered.kt
@@ -17,6 +17,7 @@ import godot.core.VariantParser.OBJECT
 import kotlin.Boolean
 import kotlin.Int
 import kotlin.Long
+import kotlin.NotImplementedError
 import kotlin.Suppress
 import kotlin.Unit
 
@@ -188,5 +189,35 @@ public abstract class TextureLayered : Texture() {
 
     internal val getLayerDataPtr: VoidPtr =
         TypeManager.getMethodBindPtr("TextureLayered", "get_layer_data", 3655284255)
+  }
+}
+
+internal class TextureLayeredDummy : TextureLayered() {
+  public override fun _getFormat(): Image.Format {
+    throw NotImplementedError("TextureLayered::_getFormat is only implemented by non-JVM code.")
+  }
+
+  public override fun _getLayeredType(): Long {
+    throw NotImplementedError("TextureLayered::_getLayeredType is only implemented by non-JVM code.")
+  }
+
+  public override fun _getWidth(): Int {
+    throw NotImplementedError("TextureLayered::_getWidth is only implemented by non-JVM code.")
+  }
+
+  public override fun _getHeight(): Int {
+    throw NotImplementedError("TextureLayered::_getHeight is only implemented by non-JVM code.")
+  }
+
+  public override fun _getLayers(): Int {
+    throw NotImplementedError("TextureLayered::_getLayers is only implemented by non-JVM code.")
+  }
+
+  public override fun _hasMipmaps(): Boolean {
+    throw NotImplementedError("TextureLayered::_hasMipmaps is only implemented by non-JVM code.")
+  }
+
+  public override fun _getLayerData(layerIndex: Int): Image? {
+    throw NotImplementedError("TextureLayered::_getLayerData is only implemented by non-JVM code.")
   }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/VideoStream.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/VideoStream.kt
@@ -12,6 +12,7 @@ import godot.`internal`.reflection.TypeManager
 import godot.common.interop.VoidPtr
 import godot.core.VariantParser.NIL
 import godot.core.VariantParser.STRING
+import kotlin.NotImplementedError
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -66,5 +67,11 @@ public abstract class VideoStream : Resource() {
 
     internal val getFilePtr: VoidPtr =
         TypeManager.getMethodBindPtr("VideoStream", "get_file", 2841200299)
+  }
+}
+
+internal class VideoStreamDummy : VideoStream() {
+  public override fun _instantiatePlayback(): VideoStreamPlayback? {
+    throw NotImplementedError("VideoStream::_instantiatePlayback is only implemented by non-JVM code.")
   }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/VideoStreamPlayback.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/VideoStreamPlayback.kt
@@ -150,3 +150,9 @@ public abstract class VideoStreamPlayback : Resource() {
         TypeManager.getMethodBindPtr("VideoStreamPlayback", "mix_audio", 93876830)
   }
 }
+
+internal class VideoStreamPlaybackDummy : VideoStreamPlayback() {
+  public override fun _update(delta: Double): Unit {
+    throw NotImplementedError("VideoStreamPlayback::_update is only implemented by non-JVM code.")
+  }
+}

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/WebRTCDataChannelExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/WebRTCDataChannelExtension.kt
@@ -11,6 +11,7 @@ import godot.common.interop.VoidPtr
 import godot.core.Error
 import kotlin.Boolean
 import kotlin.Int
+import kotlin.NotImplementedError
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -56,4 +57,70 @@ public abstract class WebRTCDataChannelExtension : WebRTCDataChannel() {
   public companion object
 
   public object MethodBindings
+}
+
+internal class WebRTCDataChannelExtensionDummy : WebRTCDataChannelExtension() {
+  public override fun _getAvailablePacketCount(): Int {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getAvailablePacketCount is only implemented by non-JVM code.")
+  }
+
+  public override fun _getMaxPacketSize(): Int {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getMaxPacketSize is only implemented by non-JVM code.")
+  }
+
+  public override fun _poll(): Error {
+    throw NotImplementedError("WebRTCDataChannelExtension::_poll is only implemented by non-JVM code.")
+  }
+
+  public override fun _close(): Unit {
+    throw NotImplementedError("WebRTCDataChannelExtension::_close is only implemented by non-JVM code.")
+  }
+
+  public override fun _setWriteMode(pWriteMode: WebRTCDataChannel.WriteMode): Unit {
+    throw NotImplementedError("WebRTCDataChannelExtension::_setWriteMode is only implemented by non-JVM code.")
+  }
+
+  public override fun _getWriteMode(): WebRTCDataChannel.WriteMode {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getWriteMode is only implemented by non-JVM code.")
+  }
+
+  public override fun _wasStringPacket(): Boolean {
+    throw NotImplementedError("WebRTCDataChannelExtension::_wasStringPacket is only implemented by non-JVM code.")
+  }
+
+  public override fun _getReadyState(): WebRTCDataChannel.ChannelState {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getReadyState is only implemented by non-JVM code.")
+  }
+
+  public override fun _getLabel(): String {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getLabel is only implemented by non-JVM code.")
+  }
+
+  public override fun _isOrdered(): Boolean {
+    throw NotImplementedError("WebRTCDataChannelExtension::_isOrdered is only implemented by non-JVM code.")
+  }
+
+  public override fun _getId(): Int {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getId is only implemented by non-JVM code.")
+  }
+
+  public override fun _getMaxPacketLifeTime(): Int {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getMaxPacketLifeTime is only implemented by non-JVM code.")
+  }
+
+  public override fun _getMaxRetransmits(): Int {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getMaxRetransmits is only implemented by non-JVM code.")
+  }
+
+  public override fun _getProtocol(): String {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getProtocol is only implemented by non-JVM code.")
+  }
+
+  public override fun _isNegotiated(): Boolean {
+    throw NotImplementedError("WebRTCDataChannelExtension::_isNegotiated is only implemented by non-JVM code.")
+  }
+
+  public override fun _getBufferedAmount(): Int {
+    throw NotImplementedError("WebRTCDataChannelExtension::_getBufferedAmount is only implemented by non-JVM code.")
+  }
 }

--- a/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/WebRTCPeerConnectionExtension.kt
+++ b/kt/godot-library/godot-api-library/src/main/kotlin/godot/api/WebRTCPeerConnectionExtension.kt
@@ -12,6 +12,7 @@ import godot.core.Dictionary
 import godot.core.Error
 import kotlin.Any
 import kotlin.Int
+import kotlin.NotImplementedError
 import kotlin.String
 import kotlin.Suppress
 import kotlin.Unit
@@ -52,4 +53,55 @@ public abstract class WebRTCPeerConnectionExtension : WebRTCPeerConnection() {
   public companion object
 
   public object MethodBindings
+}
+
+internal class WebRTCPeerConnectionExtensionDummy : WebRTCPeerConnectionExtension() {
+  public override fun _getConnectionState(): WebRTCPeerConnection.ConnectionState {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_getConnectionState is only implemented by non-JVM code.")
+  }
+
+  public override fun _getGatheringState(): WebRTCPeerConnection.GatheringState {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_getGatheringState is only implemented by non-JVM code.")
+  }
+
+  public override fun _getSignalingState(): WebRTCPeerConnection.SignalingState {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_getSignalingState is only implemented by non-JVM code.")
+  }
+
+  public override fun _initialize(pConfig: Dictionary<Any?, Any?>): Error {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_initialize is only implemented by non-JVM code.")
+  }
+
+  public override fun _createDataChannel(pLabel: String, pConfig: Dictionary<Any?, Any?>):
+      WebRTCDataChannel? {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_createDataChannel is only implemented by non-JVM code.")
+  }
+
+  public override fun _createOffer(): Error {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_createOffer is only implemented by non-JVM code.")
+  }
+
+  public override fun _setRemoteDescription(pType: String, pSdp: String): Error {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_setRemoteDescription is only implemented by non-JVM code.")
+  }
+
+  public override fun _setLocalDescription(pType: String, pSdp: String): Error {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_setLocalDescription is only implemented by non-JVM code.")
+  }
+
+  public override fun _addIceCandidate(
+    pSdpMidName: String,
+    pSdpMlineIndex: Int,
+    pSdpName: String,
+  ): Error {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_addIceCandidate is only implemented by non-JVM code.")
+  }
+
+  public override fun _poll(): Error {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_poll is only implemented by non-JVM code.")
+  }
+
+  public override fun _close(): Unit {
+    throw NotImplementedError("WebRTCPeerConnectionExtension::_close is only implemented by non-JVM code.")
+  }
 }


### PR DESCRIPTION
Necessary so the base ones stay abstract but we still get a wrapper if Godot-JVM receive a base abstract instance + non-JVM script